### PR TITLE
fix: correct method name in session creation WebSocket broadcast

### DIFF
--- a/src/web_server.py
+++ b/src/web_server.py
@@ -539,7 +539,7 @@ class ClaudeWebUI:
                 )
 
                 # Broadcast session creation to all UI clients
-                session_info = await self.coordinator.session_manager.get_session(session_id)
+                session_info = await self.coordinator.session_manager.get_session_info(session_id)
                 if session_info:
                     await self.ui_websocket_manager.broadcast_to_all({
                         "type": "state_change",


### PR DESCRIPTION
## Summary
Resolves #108

Fixes `AttributeError` that occurred when creating a project/legion with a new session/minion. The error was caused by calling a non-existent method `get_session()` instead of the correct `get_session_info()`.

## Changes Made
- **Line 542 of `src/web_server.py`**: Changed `get_session()` to `get_session_info()`

## Root Cause
The `SessionManager` class does not have a `get_session()` method. The correct method name is `get_session_info()`.

## Testing
✅ Created test project and session via API  
✅ Verified no `AttributeError` in server logs  
✅ Confirmed session creation returns 200 OK  
✅ Verified WebSocket broadcast message sent successfully  

**Test Commands:**
```bash
# Create project
curl -X POST http://localhost:8001/api/projects -H "Content-Type: application/json" \
  -d '{"name": "Test Project", "working_directory": "...", "is_multi_agent": false}'

# Create session in project (this previously threw AttributeError)
curl -X POST http://localhost:8001/api/sessions -H "Content-Type: application/json" \
  -d '{"project_id": "<project_id>", "permission_mode": "default", ...}'
```

**Result:** No errors, session created successfully with WebSocket broadcast.

## Impact
- Fixes bug introduced in commit `b268f57` (PR #106)
- Users can now create projects with new sessions without errors
- UI receives proper WebSocket updates when sessions are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)