### PR TITLE
chore: Fix delete session modal button styling

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -323,7 +323,7 @@
                         </div>
                     </div>
                     <div class="modal-footer">
-                        <button type="button" class="btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
                         <button type="button" id="confirm-delete-session" class="btn btn-danger">Delete Session</button>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
Resolves #41

Adds the missing `btn` Bootstrap class to the Cancel button in the delete session confirmation modal to match the styling of other modals.

## Changes Made
- Added `btn` class to Cancel button in delete session modal (`static/index.html` line 326)
- Changed `class="btn-secondary"` to `class="btn btn-secondary"`

## Details
The delete session modal's Cancel button was rendering as plain text because it was missing the base `btn` Bootstrap class. The delete project modal already had correct styling. This one-word change makes both modals consistent with the reset confirmation modal, which uses properly styled buttons.

## Testing
Manual testing recommended:
1. Open the delete session modal (right-click session → Delete)
2. Verify Cancel button has proper Bootstrap styling (gray background, rounded corners, hover effects)
3. Verify Delete Session button styling is unchanged (red/danger styling)
4. Compare with delete project modal styling (should match)

🤖 Generated with [Claude Code](https://claude.com/claude-code)