### PR TITLE
qol: Display ExitPlanMode plan as preformatted text

### DIFF
--- a/static/tools/handlers/misc-handlers.js
+++ b/static/tools/handlers/misc-handlers.js
@@ -81,12 +81,12 @@ class ExitPlanModeToolHandler {
         html += '</div>';
         html += '</div>';
 
-        // Plan section
+        // Plan section (preformatted text)
         if (plan) {
             html += '<div class="exitplan-plan-section">';
-            html += '<div class="exitplan-plan-content">';
+            html += '<pre class="tool-result-content exitplan-plan-content">';
             html += escapeHtmlFn(plan);
-            html += '</div>';
+            html += '</pre>';
             html += '</div>';
         }
 


### PR DESCRIPTION
## Summary
Resolves #17

Fixed ExitPlanMode plan display to show content as preformatted text instead of inline HTML, preserving line breaks, indentation, and whitespace for better readability.

## Changes Made
- Changed `ExitPlanModeToolHandler.renderParameters()` in `static/tools/handlers/misc-handlers.js`:
  - Replaced `<div class="exitplan-plan-content">` with `<pre class="tool-result-content exitplan-plan-content">`
  - Added `tool-result-content` class to leverage existing CSS for monospace font, whitespace preservation, and styling
  - Updated comment to indicate preformatted text rendering

## Technical Details
- Uses existing `.tool-result-content` CSS class (no new CSS needed)
- Aligns with pattern used by BashToolHandler, ReadToolHandler, and other multi-line content handlers
- `escapeHtmlFn()` still used for XSS protection
- Markdown not rendered (consistent with other tool handlers)

## Testing
To verify this fix:
1. Start a session in plan mode
2. Trigger ExitPlanMode by asking Claude to create and submit a plan
3. Verify the plan displays with:
   - Preserved line breaks (multi-line plans don't collapse)
   - Maintained indentation
   - Monospace font
   - Light background matching other tool results
   - Proper text wrapping without horizontal scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)