### PR TITLE
feat: add interrupt priority to send_comm MCP tool

### DIFF
--- a/src/legion/overseer_controller.py
+++ b/src/legion/overseer_controller.py
@@ -10,9 +10,8 @@ Responsibilities:
 """
 
 import uuid
-from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Optional
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 from src.models.legion_models import Horde
 
@@ -33,7 +32,7 @@ class OverseerController:
         self.system = system
 
         # Track hordes by horde_id
-        self.hordes: Dict[str, Horde] = {}
+        self.hordes: dict[str, Horde] = {}
 
     async def create_minion_for_user(
         self,
@@ -42,9 +41,9 @@ class OverseerController:
         role: str = "",
         system_prompt: str = "",
         override_system_prompt: bool = False,
-        capabilities: Optional[List[str]] = None,
+        capabilities: list[str] | None = None,
         permission_mode: str = "default",
-        allowed_tools: Optional[List[str]] = None
+        allowed_tools: list[str] | None = None
     ) -> str:
         """
         Create a minion for the user (root overseer).
@@ -192,10 +191,10 @@ class OverseerController:
         name: str,
         role: str,
         system_prompt: str,
-        capabilities: Optional[List[str]] = None,
-        channels: Optional[List[str]] = None,
-        permission_mode: Optional[str] = None,
-        allowed_tools: Optional[List[str]] = None
+        capabilities: list[str] | None = None,
+        channels: list[str] | None = None,
+        permission_mode: str | None = None,
+        allowed_tools: list[str] | None = None
     ) -> str:
         """
         Spawn a child minion autonomously by a parent overseer.
@@ -335,7 +334,7 @@ class OverseerController:
             summary=f"Spawned {name}",
             content=f"**{parent_session.name}** spawned minion **{name}** ({role})",
             comm_type=CommType.SPAWN,
-            interrupt_priority=InterruptPriority.ROUTINE,
+            interrupt_priority=InterruptPriority.NONE,
             visible_to_user=True
         )
         await self.system.comm_router.route_comm(spawn_comm)
@@ -361,7 +360,7 @@ class OverseerController:
         self,
         parent_overseer_id: str,
         child_minion_name: str
-    ) -> Dict[str, any]:
+    ) -> dict[str, any]:
         """
         Dispose of a child minion (terminate with cleanup).
 
@@ -470,7 +469,7 @@ class OverseerController:
                 f" (and {descendants_disposed} descendants)" if descendants_disposed > 0 else ""
             ),
             comm_type=CommType.DISPOSE,
-            interrupt_priority=InterruptPriority.ROUTINE,
+            interrupt_priority=InterruptPriority.NONE,
             visible_to_user=True
         )
         await self.system.comm_router.route_comm(dispose_comm)


### PR DESCRIPTION
## Summary
Resolves #185

Enables minions to interrupt each other when sending urgent messages by adding an optional `interrupt_priority` parameter to the `send_comm` and `send_comm_to_channel` MCP tools.

## Changes Made

### Core Implementation
- **Updated InterruptPriority enum**: Renamed `ROUTINE` → `NONE`, added `HALT` for clarity
- **Added interrupt_priority parameter** to both `send_comm` and `send_comm_to_channel` tools
- **Implemented interrupt logic** in `CommRouter._send_to_minion()` to call `interrupt_session()` for HALT/PIVOT priorities
- **Updated tool descriptions** with comprehensive usage guidance

### Behavior by Priority
- **NONE (default)**: Queue message normally (existing behavior)
- **HALT**: Interrupt target minion immediately, deliver message, minion can resume
- **PIVOT**: Interrupt target minion, deliver message with explicit "cease prior work" instructions (message content must include redirect instructions)

### Implementation Notes
- **Backward compatible**: Omitting parameter defaults to NONE
- **No queue clearing for PIVOT**: SDK handles message queuing; PIVOT message will be delivered last and should invalidate previous work
- **Graceful degradation**: Message queues normally if interrupt fails
- **Updated all ROUTINE references** to NONE across codebase (8 occurrences)

## Files Modified
- `src/models/legion_models.py` - Updated InterruptPriority enum, Comm default
- `src/legion/mcp/legion_mcp_tools.py` - Added parameter, validation, tool descriptions
- `src/legion/comm_router.py` - Implemented interrupt logic
- `src/legion/overseer_controller.py` - Updated ROUTINE → NONE
- `src/web_server.py` - Updated ROUTINE → NONE

## Testing

### Manual Testing Approach
1. Create test legion with 2 minions (parent + child)
2. Test NONE priority (default): Message queues normally
3. Test HALT priority: Worker interrupted, processes message, resumes
4. Test PIVOT priority: Worker interrupted, follows redirect (message contains "cease prior work" instructions)
5. Test send_comm_to_channel with priorities
6. Test error cases: invalid priority value, target not found

### Validation
- ✅ Valid priorities accepted: "none", "halt", "pivot"
- ✅ Invalid priorities rejected with clear error message
- ✅ Backward compatible: existing calls without parameter work
- ✅ Priority stored and visible in timeline/history
- ✅ Interrupt logic only triggers for HALT/PIVOT

## Use Cases Addressed
1. **Database connection failure (HALT)**: Stop temporarily, be aware of issues, continue working
2. **Requirements changed (PIVOT)**: Stop current work permanently, redirect to new task (message includes explicit redirect instructions)
3. **Task unblocked (NONE)**: Normal queue, minion processes when ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)