### PR TITLE
qol: Enable session name input in create session modal

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -127,6 +127,11 @@
                     </div>
                     <div class="modal-body">
                         <form id="create-session-form">
+                    <div class="mb-3">
+                        <label for="session-name" class="form-label">Session Name (optional):</label>
+                        <input type="text" class="form-control" id="session-name" name="name" maxlength="255" placeholder="Leave empty for auto-generated timestamp">
+                    </div>
+
                     <div class="mb-3" id="working-directory-group">
                         <label for="working-directory" class="form-label">Working Directory:</label>
                         <div class="input-group">


### PR DESCRIPTION
## Summary
Resolves #21

Adds optional session name input field to the "Create New Session" modal, positioned at the top of the form. Users can provide a custom name or leave it empty for auto-generated timestamp.

## Changes Made
- Added session name input field to `static/index.html`
- Field attributes: `name="name"`, `maxlength="255"`, optional
- Positioned at top of form (before working directory field)
- Includes placeholder text explaining fallback behavior

## Implementation Notes
- Backend already fully supports session naming (no changes required)
- JavaScript payload already includes `name` field
- Maintains backward compatibility with existing auto-naming
- Validation handled by HTML5 `maxlength` attribute

## Testing
- [x] Field appears at top of Create Session modal
- [x] Form submits with custom name
- [x] Empty field falls back to timestamp
- [x] 255 character limit enforced

🤖 Generated with [Claude Code](https://claude.com/claude-code)