### PR TITLE
fix: WebSocket timeout too aggressive, causes false disconnects

### DIFF
--- a/frontend/src/stores/websocket.js
+++ b/frontend/src/stores/websocket.js
@@ -40,7 +40,7 @@ export const useWebSocketStore = defineStore('websocket', () => {
   const currentLegionId = ref(null)
 
   // Heartbeat monitoring configuration
-  const PING_TIMEOUT_MS = 5000  // 5 seconds without ping = disconnected
+  const PING_TIMEOUT_MS = 10000  // 10 seconds without ping = disconnected (allows 3+ ping attempts)
   const HEARTBEAT_CHECK_INTERVAL_MS = 1000  // Check every second
 
   // Heartbeat last received timestamps

--- a/main.py
+++ b/main.py
@@ -26,14 +26,15 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Debug Flags:
-  --debug-websocket      Enable WebSocket lifecycle debugging
-  --debug-sdk            Enable SDK integration debugging
-  --debug-permissions    Enable permission callback debugging
-  --debug-storage        Enable data storage debugging
-  --debug-parser         Enable message parser debugging
-  --debug-error-handler  Enable error handler debugging
-  --debug-legion         Enable Legion multi-agent system debugging
-  --debug-all            Enable all debug logging
+  --debug-websocket         Enable WebSocket lifecycle debugging
+  --debug-websocket-verbose Enable verbose WebSocket ping/pong logging
+  --debug-sdk               Enable SDK integration debugging
+  --debug-permissions       Enable permission callback debugging
+  --debug-storage           Enable data storage debugging
+  --debug-parser            Enable message parser debugging
+  --debug-error-handler     Enable error handler debugging
+  --debug-legion            Enable Legion multi-agent system debugging
+  --debug-all               Enable all debug logging
         """
     )
 
@@ -44,6 +45,7 @@ Debug Flags:
 
     # Debug flags
     parser.add_argument('--debug-websocket', action='store_true', help='Enable WebSocket lifecycle debugging')
+    parser.add_argument('--debug-websocket-verbose', action='store_true', help='Enable verbose WebSocket ping/pong logging')
     parser.add_argument('--debug-sdk', action='store_true', help='Enable SDK integration debugging')
     parser.add_argument('--debug-permissions', action='store_true', help='Enable permission callback debugging')
     parser.add_argument('--debug-storage', action='store_true', help='Enable data storage debugging')
@@ -66,6 +68,7 @@ Debug Flags:
     # Configure logging with debug flags
     configure_logging(
         debug_websocket=args.debug_websocket,
+        debug_websocket_verbose=args.debug_websocket_verbose,
         debug_sdk=args.debug_sdk,
         debug_permissions=args.debug_permissions,
         debug_storage=args.debug_storage,

--- a/src/logging_config.py
+++ b/src/logging_config.py
@@ -55,6 +55,7 @@ _log_config = {}
 
 def configure_logging(
     debug_websocket: bool = False,
+    debug_websocket_verbose: bool = False,
     debug_sdk: bool = False,
     debug_permissions: bool = False,
     debug_storage: bool = False,
@@ -68,6 +69,7 @@ def configure_logging(
 
     Args:
         debug_websocket: Enable WebSocket lifecycle debugging
+        debug_websocket_verbose: Enable verbose WebSocket ping/pong logging
         debug_sdk: Enable SDK integration debugging
         debug_permissions: Enable permission callback debugging
         debug_storage: Enable data storage debugging
@@ -85,6 +87,7 @@ def configure_logging(
     # Store configuration for get_logger to reference
     _log_config = {
         'debug_websocket': debug_websocket or debug_all,
+        'debug_websocket_verbose': debug_websocket_verbose,  # Only enabled with explicit --debug-websocket-verbose
         'debug_sdk': debug_sdk or debug_all,
         'debug_permissions': debug_permissions or debug_all,
         'debug_storage': debug_storage or debug_all,
@@ -119,6 +122,12 @@ def configure_logging(
             'file': f"{log_dir}/websocket_debug.log",
             'enabled': _log_config['debug_websocket'],
             'console': _log_config['debug_websocket'],
+            'level': logging.DEBUG
+        },
+        'websocket_verbose': {
+            'file': f"{log_dir}/websocket_verbose.log",
+            'enabled': _log_config['debug_websocket_verbose'],
+            'console': _log_config['debug_websocket_verbose'],
             'level': logging.DEBUG
         },
         'sdk_debug': {

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -31,6 +31,8 @@ from .timestamp_utils import normalize_timestamp
 
 # Get specialized logger for WebSocket lifecycle debugging
 ws_logger = get_logger('websocket_debug', category='WS_LIFECYCLE')
+# Get verbose logger for ping/pong (use only with --debug-websocket-verbose)
+ws_verbose_logger = get_logger('websocket_verbose', category='WS_PING_PONG')
 # Keep standard logger for errors
 logger = logging.getLogger(__name__)
 
@@ -1782,14 +1784,14 @@ class ClaudeWebUI:
                     except asyncio.TimeoutError:
                         # Send ping to keep connection alive
                         timeout_time = time.time()
-                        ws_logger.debug(f"WebSocket timeout for session {session_id} at {timeout_time} - sending ping")
+                        ws_verbose_logger.debug(f"WebSocket timeout for session {session_id} at {timeout_time} - sending ping")
 
                         try:
                             ping_start_time = time.time()
                             await websocket.send_text(json.dumps({"type": "ping", "timestamp": datetime.now(timezone.utc).isoformat()}))
 
                             ping_sent_time = time.time()
-                            ws_logger.debug(f"Ping sent successfully at {ping_sent_time}")
+                            ws_verbose_logger.debug(f"Ping sent successfully at {ping_sent_time}")
 
                         except Exception as ping_error:
                             # Connection is dead, break the loop


### PR DESCRIPTION
Fixes #171

## Summary

This PR addresses two related issues with aggressive WebSocket behavior:

1. **Frontend timeout too short** - False disconnect warnings during normal network latency
2. **Backend logging too noisy** - Ping/pong messages flooding debug logs

## Changes

### 1. Frontend: Increased WebSocket Timeout (5s → 10s)

**File**: `frontend/src/stores/websocket.js:43`

**Before**:
```javascript
const PING_TIMEOUT_MS = 5000  // 5 seconds without ping = disconnected
```

**After**:
```javascript
const PING_TIMEOUT_MS = 10000  // 10 seconds without ping = disconnected (allows 3+ ping attempts)
```

**Impact**:
- Allows 3+ ping/pong attempts before declaring connection dead (was 1.67)
- Reduces false disconnect warnings during normal network latency (2-4 second spikes)
- True disconnects still detected within 10 seconds

### 2. Backend: Added `--debug-websocket-verbose` Flag

**Files**: `main.py`, `src/logging_config.py`, `src/web_server.py`

**New Logging Behavior**:
- `--debug-websocket`: Shows lifecycle events (connect, disconnect, errors) **WITHOUT** ping/pong noise
- `--debug-websocket-verbose`: Adds ping/pong logging (20+ messages/min per connection)
- `--debug-all`: Includes websocket lifecycle but **NOT** verbose pings (explicit opt-in required)

**Implementation**:
- Created separate `websocket_verbose` logger
- Moved ping/pong debug logs from `ws_logger` to `ws_verbose_logger`
- Verbose flag excluded from `--debug-all` to prevent log spam

## Benefits

**User Experience**:
- ✅ Fewer false "disconnected" warnings during normal use
- ✅ Stable UI without status flickering
- ✅ Better handling of brief network hiccups

**Developer Experience**:
- ✅ Can debug WebSocket lifecycle without ping/pong spam
- ✅ More granular control over logging verbosity
- ✅ Cleaner logs with `--debug-all`

## Testing

Tested with backend on port 8001:
- ✅ `--debug-websocket`: Shows lifecycle WITHOUT ping/pong messages
- ✅ `--debug-websocket-verbose`: Shows ping/pong messages
- ✅ `--debug-all`: Does NOT include verbose pings (requires explicit flag)
- ✅ Frontend timeout updated to 10 seconds

## Technical Details

**Timeout Math**:
- Server sends pings every 3 seconds
- **Before**: 5s timeout ÷ 3s interval = 1.67 ping attempts
- **After**: 10s timeout ÷ 3s interval = 3.33 ping attempts

**10 seconds chosen because**:
- Industry standard for active connections
- Fast enough to detect real disconnects
- Generous enough to handle normal latency
- Balances responsiveness vs stability