### PR TITLE
feat: Add session management modal with restart, reset, and end options

### DIFF
--- a/src/data_storage.py
+++ b/src/data_storage.py
@@ -115,6 +115,27 @@ class DataStorageManager:
             logger.error(f"Failed to count messages: {e}")
             return 0
 
+    async def clear_messages(self) -> bool:
+        """
+        Clear all messages from the session.
+
+        Truncates the messages.jsonl file to remove all message history.
+        Used when resetting a session.
+        """
+        try:
+            # Truncate messages file
+            messages_path = self.messages_file
+            if messages_path.exists():
+                with open(messages_path, 'w') as f:
+                    pass  # Truncate to empty
+                storage_logger.info(f"Cleared all messages for session {self.session_dir.name}")
+
+            return True
+
+        except Exception as e:
+            logger.error(f"Failed to clear messages: {e}")
+            return False
+
     async def write_history(self, history_data: List[Dict[str, Any]]):
         """Write command history data"""
         await self._write_history(history_data)

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -392,8 +392,8 @@ class SessionManager:
             logger.error(f"Failed to persist session state for {session_id}: {e}")
             raise
 
-    async def update_claude_code_session_id(self, session_id: str, claude_code_session_id: str):
-        """Update the Claude Code session ID for a session"""
+    async def update_claude_code_session_id(self, session_id: str, claude_code_session_id: Optional[str]):
+        """Update the Claude Code session ID for a session (including setting to None for reset)"""
         async with self._get_session_lock(session_id):
             try:
                 session = self._active_sessions.get(session_id)

--- a/static/index.html
+++ b/static/index.html
@@ -78,9 +78,6 @@
                             <span id="current-session-id" class="fw-semibold"></span>
                             <div id="session-error-message" class="d-none alert alert-danger mb-0 py-1 px-2"></div>
                         </div>
-                        <div class="d-flex gap-2">
-                            <button id="exit-session-btn" class="btn btn-sm btn-secondary">Exit Session</button>
-                        </div>
                     </div>
 
                     <!-- Messages Area -->
@@ -106,6 +103,9 @@
                                 </button>
                                 <button id="session-info-btn" class="btn btn-sm btn-outline-secondary" disabled title="Session configuration not yet available (waiting for init message)">
                                     ℹ️ Info
+                                </button>
+                                <button id="manage-session-btn" class="btn btn-sm btn-outline-secondary" title="Restart, reset, or end session">
+                                    ⚙️ Manage
                                 </button>
                             </div>
                             <div id="claude-progress" class="d-none">
@@ -406,6 +406,45 @@
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Manage Session Modal (Bootstrap) -->
+        <div class="modal fade" id="manage-session-modal" tabindex="-1" aria-labelledby="manage-session-modal-label" aria-hidden="true">
+            <div class="modal-dialog modal-dialog-centered">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="manage-session-modal-label">Manage Session</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <p class="text-muted">Choose how to manage this session:</p>
+
+                        <div class="d-grid gap-2">
+                            <button id="restart-session-btn" class="btn btn-outline-primary text-start">
+                                <strong>🔄 Restart Agent</strong>
+                                <div class="small text-muted">Disconnect and resume session (keeps all messages)</div>
+                            </button>
+
+                            <button id="reset-session-btn" class="btn btn-outline-warning text-start">
+                                <strong>🗑️ Reset Session</strong>
+                                <div class="small text-muted">Clear all messages and start fresh (keeps settings)</div>
+                            </button>
+
+                            <button id="end-session-btn" class="btn btn-outline-secondary text-start">
+                                <strong>🚪 End Session</strong>
+                                <div class="small text-muted">Close agent and return to session list</div>
+                            </button>
+                        </div>
+
+                        <div class="alert alert-warning mt-3 mb-0">
+                            <small><strong>Note:</strong> Restart is the recommended option for unsticking the agent.</small>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
Resolves #12

Replaces the "Exit Session" button with a comprehensive "Manage Session" modal that provides three options for managing active sessions without having to delete and recreate them.

## Changes Made

### Backend
- **src/claude_sdk.py**: Added `disconnect()` method to gracefully disconnect SDK sessions
- **src/session_coordinator.py**: Added `restart_session()` and `reset_session()` methods
- **src/data_storage.py**: Added `clear_messages()` method to truncate message history
- **src/session_manager.py**: Updated `update_claude_code_session_id()` to accept `None` values
- **src/web_server.py**: Added three new REST endpoints:
  - `POST /api/sessions/{id}/restart` - Restart session with resume
  - `POST /api/sessions/{id}/reset` - Clear messages and start fresh
  - `POST /api/sessions/{id}/disconnect` - Disconnect SDK cleanly

### Frontend
- **static/index.html**:
  - Removed "Exit Session" button from session info bar
  - Added "Manage Session" button to status bar
  - Added new "Manage Session" modal with 3 action buttons
- **static/app.js**:
  - Replaced exit button listener with manage button listeners
  - Implemented `showManageSessionModal()` method
  - Implemented `restartSession()` method - disconnects and resumes with same session ID
  - Implemented `resetSession()` method - clears messages and starts fresh
  - Implemented `endSession()` method - properly disconnects SDK and returns to session list

## Session Management Options

### 🔄 Restart Agent (Recommended)
- Disconnects SDK and resumes with same session ID
- Keeps all messages and conversation history
- Useful for unsticking the agent when it gets into a bad state

### 🗑️ Reset Session
- Clears all messages from session history
- Keeps settings (permission mode, tools, model, etc.)
- Starts fresh conversation with new Claude Code session ID
- Requires confirmation due to destructive nature

### 🚪 End Session
- Properly disconnects SDK (releases resources)
- Returns UI to no-session-selected state
- Equivalent to old "Exit Session" but with proper SDK cleanup

## Testing
- [x] Server starts without errors
- [x] Backend endpoints exist and follow existing patterns
- [x] Frontend modal displays correctly
- [x] Event listeners properly wired
- [ ] Manual testing: Restart agent maintains message history
- [ ] Manual testing: Reset session clears messages  
- [ ] Manual testing: End session disconnects and returns to session list
- [ ] Manual testing: All three operations properly update session state

🤖 Generated with [Claude Code](https://claude.com/claude-code)