### PR TITLE
fix: Improve bash command display readability with dark terminal colors

### DIFF
--- a/frontend/src/components/tools/BashToolHandler.vue
+++ b/frontend/src/components/tools/BashToolHandler.vue
@@ -175,7 +175,8 @@ const resultContent = computed(() => {
   font-size: 0.9rem;
   white-space: pre;
   overflow-x: auto;
-  color: #00ff00;
+  background: #212529;  /* Override global light blue - use dark terminal background */
+  color: #f8f9fa;  /* White/light gray text for readability */
 }
 
 .tool-result {


### PR DESCRIPTION
## Summary
Resolves #71

Fixes the unreadable bash command display by changing from light blue background + green text to dark terminal styling with white text, matching the output box appearance.

## Changes Made
- **Override global light blue background** (`#e7f3ff`) with dark terminal background (`#212529`)
- **Replace bright green text** (`#00ff00`) with white/light gray text (`#f8f9fa`)
- Changes scoped to `BashToolHandler.vue` component only
- Maintains terminal-style appearance consistent with output section

## Root Cause
The issue was caused by a combination of:
1. Global CSS rule applying light blue background to `.bash-command-content`
2. Component CSS applying bright green text color
3. This created poor contrast violating accessibility guidelines

## Testing
Visual verification steps:
1. Run frontend dev server: `cd frontend && npm run dev`
2. Create a session and execute Bash commands
3. Verify command section has dark background with white text
4. Confirm consistency with output section styling

## Screenshots
**Before:** Light blue background + green text (unreadable)
**After:** Dark background + white text (readable, terminal-style)

🤖 Generated with [Claude Code](https://claude.com/claude-code)