### PR TITLE
qol: Move delete session into Manage Session modal

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -300,12 +300,9 @@
                             <small class="form-text text-muted">Note: bypassPermissions mode can only be set during session creation.</small>
                         </div>
                     </div>
-                    <div class="modal-footer d-flex justify-content-between">
-                        <button type="button" id="delete-session-from-edit-btn" class="btn btn-danger">Delete</button>
-                        <div>
-                            <button type="button" class="btn btn-secondary me-2" data-bs-dismiss="modal">Cancel</button>
-                            <button type="button" id="save-session-btn" class="btn btn-primary">OK</button>
-                        </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary me-2" data-bs-dismiss="modal">Cancel</button>
+                        <button type="button" id="save-session-btn" class="btn btn-primary">OK</button>
                     </div>
                 </div>
             </div>
@@ -430,19 +427,29 @@
                         <p class="text-muted">Choose how to manage this session:</p>
 
                         <div class="d-grid gap-2">
+                            <!-- Non-destructive actions -->
                             <button id="restart-session-btn" class="btn btn-outline-primary text-start">
                                 <strong>🔄 Restart Agent</strong>
                                 <div class="small text-muted">Disconnect and resume session (keeps all messages)</div>
                             </button>
 
+                            <button id="end-session-btn" class="btn btn-outline-secondary text-start">
+                                <strong>🚪 End Session</strong>
+                                <div class="small text-muted">Close agent and return to session list</div>
+                            </button>
+
+                            <!-- Visual separator -->
+                            <hr class="my-2">
+
+                            <!-- Destructive actions grouped together -->
                             <button id="reset-session-btn" class="btn btn-outline-warning text-start">
                                 <strong>🗑️ Reset Session</strong>
                                 <div class="small text-muted">Clear all messages and start fresh (keeps settings)</div>
                             </button>
 
-                            <button id="end-session-btn" class="btn btn-outline-secondary text-start">
-                                <strong>🚪 End Session</strong>
-                                <div class="small text-muted">Close agent and return to session list</div>
+                            <button id="delete-session-from-manage-btn" class="btn btn-outline-danger text-start">
+                                <strong>❌ Delete Session</strong>
+                                <div class="small text-muted">Permanently delete this session and all its data</div>
                             </button>
                         </div>
 


### PR DESCRIPTION
## Summary
Resolves #54

Consolidates the delete session action into the Manage Session modal and reorganizes menu items to group destructive actions together, improving UX and reducing accidental deletions.

## Changes Made

### HTML Changes (static/index.html)
- **Removed** standalone delete button from Edit Session modal footer
- **Added** Delete Session button to Manage Session modal
- **Reordered** Manage Session menu:
  - Non-destructive actions (top): Restart Agent, End Session
  - Visual separator (`<hr>`)
  - Destructive actions (bottom): Reset Session, Delete Session

### JavaScript Changes (static/app.js)
- **Created** `showDeleteSessionConfirmationInline()` - swaps Manage Session modal content to show delete confirmation (same pattern as Reset Session)
- **Created** `confirmDeleteSessionFromManage()` - handles deletion with loading state in the same modal
- **Updated** `attachManageSessionListeners()` to wire up delete button
- **Removed** old separate delete modal logic:
  - Removed `showDeleteSessionConfirmation()` method
  - Removed `hideDeleteSessionModal()` method
  - Removed `onDeleteSessionModalHidden()` method
  - Removed `confirmDeleteSession()` method
  - Removed event listeners for old delete flow
  - Removed `deleteFromManageModal` flag

### UX Improvements
- **Delete warning** now matches Reset Session warning style:
  - Red danger alert with "⚠️ Warning: This action cannot be undone"
  - Clear explanation that session (with name) will be permanently deleted
  - Emphasizes ALL messages, conversation history, settings, and configuration will be destroyed
  - Clarifies "This is more destructive than Reset Session"

## Benefits
✅ Cleaner Edit Session modal (no exposed delete button)
✅ Better information architecture (all session management actions in one place)
✅ Reduced accidental deletions (delete grouped with other destructive actions)
✅ Clear visual separation of destructive vs. safe actions
✅ Consistent modal interaction pattern with Reset Session
✅ Improved warning clarity

## Testing
- [x] Click "Manage" button → Modal shows 4 actions with separator
- [x] Visual separator appears between End Session and Reset Session
- [x] Click "Delete Session" → Modal content swaps to confirmation (stays in same modal)
- [x] Click "Cancel" → Returns to Manage Session menu
- [x] Click "Delete Session" again, confirm → Shows loading, deletes session, closes modal
- [x] Edit Session modal no longer has delete button
- [x] Delete warning matches Reset warning style and is clear about destructiveness

🤖 Generated with [Claude Code](https://claude.com/claude-code)