### PR TITLE
feat: add minion templates backend storage and CRUD API

### DIFF
--- a/src/models/minion_template.py
+++ b/src/models/minion_template.py
@@ -1,0 +1,52 @@
+"""
+Minion Template Data Model
+
+Defines reusable configuration templates for minion creation with
+pre-configured permissions, tools, and default settings.
+"""
+
+from dataclasses import dataclass, asdict
+from datetime import datetime, timezone
+from typing import List, Optional, Dict, Any
+
+
+@dataclass
+class MinionTemplate:
+    """
+    Reusable configuration template for minion creation.
+
+    Stores permission mode, allowed tools, and default settings
+    that can be applied when creating new minions.
+    """
+    template_id: str
+    name: str
+    permission_mode: str  # default, acceptEdits, plan, bypassPermissions
+    allowed_tools: Optional[List[str]] = None
+    default_role: Optional[str] = None
+    default_system_prompt: Optional[str] = None
+    description: Optional[str] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+    def __post_init__(self):
+        """Initialize timestamps and ensure allowed_tools is a list."""
+        if self.created_at is None:
+            self.created_at = datetime.now(timezone.utc)
+        if self.updated_at is None:
+            self.updated_at = datetime.now(timezone.utc)
+        if self.allowed_tools is None:
+            self.allowed_tools = []
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        data = asdict(self)
+        data['created_at'] = self.created_at.isoformat()
+        data['updated_at'] = self.updated_at.isoformat()
+        return data
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> 'MinionTemplate':
+        """Create from dictionary loaded from JSON."""
+        data['created_at'] = datetime.fromisoformat(data['created_at'])
+        data['updated_at'] = datetime.fromisoformat(data['updated_at'])
+        return cls(**data)

--- a/src/template_manager.py
+++ b/src/template_manager.py
@@ -1,0 +1,228 @@
+"""
+Template Manager for Claude Code WebUI
+
+Manages minion templates storage and retrieval with full CRUD operations.
+"""
+
+import uuid
+import json
+import logging
+from pathlib import Path
+from datetime import datetime, timezone
+from typing import List, Optional, Dict
+
+from .models.minion_template import MinionTemplate
+from .logging_config import get_logger
+
+# Get specialized logger for template operations
+template_logger = get_logger('template_manager', category='TEMPLATE_MANAGER')
+# Keep standard logger for errors
+logger = logging.getLogger(__name__)
+
+
+class TemplateManager:
+    """Manages minion templates storage and retrieval."""
+
+    def __init__(self, data_dir: Path):
+        self.templates_dir = data_dir / "templates"
+        self.templates_dir.mkdir(parents=True, exist_ok=True)
+
+        # In-memory cache
+        self.templates: Dict[str, MinionTemplate] = {}
+        template_logger.debug(f"TemplateManager initialized with data_dir: {data_dir}")
+
+    async def load_templates(self):
+        """Load all templates from disk on startup."""
+        self.templates.clear()
+        loaded_count = 0
+
+        for template_file in self.templates_dir.glob("*.json"):
+            try:
+                with open(template_file, 'r') as f:
+                    data = json.load(f)
+                    template = MinionTemplate.from_dict(data)
+                    self.templates[template.template_id] = template
+                    loaded_count += 1
+                    template_logger.debug(f"Loaded template: {template.name} ({template.template_id})")
+            except Exception as e:
+                logger.error(f"Error loading template {template_file}: {e}")
+
+        template_logger.info(f"Loaded {loaded_count} templates from disk")
+
+    async def create_template(
+        self,
+        name: str,
+        permission_mode: str,
+        allowed_tools: Optional[List[str]] = None,
+        default_role: Optional[str] = None,
+        default_system_prompt: Optional[str] = None,
+        description: Optional[str] = None
+    ) -> MinionTemplate:
+        """Create a new template."""
+        # Validate name is not empty
+        if not name or not name.strip():
+            raise ValueError("Template name cannot be empty")
+
+        # Validate name uniqueness
+        if any(t.name == name for t in self.templates.values()):
+            raise ValueError(f"Template with name '{name}' already exists")
+
+        # Validate permission_mode
+        valid_modes = ["default", "acceptEdits", "plan", "bypassPermissions"]
+        if permission_mode not in valid_modes:
+            raise ValueError(f"Invalid permission_mode. Must be one of: {', '.join(valid_modes)}")
+
+        # Create template
+        template = MinionTemplate(
+            template_id=str(uuid.uuid4()),
+            name=name.strip(),
+            permission_mode=permission_mode,
+            allowed_tools=allowed_tools if allowed_tools is not None else [],
+            default_role=default_role,
+            default_system_prompt=default_system_prompt,
+            description=description
+        )
+
+        # Save to disk
+        await self._save_template(template)
+
+        # Cache in memory
+        self.templates[template.template_id] = template
+
+        template_logger.info(f"Created template: {template.name} ({template.template_id})")
+        return template
+
+    async def get_template(self, template_id: str) -> Optional[MinionTemplate]:
+        """Get template by ID."""
+        return self.templates.get(template_id)
+
+    async def get_template_by_name(self, name: str) -> Optional[MinionTemplate]:
+        """Get template by name."""
+        for template in self.templates.values():
+            if template.name == name:
+                return template
+        return None
+
+    async def list_templates(self) -> List[MinionTemplate]:
+        """List all templates."""
+        return list(self.templates.values())
+
+    async def update_template(
+        self,
+        template_id: str,
+        name: Optional[str] = None,
+        permission_mode: Optional[str] = None,
+        allowed_tools: Optional[List[str]] = None,
+        default_role: Optional[str] = None,
+        default_system_prompt: Optional[str] = None,
+        description: Optional[str] = None
+    ) -> MinionTemplate:
+        """Update existing template."""
+        template = self.templates.get(template_id)
+        if not template:
+            raise ValueError(f"Template {template_id} not found")
+
+        # Check name uniqueness if changing name
+        if name and name.strip() != template.name:
+            if any(t.name == name.strip() for t in self.templates.values()):
+                raise ValueError(f"Template with name '{name}' already exists")
+            template.name = name.strip()
+
+        # Update fields if provided
+        if permission_mode:
+            valid_modes = ["default", "acceptEdits", "plan", "bypassPermissions"]
+            if permission_mode not in valid_modes:
+                raise ValueError(f"Invalid permission_mode")
+            template.permission_mode = permission_mode
+
+        if allowed_tools is not None:
+            template.allowed_tools = allowed_tools
+
+        if default_role is not None:
+            template.default_role = default_role
+
+        if default_system_prompt is not None:
+            template.default_system_prompt = default_system_prompt
+
+        if description is not None:
+            template.description = description
+
+        # Update timestamp
+        template.updated_at = datetime.now(timezone.utc)
+
+        # Save to disk
+        await self._save_template(template)
+
+        template_logger.info(f"Updated template: {template.name} ({template.template_id})")
+        return template
+
+    async def delete_template(self, template_id: str) -> bool:
+        """Delete template."""
+        if template_id not in self.templates:
+            return False
+
+        template = self.templates[template_id]
+
+        # Delete from disk
+        template_file = self.templates_dir / f"{template_id}.json"
+        if template_file.exists():
+            template_file.unlink()
+
+        # Remove from cache
+        del self.templates[template_id]
+
+        template_logger.info(f"Deleted template: {template.name} ({template_id})")
+        return True
+
+    async def _save_template(self, template: MinionTemplate):
+        """Save template to disk."""
+        template_file = self.templates_dir / f"{template.template_id}.json"
+        with open(template_file, 'w') as f:
+            json.dump(template.to_dict(), f, indent=2)
+        template_logger.debug(f"Saved template to disk: {template_file}")
+
+    async def create_default_templates(self):
+        """Create default example templates on first run."""
+        # Check if any templates exist
+        if self.templates:
+            template_logger.debug("Templates already exist, skipping default template creation")
+            return
+
+        template_logger.info("Creating default templates")
+
+        # Create default templates
+        defaults = [
+            {
+                "name": "Code Expert",
+                "permission_mode": "acceptEdits",
+                "allowed_tools": ["bash", "edit", "read", "write", "glob", "grep"],
+                "default_role": "Code review and refactoring specialist",
+                "description": "Can freely edit code and run tests"
+            },
+            {
+                "name": "Web Researcher",
+                "permission_mode": "default",
+                "allowed_tools": ["webfetch", "websearch", "read"],
+                "default_role": "Documentation and research specialist",
+                "description": "Can search web and read docs, requires permission for edits"
+            },
+            {
+                "name": "Project Manager",
+                "permission_mode": "acceptEdits",
+                "allowed_tools": ["bash", "edit", "read", "send_comm", "spawn_minion", "create_channel"],
+                "default_role": "Overseer for delegation and coordination",
+                "description": "Can manage project structure and delegate tasks"
+            },
+            {
+                "name": "Safe Sandbox",
+                "permission_mode": "default",
+                "allowed_tools": ["read"],
+                "default_role": "Read-only analyst",
+                "description": "Highly restricted for safe experimentation"
+            }
+        ]
+
+        for default in defaults:
+            await self.create_template(**default)
+
+        template_logger.info(f"Created {len(defaults)} default templates")


### PR DESCRIPTION
## Summary
Resolves #146

Enable users to create and manage reusable minion configuration templates with pre-configured permissions, tools, and default settings to streamline minion creation workflows.

## Changes Made

### Backend Implementation

**New Files:**
- `src/models/minion_template.py` - MinionTemplate data model
  - Stores template_id, name, permission_mode, allowed_tools
  - Optional default_role, default_system_prompt, description
  - Timestamps with automatic initialization
  - JSON serialization methods

- `src/template_manager.py` - TemplateManager class
  - Full CRUD operations (create, read, update, delete, list)
  - Persistent storage in `data/templates/` directory
  - In-memory caching for performance
  - Validation (unique names, valid permission modes)
  - Automatic default template creation

**Modified Files:**
- `src/web_server.py`
  - 5 new REST API endpoints for template management
  - Pydantic request models (TemplateCreateRequest, TemplateUpdateRequest)
  - TemplateManager initialization in ClaudeWebUI.__init__
  - Template loading in initialize() method

### REST API Endpoints

- `GET /api/templates` - List all templates
- `GET /api/templates/{id}` - Get specific template
- `POST /api/templates` - Create new template
- `PUT /api/templates/{id}` - Update existing template
- `DELETE /api/templates/{id}` - Delete template

### Default Templates

Four templates created on first run:
1. **Code Expert** - acceptEdits mode with code editing tools
2. **Web Researcher** - default mode with web search tools
3. **Project Manager** - acceptEdits mode with delegation tools
4. **Safe Sandbox** - default mode, read-only access

### Validation

- Template names must be unique
- Permission modes: `default`, `acceptEdits`, `plan`, `bypassPermissions`
- Empty names rejected
- Invalid permission modes rejected with clear error messages

## Testing

All CRUD operations tested and verified:
- ✅ List all templates (GET /api/templates)
- ✅ Get specific template (GET /api/templates/{id})
- ✅ Create template (POST /api/templates)
- ✅ Update template (PUT /api/templates/{id})
- ✅ Delete template (DELETE /api/templates/{id})
- ✅ Validation: duplicate name detection
- ✅ Validation: invalid permission mode rejection
- ✅ Default template creation
- ✅ Persistence across server restarts

## Related Issues

This is Part 1 of 4-part Templates feature:
- Provides foundation for UI integration (future issue)
- Enables MCP tool access (future issue)
- Supports spawn_minion with templates (future issue)
- Builds on #145 (minion permission management)

🤖 Generated with Claude Code (https://claude.com/claude-code)