### PR TITLE
feat: Support markdown for assistant and user messages

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -11,6 +11,10 @@
     <!-- Diff2html CSS for code diffs -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/diff2html/bundles/css/diff2html.min.css" />
 
+    <!-- Markdown rendering libraries -->
+    <script src="https://cdn.jsdelivr.net/npm/marked@11.1.1/marked.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.8/dist/purify.min.js"></script>
+
     <!-- Application Custom Styles -->
     <!-- TEMPORARILY DISABLED: Rebuilding with Bootstrap-first approach -->
     <!-- <link rel="stylesheet" href="/static/custom.css"> -->

--- a/static/styles.css
+++ b/static/styles.css
@@ -665,3 +665,207 @@ html {
 .mode-change-flash {
     animation: mode-change-flash 0.6s ease-in-out 3;
 }
+
+/* ========== MARKDOWN CONTENT STYLES ========== */
+
+.markdown-content {
+    line-height: 1.4 !important;
+    display: inline-grid;
+}
+
+/* Headers */
+.markdown-content h1,
+.markdown-content h2,
+.markdown-content h3,
+.markdown-content h4,
+.markdown-content h5,
+.markdown-content h6 {
+    margin-top: 0;
+    margin-bottom: 0;
+    font-weight: 600;
+}
+
+.markdown-content h1 { font-size: 1.15rem; border-bottom: 1px solid #e1e4e8; padding-bottom: 0.5rem; }
+.markdown-content h2 { font-size: 1.1rem; border-bottom: 1px solid #e1e4e8; padding-bottom: 0.5rem; }
+.markdown-content h3 { font-size: 1.05rem; padding-bottom: 0.5rem; }
+.markdown-content h4 { font-size: 1rem; padding-bottom: 0.5rem; }
+.markdown-content h5 { font-size: 0.95rem; padding-bottom: 0.5rem; }
+.markdown-content h6 { font-size: 0.9rem; color: #6a737d; padding-bottom: 0.5rem; }
+
+.markdown-content h1:first-child,
+.markdown-content h2:first-child,
+.markdown-content h3:first-child {
+    margin-top: 0;
+}
+
+/* Paragraphs */
+.markdown-content p {
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.markdown-content p:last-child {
+    margin-bottom: 0;
+}
+
+/* Lists */
+.markdown-content ul,
+.markdown-content ol {
+    margin-top: 0;
+    margin-bottom: 0;
+    padding-left: 1.5rem;
+    display: grid;
+    font-size: 0; /* Collapse whitespace text nodes between tags */
+}
+
+.markdown-content li {
+    margin-top: 0;
+    margin-bottom: 0;
+    font-size: 0.875rem; /* Restore font size for list content */
+}
+
+.markdown-content li > p {
+    line-height: 1;
+    margin: 0;
+}
+
+.markdown-content ul ul,
+.markdown-content ol ol,
+.markdown-content ul ol,
+.markdown-content ol ul {
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+/* Code blocks */
+.markdown-content pre {
+    background: #f6f8fa;
+    border: 1px solid #e1e4e8;
+    border-radius: 4px;
+    padding: 0.5rem;
+    overflow-x: auto;
+    margin-top: 0;
+    margin-bottom: 0;
+    font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+    font-size: 0.875rem;
+}
+
+.markdown-content pre code {
+    background: transparent;
+    border: none;
+    padding: 0;
+    font-size: inherit;
+}
+
+/* Inline code */
+.markdown-content code {
+    background: #f6f8fa;
+    border: 1px solid #e1e4e8;
+    border-radius: 3px;
+    padding: 0.1em 0.3em;
+    font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+    font-size: 0.875em;
+}
+
+/* Blockquotes */
+.markdown-content blockquote {
+    border-left: 4px solid #dfe2e5;
+    padding-left: 0.75rem;
+    margin-top: 0;
+    margin-bottom: 0;
+    margin-left: 0;
+    color: #6a737d;
+}
+
+.markdown-content blockquote p {
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+/* Links */
+.markdown-content a {
+    color: #0366d6;
+    text-decoration: none;
+}
+
+.markdown-content a:hover {
+    text-decoration: underline;
+}
+
+/* Tables */
+.markdown-content table {
+    border-collapse: collapse;
+    width: 100%;
+    margin-top: 0;
+    margin-bottom: 0;
+    font-size: 0.875rem;
+}
+
+.markdown-content th,
+.markdown-content td {
+    border: 1px solid #dfe2e5;
+    padding: 0.35rem 0.5rem;
+    text-align: left;
+}
+
+.markdown-content th {
+    background: #f6f8fa;
+    font-weight: 600;
+}
+
+.markdown-content tr:nth-child(even) {
+    background: #f6f8fa;
+}
+
+/* Horizontal rules */
+.markdown-content hr {
+    border: none;
+    border-top: 1px solid #e1e4e8;
+    margin: 0;
+}
+
+/* Strong and emphasis */
+.markdown-content strong {
+    font-weight: 600;
+}
+
+.markdown-content em {
+    font-style: italic;
+}
+
+/* Strikethrough and insert */
+.markdown-content del {
+    text-decoration: line-through;
+    opacity: 0.7;
+}
+
+.markdown-content ins {
+    text-decoration: underline;
+    background: #ffffcc;
+}
+
+/* Details/Summary (collapsible sections) */
+.markdown-content details {
+    margin-top: 0;
+    margin-bottom: 0;
+    border: 1px solid #e1e4e8;
+    border-radius: 4px;
+    padding: 0.35rem;
+}
+
+.markdown-content summary {
+    cursor: pointer;
+    font-weight: 600;
+    padding: 0.35rem;
+    user-select: none;
+}
+
+.markdown-content summary:hover {
+    background: #f6f8fa;
+    border-radius: 4px;
+}
+
+/* Adjust spacing for nested elements */
+.markdown-content > *:last-child {
+    margin-bottom: 0;
+}


### PR DESCRIPTION
## Summary
Resolves #5

Implemented markdown rendering for both assistant and user messages to improve readability of formatted responses. The implementation uses marked.js for parsing and DOMPurify for security.

## Changes Made

### Libraries Added
- **marked.js v11.1.1**: Fast, GitHub Flavored Markdown parser
- **DOMPurify v3.0.8**: XSS sanitization for rendered HTML

### Core Functionality
- Added `renderMarkdown()` method in `app.js` that:
  - Parses markdown to HTML using marked.js
  - Sanitizes output with DOMPurify (whitelist of safe tags)
  - Post-processes HTML to remove unwanted newlines from marked.js output
  - Fallbacks to escaped plain text if libraries fail
- Updated `_formatMessageContent()` to render markdown for both assistant and user messages
- Configured marked.js with GFM support, security settings, and modern markdown parsing

### Markdown Elements Supported
- Headers (H1-H6) with compact font sizes and bottom padding
- Paragraphs with 1.4em line-height for readability
- Ordered and unordered lists with proper nesting
- Code blocks (inline and fenced) with monospace font
- Blockquotes with left border styling
- Tables with alternating row colors
- Links (forced to open in new tab with security attributes)
- Text formatting (bold, italic, strikethrough)
- Horizontal rules

### CSS Styling
- Ultra-compact spacing with `line-height: 1` and `display: inline-grid`
- Paragraphs use `line-height: 1.4em` to prevent wrapped text overlap
- Headers have `padding-bottom: 0.5rem` for visual separation
- Lists use `display: grid` to eliminate browser default spacing
- All margins set to 0 for tight vertical spacing

### HTML Post-Processing
Added regex filters to remove unwanted newlines from marked.js output:
- After closing `</ul>`, `</ol>`, `</p>`, `</pre>` tags
- After opening `<blockquote>` tags
- After closing `</blockquote>` tags

This eliminates extra whitespace that would otherwise appear as text nodes in the DOM.

### Security Measures
- DOMPurify sanitization with strict tag whitelist
- No inline event handlers or data attributes allowed
- Links forced to `target="_blank"` with `rel="noopener noreferrer"`
- Fallback to escaped plain text if rendering fails

## Testing
- Manually tested with various markdown elements (headers, lists, code, tables, blockquotes)
- Verified nested lists render without extra spacing
- Confirmed security sanitization works correctly
- Tested on test server (port 8001) with dedicated test data directory

## Future Enhancements (Not in This PR)
- Syntax highlighting for code blocks (Prism.js or highlight.js)
- Math rendering (KaTeX or MathJax)
- Mermaid diagram support
- User preference toggle for markdown rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)