### PR TITLE
chore: shrink mobile speaker column to 80% of desktop size

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -494,6 +494,13 @@ html {
     #sidebar-toggle-btn {
         padding: 0.2rem 0.4rem;
     }
+
+    /* Shrink speaker column to 80% of desktop size */
+    .message-speaker {
+        min-width: 64px;   /* 80% of 80px */
+        max-width: 80px;   /* 80% of 100px */
+        font-size: 0.85rem; /* Slightly smaller font for better fit */
+    }
 }
 
 /* Permission Suggestion Styles */


### PR DESCRIPTION
## Summary
Resolves #38

Reduces the message speaker column width on mobile devices to free up horizontal space for message content on portrait mobile screens.

## Changes Made
- Added mobile-specific CSS rules inside the existing `@media (max-width: 767px)` block in `static/styles.css`
- Reduced `.message-speaker` min-width from 80px to 64px (80% of desktop)
- Reduced `.message-speaker` max-width from 100px to 80px (80% of desktop)
- Added slightly smaller font size (0.85rem) for better fit on narrow screens

## Testing
To test these changes:
1. Open the application on a mobile device or use browser dev tools mobile emulation
2. Verify that speaker labels ("user", "agent", "system") remain readable
3. Confirm that message content area has gained additional horizontal space (~16-20% more width)
4. Test on various mobile device sizes (iPhone SE at 375px, standard Android at 360-412px)
5. Verify desktop view remains unchanged (should only affect screens ≤767px wide)

## Expected Outcome
On mobile devices, the speaker column will occupy less horizontal space (64px instead of 80px minimum), providing more room for message content without sacrificing readability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)