### PR TITLE
feat: Mobile-responsive status bar with compressed button text

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1040,7 +1040,9 @@ class ClaudeWebUI {
         const permissionModeClickable = document.getElementById('permission-mode-clickable');
 
         if (permissionModeText) {
-            permissionModeText.textContent = `Mode: ${mode}`;
+            // Show only mode name on mobile, full text on desktop
+            const isMobile = window.innerWidth < 768;
+            permissionModeText.textContent = isMobile ? mode : `Mode: ${mode}`;
         }
 
         // Update icon and title based on mode
@@ -3049,6 +3051,14 @@ class ClaudeWebUI {
         // Show/hide status bar based on session state
         if (isActive) {
             statusBar.classList.remove('d-none');
+
+            // Initialize auto-scroll text with correct format for current viewport
+            const autoScrollText = document.getElementById('auto-scroll-text');
+            if (autoScrollText) {
+                const isMobile = window.innerWidth < 768;
+                const statusText = this.autoScrollEnabled ? 'ON' : 'OFF';
+                autoScrollText.textContent = isMobile ? ` ${statusText}` : ` Auto-scroll: ${statusText}`;
+            }
         } else {
             statusBar.classList.add('d-none');
             return;
@@ -3079,7 +3089,10 @@ class ClaudeWebUI {
         const config = modeConfig[currentMode] || modeConfig['acceptEdits'];
 
         permissionModeIcon.textContent = config.icon;
-        permissionModeText.textContent = config.label;
+
+        // Show only mode name on mobile, full text on desktop
+        const isMobile = window.innerWidth < 768;
+        permissionModeText.textContent = isMobile ? currentMode : config.label;
 
         // Set description as tooltip on the clickable area
         permissionModeClickable.title = config.description;
@@ -4030,13 +4043,20 @@ class ClaudeWebUI {
     toggleAutoScroll() {
         this.autoScrollEnabled = !this.autoScrollEnabled;
         const button = document.getElementById('auto-scroll-toggle');
+        const autoScrollText = document.getElementById('auto-scroll-text');
 
         if (this.autoScrollEnabled) {
-            button.textContent = '📜 Auto-scroll: ON';
+            if (autoScrollText) {
+                const isMobile = window.innerWidth < 768;
+                autoScrollText.textContent = isMobile ? ' ON' : ' Auto-scroll: ON';
+            }
             button.className = 'btn btn-sm btn-outline-secondary';
             this.smartScrollToBottom();
         } else {
-            button.textContent = '📜 Auto-scroll: OFF';
+            if (autoScrollText) {
+                const isMobile = window.innerWidth < 768;
+                autoScrollText.textContent = isMobile ? ' OFF' : ' Auto-scroll: OFF';
+            }
             button.className = 'btn btn-sm btn-secondary';
         }
     }

--- a/static/index.html
+++ b/static/index.html
@@ -105,10 +105,10 @@
                                     <span id="permission-mode-text">Mode: default</span>
                                 </button>
                                 <button id="session-info-btn" class="btn btn-sm btn-outline-secondary" disabled title="Session configuration not yet available (waiting for init message)">
-                                    ℹ️ Info
+                                    <span class="btn-icon">ℹ️</span><span class="btn-text"> Info</span>
                                 </button>
                                 <button id="manage-session-btn" class="btn btn-sm btn-outline-secondary" title="Restart, reset, or end session">
-                                    ⚙️ Manage
+                                    <span class="btn-icon">⚙️</span><span class="btn-text"> Manage</span>
                                 </button>
                             </div>
                             <div id="claude-progress" class="d-none">
@@ -117,7 +117,7 @@
                                 </div>
                             </div>
                             <button id="auto-scroll-toggle" class="btn btn-sm btn-outline-secondary" title="Toggle auto-scroll">
-                                📜 Auto-scroll: ON
+                                <span class="btn-icon">📜</span><span class="btn-text" id="auto-scroll-text"> Auto-scroll: ON</span>
                             </button>
                         </div>
                     </div>

--- a/static/styles.css
+++ b/static/styles.css
@@ -512,6 +512,16 @@ html {
         max-width: 80px;   /* 80% of 100px */
         font-size: 0.85rem; /* Slightly smaller font for better fit */
     }
+
+    /* Status bar buttons compress text on mobile (except auto-scroll which shows short status) */
+    #session-info-btn .btn-text,
+    #manage-session-btn .btn-text {
+        display: none;
+    }
+
+    #status-bar .btn {
+        min-width: 40px; /* Ensure adequate tap target */
+    }
 }
 
 /* Permission Suggestion Styles */


### PR DESCRIPTION
## Summary
Resolves #47

Implements mobile-responsive status bar that compresses button text to save horizontal space on narrow viewports (<768px).

## Changes Made

### Mobile Display (<768px width)
- **Permission mode button**: Shows only mode name (e.g., "🔒 default") without "Mode:" prefix
- **Session Info button**: Icon only (ℹ️)
- **Manage button**: Icon only (⚙️)
- **Auto-scroll button**: Short status (📜 ON / 📜 OFF)

### Desktop Display (≥768px width)
- All buttons show full text as before
- Permission mode: "🔒 Mode: default"
- Auto-scroll: "📜 Auto-scroll: ON"

## Implementation Details

**HTML Changes** (static/index.html):
- Wrapped button text in `.btn-icon` and `.btn-text` spans for selective hiding

**CSS Changes** (static/styles.css):
- Added mobile media query to hide `.btn-text` for Info/Manage buttons
- Maintained 40px minimum tap target for accessibility

**JavaScript Changes** (static/app.js):
- `updatePermissionModeUI()`: Checks viewport width, sets appropriate text
- `updatePermissionModeDisplay()`: Initializes permission mode and auto-scroll text on session load
- `toggleAutoScroll()`: Updates auto-scroll text based on viewport width

## Testing

Tested at multiple viewport widths:
- 767px (breakpoint boundary)
- 375px (iPhone SE)
- 320px (small mobile)
- 768px+ (tablet/desktop)

Verified:
- Text format updates correctly on toggle
- Text initializes correctly when session loads
- Buttons remain clickable with adequate tap targets
- Tooltips accessible on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)