### PR TITLE
feat: Add MCP tool handler for display and content rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,9 @@ __marimo__/
 data/
 tmp*/
 test_data/
+
+# Claude settings
+.claude/settings.local.json
+
+# MCP configuration
+.mcp.json

--- a/static/app.js
+++ b/static/app.js
@@ -88,8 +88,8 @@ class ClaudeWebUI {
         this.toolHandlerRegistry.registerHandler('Task', new TaskToolHandler());
         this.toolHandlerRegistry.registerHandler('ExitPlanMode', new ExitPlanModeToolHandler());
 
-        // Register pattern handlers for MCP tools (can be customized later)
-        // this.toolHandlerRegistry.registerPatternHandler('mcp__*', new McpToolHandler());
+        // Register pattern handlers for MCP tools
+        this.toolHandlerRegistry.registerPatternHandler('mcp__*', new McpToolHandler());
     }
 
     initializeStatusColors() {

--- a/static/index.html
+++ b/static/index.html
@@ -485,6 +485,7 @@
     <script src="/static/tools/handlers/web-handlers.js"></script>
     <script src="/static/tools/handlers/bash-handlers.js"></script>
     <script src="/static/tools/handlers/misc-handlers.js"></script>
+    <script src="/static/tools/handlers/mcp-handler.js"></script>
 
     <!-- Main Application -->
     <script src="/static/app.js"></script>

--- a/static/styles.css
+++ b/static/styles.css
@@ -869,3 +869,103 @@ html {
 .markdown-content > *:last-child {
     margin-bottom: 0;
 }
+
+/* ========== MCP TOOL STYLES ========== */
+
+.tool-mcp-params {
+    background: #f0f9ff;
+    border-left: 3px solid #0ea5e9;
+    padding: 0.75rem;
+    border-radius: 0.25rem;
+    margin: 0.5rem 0;
+}
+
+.mcp-header {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
+}
+
+.mcp-icon {
+    font-size: 1.2rem;
+    flex-shrink: 0;
+}
+
+.mcp-header-content {
+    flex: 1;
+}
+
+.mcp-server-row,
+.mcp-tool-row {
+    margin-bottom: 0.25rem;
+}
+
+.mcp-label {
+    color: #64748b;
+    font-size: 0.875rem;
+    font-weight: 500;
+}
+
+.mcp-server-name {
+    background: #e0f2fe;
+    color: #0369a1;
+    padding: 0.125rem 0.375rem;
+    border-radius: 0.25rem;
+    font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+    font-size: 0.875rem;
+    font-weight: 600;
+}
+
+.mcp-tool-name {
+    background: #f0f9ff;
+    color: #0284c7;
+    padding: 0.125rem 0.375rem;
+    border-radius: 0.25rem;
+    font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+    font-size: 0.875rem;
+    font-weight: 500;
+}
+
+.mcp-params-section {
+    margin-top: 0.5rem;
+}
+
+.mcp-params-label {
+    margin-bottom: 0.25rem;
+    color: #475569;
+    font-size: 0.875rem;
+}
+
+.mcp-params-json {
+    background: #f8fafc;
+    border: 1px solid #cbd5e1;
+    border-radius: 0.25rem;
+    padding: 0.5rem;
+    font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+    font-size: 0.8rem;
+    line-height: 1.5;
+    overflow-x: auto;
+    margin: 0;
+    color: #334155;
+}
+
+.mcp-no-params {
+    color: #94a3b8;
+    font-style: italic;
+    font-size: 0.875rem;
+    margin-top: 0.5rem;
+}
+
+.mcp-success-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+    color: #059669;
+}
+
+.tool-result-content.json-content {
+    background: #f8fafc;
+    color: #334155;
+}

--- a/static/tools/handlers/mcp-handler.js
+++ b/static/tools/handlers/mcp-handler.js
@@ -1,0 +1,141 @@
+// MCP Tool Handler - displays MCP server tool calls
+class McpToolHandler {
+    /**
+     * Parse MCP tool name into components
+     * Format: mcp__<server-name>__<tool-name>
+     */
+    parseMcpToolName(toolName) {
+        if (!toolName.startsWith('mcp__')) {
+            return null;
+        }
+
+        // Remove 'mcp__' prefix and split by '__'
+        const parts = toolName.substring(5).split('__');
+        if (parts.length < 2) {
+            return null;
+        }
+
+        const serverName = parts[0];
+        const toolNamePart = parts.slice(1).join('__'); // Handle tool names with __ in them
+
+        return {
+            serverName,
+            toolName: toolNamePart
+        };
+    }
+
+    renderParameters(toolCall, escapeHtmlFn) {
+        const parsed = this.parseMcpToolName(toolCall.name);
+        if (!parsed) {
+            return `<div class="tool-parameters">Invalid MCP tool name format</div>`;
+        }
+
+        const { serverName, toolName } = parsed;
+        const input = toolCall.input || {};
+        const hasParams = Object.keys(input).length > 0;
+
+        let html = '<div class="tool-parameters tool-mcp-params">';
+
+        // Header with MCP server and tool info
+        html += '<div class="mcp-header">';
+        html += '<span class="mcp-icon">🔌</span>';
+        html += '<div class="mcp-header-content">';
+        html += '<div class="mcp-server-row">';
+        html += '<span class="mcp-label">MCP Server:</span> ';
+        html += `<code class="mcp-server-name">${escapeHtmlFn(serverName)}</code>`;
+        html += '</div>';
+        html += '<div class="mcp-tool-row">';
+        html += '<span class="mcp-label">Tool:</span> ';
+        html += `<code class="mcp-tool-name">${escapeHtmlFn(toolName)}</code>`;
+        html += '</div>';
+        html += '</div>';
+        html += '</div>';
+
+        // Parameters section (if any)
+        if (hasParams) {
+            html += '<div class="mcp-params-section">';
+            html += '<div class="mcp-params-label"><strong>Parameters:</strong></div>';
+            html += '<pre class="mcp-params-json">';
+            html += escapeHtmlFn(JSON.stringify(input, null, 2));
+            html += '</pre>';
+            html += '</div>';
+        } else {
+            html += '<div class="mcp-no-params">No parameters</div>';
+        }
+
+        html += '</div>';
+        return html;
+    }
+
+    renderResult(toolCall, escapeHtmlFn) {
+        if (!toolCall.result) return '';
+
+        const resultClass = toolCall.result.error ? 'tool-result-error' : 'tool-result-success';
+        const content = toolCall.result.content || '';
+
+        if (toolCall.result.error) {
+            return `
+                <div class="tool-result ${resultClass}">
+                    <strong>MCP Tool Error:</strong>
+                    <pre class="tool-result-content">${escapeHtmlFn(content || 'Unknown error')}</pre>
+                </div>
+            `;
+        }
+
+        // Try to parse as JSON for pretty display
+        let displayContent = content;
+        let isJson = false;
+
+        try {
+            const parsed = JSON.parse(content);
+            displayContent = JSON.stringify(parsed, null, 2);
+            isJson = true;
+        } catch (e) {
+            // Not JSON, display as-is
+        }
+
+        return `
+            <div class="tool-result ${resultClass}">
+                <div class="mcp-success-header">
+                    <span class="success-icon">✅</span>
+                    <strong>MCP Tool Result</strong>
+                </div>
+                <pre class="tool-result-content ${isJson ? 'json-content' : ''}">${escapeHtmlFn(displayContent)}</pre>
+            </div>
+        `;
+    }
+
+    getCollapsedSummary(toolCall) {
+        const parsed = this.parseMcpToolName(toolCall.name);
+        if (!parsed) {
+            return '🔌 MCP Tool';
+        }
+
+        const { serverName, toolName } = parsed;
+
+        const statusIcon = {
+            'pending': '🔄',
+            'permission_required': '❓',
+            'executing': '⚡',
+            'completed': toolCall.permissionDecision === 'deny' ? '❌' : '✅',
+            'error': '💥'
+        }[toolCall.status] || '🔧';
+
+        let statusText = '';
+        if (toolCall.status === 'completed' && !toolCall.result?.error) {
+            statusText = 'Success';
+        } else if (toolCall.result?.error) {
+            statusText = 'Error';
+        } else {
+            statusText = {
+                'pending': 'Pending',
+                'permission_required': 'Awaiting Permission',
+                'executing': 'Executing',
+                'completed': 'Completed',
+                'error': 'Error'
+            }[toolCall.status] || 'Unknown';
+        }
+
+        return `${statusIcon} MCP (${serverName}): ${toolName} - ${statusText}`;
+    }
+}


### PR DESCRIPTION
## Summary
Resolves #8

Implements a custom tool handler for Model Context Protocol (MCP) tools to provide enhanced visualization of MCP server tool execution in the web UI.

## Changes Made

### New Files
- **static/tools/handlers/mcp-handler.js** - Complete MCP tool handler implementation
  - Parses MCP tool names (format: `mcp__<server>__<tool>`)
  - Renders parameters with server/tool identification
  - Auto-detects and pretty-prints JSON results
  - Provides collapsed summary with status indicators

### Modified Files
- **static/styles.css** - Added MCP-specific CSS styling (~100 lines)
  - Light blue color scheme (#0ea5e9) representing connectivity
  - Monospace fonts for server/tool names
  - Responsive design for parameters and results
  
- **static/app.js** - Uncommented MCP handler registration (1 line)
  - Activates pattern matching for `mcp__*` tools

- **static/index.html** - Added script tag for mcp-handler.js (1 line)
  - Loads handler before main application

- **.gitignore** - Added local settings exclusions
  - `.claude/settings.local.json` - Local Claude settings
  - `.mcp.json` - MCP configuration file

## Technical Implementation

The handler leverages the existing pattern matching infrastructure in `ToolHandlerRegistry`:
- Single handler instance handles ALL MCP tools
- No per-server registration needed
- Future-proof for any MCP server integration
- Follows existing tool handler patterns (Read, Edit, Write, etc.)

## Testing

- ✅ Test server starts without errors on port 8001
- ✅ Health endpoint responds correctly
- ✅ MCP handler script tag present in HTML
- ✅ No JavaScript console errors on page load
- ✅ Pattern matching infrastructure already in place

## Testing Checklist (for reviewers)

**Without MCP Tools:**
- [ ] App loads without errors
- [ ] Existing tools (Read, Edit, etc.) still work
- [ ] No console errors

**With MCP Tools (when available):**
- [ ] MCP tool parameters display server and tool name
- [ ] Input parameters are formatted clearly
- [ ] JSON results are pretty-printed
- [ ] Text results display correctly
- [ ] Error states show properly
- [ ] Collapsed summary shows correct icon and status
- [ ] Permission requests work for MCP tools

## Design Decisions

**Visual Theme:** Light blue (#0ea5e9 / sky-500) represents connectivity/networking, with plug icon (🔌) for MCP connection

**Information Hierarchy:**
1. Primary: MCP server name (where the tool lives)
2. Secondary: Tool name (what action is performed)
3. Tertiary: Parameters (if any)

**JSON Handling:** Auto-detect and pretty-print for readability

## Future Enhancements

- Server-specific custom handlers (e.g., `mcp__weather__*`)
- MCP server connection status indicators
- Syntax highlighting for JSON results
- Collapsible sections for large results

🤖 Generated with [Claude Code](https://claude.com/claude-code)