### PR TITLE
fix: Correct bypassPermissions mode display and cycling behavior

### DIFF
--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -48,6 +48,7 @@ class SessionInfo:
     updated_at: datetime
     working_directory: Optional[str] = None
     current_permission_mode: str = "acceptEdits"
+    initial_permission_mode: Optional[str] = None
     system_prompt: Optional[str] = None
     tools: List[str] = None
     model: Optional[str] = None
@@ -110,6 +111,11 @@ class SessionManager:
                         try:
                             with open(state_file, 'r') as f:
                                 data = json.load(f)
+
+                            # Migration: Add initial_permission_mode if missing
+                            if 'initial_permission_mode' not in data:
+                                data['initial_permission_mode'] = data.get('current_permission_mode', 'acceptEdits')
+
                             session_info = SessionInfo.from_dict(data)
 
                             # Reset active/starting sessions to created state on startup
@@ -172,6 +178,7 @@ class SessionManager:
             updated_at=now,
             working_directory=working_directory,
             current_permission_mode=permission_mode,
+            initial_permission_mode=permission_mode,
             system_prompt=system_prompt,
             tools=tools if tools is not None else [],
             model=model,

--- a/static/app.js
+++ b/static/app.js
@@ -3231,6 +3231,12 @@ class ClaudeWebUI {
                 label: 'Mode: plan',
                 description: 'Click to cycle modes • Read-only mode',
                 color: 'blue'
+            },
+            'bypassPermissions': {
+                icon: '🚫',
+                label: 'Mode: bypassPermissions',
+                description: 'Click to cycle modes • No permission prompts (most permissive)',
+                color: 'red'
             }
         };
 
@@ -3255,8 +3261,18 @@ class ClaudeWebUI {
             return;
         }
 
-        // Define cycle order (excluding bypassPermissions for safety)
-        const modeOrder = ['default', 'acceptEdits', 'plan'];
+        // Determine available modes based on initial permission mode
+        const initialMode = session.initial_permission_mode || session.current_permission_mode;
+        let modeOrder;
+
+        if (initialMode === 'bypassPermissions') {
+            // Include bypassPermissions in cycle if session started with it
+            modeOrder = ['default', 'acceptEdits', 'plan', 'bypassPermissions'];
+        } else {
+            // Exclude bypassPermissions for safety if session didn't start with it
+            modeOrder = ['default', 'acceptEdits', 'plan'];
+        }
+
         const currentMode = session.current_permission_mode || 'acceptEdits';
         const currentIndex = modeOrder.indexOf(currentMode);
         const nextIndex = (currentIndex + 1) % modeOrder.length;


### PR DESCRIPTION
## Summary
Resolves #52

This PR fixes the bypassPermissions mode display and cycling behavior. Sessions started with bypassPermissions mode now correctly display the mode icon/text and can cycle through all modes. For security, sessions started with other modes (default, acceptEdits, plan) have cycling restricted to those three modes only, preventing accidental elevation to the most permissive mode.

## Changes Made

### Backend (src/session_manager.py)
- **Added `initial_permission_mode` field** to SessionInfo dataclass to track the mode a session was created with
- **Updated `create_session()`** to set `initial_permission_mode` when creating sessions
- **Added migration logic** in `_load_existing_sessions()` to populate `initial_permission_mode` for existing sessions (defaults to `current_permission_mode`)

### Frontend (static/app.js)
- **Added bypassPermissions to modeConfig** with icon 🚫, label, and description
- **Updated `cyclePermissionMode()`** to conditionally include bypassPermissions in the cycle based on the session's `initial_permission_mode`:
  - Sessions started with `bypassPermissions`: Can cycle through all 4 modes
  - Sessions started with other modes: Restricted to 3 modes (default, acceptEdits, plan)

## Testing

Backend changes were tested with isolated test environment:
1. Created test project
2. Created session with `bypassPermissions` mode - verified `initial_permission_mode` field was set correctly
3. Created session with `default` mode - verified `initial_permission_mode` was set to `default`
4. Verified persistence to state.json files

Frontend changes should be tested by:
1. Creating a session with `bypassPermissions` mode
2. Verifying the mode button shows 🚫 icon and "bypassPermissions" text
3. Clicking the mode button to cycle - should include bypassPermissions in the cycle
4. Creating a session with `default` mode
5. Clicking the mode button to cycle - should NOT include bypassPermissions (cycle: default → acceptEdits → plan → default)

## Security Benefit

This change prevents accidental elevation to the most permissive mode (`bypassPermissions`) for sessions that started with more restrictive permissions, while allowing sessions that were explicitly created with `bypassPermissions` to maintain full control over their permission mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)