### PR TITLE
fix: Enable scroll wheel in multi-line textareas

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -87,7 +87,7 @@ html {
 /* Auto-expanding textarea with max 6 lines */
 #message-input {
     resize: none;
-    overflow-y: hidden;
+    overflow-y: auto;
     min-height: 38px; /* 1 line */
     max-height: calc(1.5em * 6 + 0.75rem); /* 6 lines + padding */
     transition: height 0.1s ease;


### PR DESCRIPTION
## Summary
Resolves #20

This PR fixes the scroll wheel functionality in multi-line text inputs throughout the application.

## Changes Made
- Changed `#message-input` overflow-y from `hidden` to `auto` in `static/styles.css`
- This enables scroll wheel functionality when textarea content exceeds the 6-line maximum height
- The permission clarification textarea already had the correct `overflow-y: auto` setting

## Testing
The fix has been verified to:
- Enable scroll wheel navigation in the main message input when content exceeds 6 lines
- Preserve the auto-expand behavior up to max height
- Not affect the visual appearance (scrollbar only appears when needed)
- Maintain compatibility with the permission clarification textarea

## Technical Details
**File Modified:** `static/styles.css:90`
**Change:** `overflow-y: hidden` → `overflow-y: auto`

The main message input textarea previously had `overflow-y: hidden` which completely prevented scrolling. Changing to `auto` enables scrolling when content height exceeds the max-height constraint (6 lines + padding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)