### PR TITLE
chore: remove unused history.json from session data storage

### DIFF
--- a/src/tests/test_data_storage.py
+++ b/src/tests/test_data_storage.py
@@ -63,7 +63,6 @@ class TestDataStorageManager:
         # Check that directories and files were created
         assert manager.session_dir.exists()
         assert manager.messages_file.exists()
-        assert manager.history_file.exists()
         # Integrity file removed - no longer used
 
     @pytest.mark.asyncio
@@ -139,65 +138,6 @@ class TestDataStorageManager:
 
         count = await manager.get_message_count()
         assert count == len(sample_messages)
-
-    @pytest.mark.asyncio
-    async def test_write_and_read_history(self, temp_storage_manager):
-        """Test writing and reading command history."""
-        manager = temp_storage_manager
-
-        history_data = [
-            {
-                "command": "ls -la",
-                "timestamp": "2024-01-01T10:00:00Z"
-            },
-            {
-                "command": "cd /home",
-                "timestamp": "2024-01-01T10:01:00Z"
-            }
-        ]
-
-        await manager.write_history(history_data)
-
-        # Read back history
-        read_history = await manager.read_history()
-        assert len(read_history) == 2
-        assert read_history[0]["command"] == "ls -la"
-        assert read_history[1]["command"] == "cd /home"
-
-    @pytest.mark.asyncio
-    async def test_append_history_item(self, temp_storage_manager):
-        """Test appending individual history items."""
-        manager = temp_storage_manager
-
-        history_item = {
-            "command": "git status",
-            "result": "On branch main"
-        }
-
-        await manager.append_history_item(history_item)
-
-        history = await manager.read_history()
-        assert len(history) == 1
-        assert history[0]["command"] == "git status"
-        assert "timestamp" in history[0]
-
-    @pytest.mark.asyncio
-    async def test_append_history_item_with_limit(self, temp_storage_manager):
-        """Test that history items are limited to prevent unbounded growth."""
-        manager = temp_storage_manager
-
-        # Add more than 1000 items (the limit)
-        for i in range(1005):
-            await manager.append_history_item({
-                "command": f"command_{i}",
-                "index": i
-            })
-
-        history = await manager.read_history()
-        # Should be limited to last 1000 items
-        assert len(history) == 1000
-        assert history[0]["index"] == 5  # First item should be index 5 (items 0-4 removed)
-        assert history[-1]["index"] == 1004  # Last item should be index 1004
 
     # Integrity verification tests removed - feature no longer used
 
@@ -339,9 +279,6 @@ class TestDataStorageManager:
 
         count = await manager.get_message_count()
         assert count == 0
-
-        history = await manager.read_history()
-        assert len(history) == 0
 
     @pytest.mark.asyncio
     async def test_message_timestamp_auto_generation(self, temp_storage_manager):


### PR DESCRIPTION
## Summary
- Removes unused `history.json` file and related code from DataStorageManager
- Command tracking is handled through `messages.jsonl` instead
- Adds migration to delete legacy history.json files on session startup

## Changes
- ✅ Removed history_file initialization from DataStorageManager.__init__
- ✅ Removed write_history, read_history, append_history_item methods (lines 137-181)
- ✅ Removed history.json checks from detect_corruption() and cleanup()
- ✅ Added migration to delete legacy history.json files during initialize()
- ✅ Removed all history-related tests from test_data_storage.py
- ✅ 13/15 data storage tests passing (2 pre-existing failures unrelated to changes)

## Files Modified
- `src/data_storage.py`: -117 lines (removed methods, added migration)
- `src/tests/test_data_storage.py`: -59 lines (removed tests)

## Test Results
```
13 passed, 2 failed
- Failed tests are pre-existing (corruption detection disabled, timestamp format issue)
- All message storage tests passing
- Session operations work correctly without history.json
```

Closes #176