### PR TITLE
chore: Add --data-dir CLI argument for custom data directory location

### DIFF
--- a/main.py
+++ b/main.py
@@ -39,6 +39,7 @@ Debug Flags:
     # Server options
     parser.add_argument('--host', default='0.0.0.0', help='Host to bind to (default: 0.0.0.0)')
     parser.add_argument('--port', type=int, default=8000, help='Port to bind to (default: 8000)')
+    parser.add_argument('--data-dir', default='./data', help='Data directory location (default: ./data)')
 
     # Debug flags
     parser.add_argument('--debug-websocket', action='store_true', help='Enable WebSocket lifecycle debugging')
@@ -51,6 +52,15 @@ Debug Flags:
 
     args = parser.parse_args()
 
+    # Validate and create data directory
+    data_dir_path = Path(args.data_dir).resolve()
+    try:
+        data_dir_path.mkdir(parents=True, exist_ok=True)
+        print(f"Using data directory: {data_dir_path}")
+    except Exception as e:
+        print(f"Failed to create data directory {data_dir_path}: {e}", file=sys.stderr)
+        sys.exit(1)
+
     # Configure logging with debug flags
     configure_logging(
         debug_websocket=args.debug_websocket,
@@ -59,11 +69,12 @@ Debug Flags:
         debug_storage=args.debug_storage,
         debug_parser=args.debug_parser,
         debug_error_handler=args.debug_error_handler,
-        debug_all=args.debug_all
+        debug_all=args.debug_all,
+        log_dir=str(data_dir_path / "logs")
     )
 
     # Create FastAPI app
-    app = create_app()
+    app = create_app(data_dir=data_dir_path)
 
     # Add startup/shutdown events
     app.add_event_handler("startup", startup_event)


### PR DESCRIPTION
## Summary
Resolves #19

Added `--data-dir` CLI argument to allow specifying a custom data directory location instead of the hardcoded `./data/` path. This enables running multiple instances with isolated data directories for testing and development purposes.

## Changes Made
- Added `--data-dir` argument to main.py with default value `./data`
- Added path validation and directory creation logic with error handling
- Pass custom `log_dir` to `configure_logging()` for log file isolation
- Pass custom `data_dir` to `create_app()` for project/session storage isolation

## Implementation Details
The existing codebase already had excellent support for custom data directories - all core components (`SessionCoordinator`, `SessionManager`, `ProjectManager`, `configure_logging`) already accepted optional `data_dir` parameters. This change simply threads the CLI argument through to these existing parameters.

## Testing
Tested with:
```bash
# Default behavior (uses ./data)
uv run python main.py --port 8000

# Custom data directory
uv run python main.py --port 8081 --data-dir ./test-data
```

Verified:
- Custom directory is created with correct subdirectories (logs/, projects/, sessions/)
- Log files are written to custom location
- Multiple instances can run in parallel without conflicts
- Default behavior unchanged when argument not provided

## Backward Compatibility
- Default behavior remains unchanged (uses `./data` when not specified)
- No migration needed for existing installations
- No breaking changes to API or configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)