### PR TITLE
feat: add emergency halt/resume controls with comm queuing

### DIFF
--- a/frontend/src/components/header/HordeHeader.vue
+++ b/frontend/src/components/header/HordeHeader.vue
@@ -1,8 +1,30 @@
 <template>
   <div class="horde-header border-bottom p-3">
-    <div>
-      <div class="project-name">{{ legionName }}</div>
-      <div class="view-name">Minion Hierarchy</div>
+    <div class="d-flex justify-content-between align-items-center">
+      <div>
+        <div class="project-name">{{ legionName }}</div>
+        <div class="view-name">Minion Hierarchy</div>
+      </div>
+      <div class="fleet-controls d-flex gap-2">
+        <button
+          class="btn btn-sm btn-outline-warning"
+          :disabled="isHaltAllDisabled || isOperating"
+          @click="handleHaltAll"
+          title="Emergency halt all active minions"
+        >
+          <span v-if="isOperating && lastOperation === 'halt'" class="spinner-border spinner-border-sm me-1"></span>
+          Halt All
+        </button>
+        <button
+          class="btn btn-sm btn-outline-success"
+          :disabled="isResumeAllDisabled || isOperating"
+          @click="handleResumeAll"
+          title="Resume all minions"
+        >
+          <span v-if="isOperating && lastOperation === 'resume'" class="spinner-border spinner-border-sm me-1"></span>
+          Resume All
+        </button>
+      </div>
     </div>
   </div>
 </template>
@@ -10,6 +32,8 @@
 <script setup>
 import { computed } from 'vue'
 import { useProjectStore } from '@/stores/project'
+import { useSessionStore } from '@/stores/session'
+import { useUIStore } from '@/stores/ui'
 
 const props = defineProps({
   legionId: {
@@ -19,9 +43,49 @@ const props = defineProps({
 })
 
 const projectStore = useProjectStore()
+const sessionStore = useSessionStore()
+const uiStore = useUIStore()
 
 const legion = computed(() => projectStore.projects.get(props.legionId))
 const legionName = computed(() => legion.value?.name || 'Legion')
+
+// Get all minions for this legion
+const legionMinions = computed(() => {
+  const sessions = Array.from(sessionStore.sessions.values())
+  return sessions.filter(s => s.is_minion && s.project_id === props.legionId)
+})
+
+// Count active minions
+const activeMinions = computed(() => {
+  return legionMinions.value.filter(m => m.state === 'active')
+})
+
+// Button disabled logic
+const isHaltAllDisabled = computed(() => {
+  return legionMinions.value.length === 0 || activeMinions.value.length === 0
+})
+
+const isResumeAllDisabled = computed(() => {
+  return legionMinions.value.length === 0
+})
+
+function handleHaltAll() {
+  uiStore.showModal('fleet-control', {
+    legionId: props.legionId,
+    operation: 'halt',
+    activeMinionsCount: activeMinions.value.length,
+    totalMinionsCount: legionMinions.value.length
+  })
+}
+
+function handleResumeAll() {
+  uiStore.showModal('fleet-control', {
+    legionId: props.legionId,
+    operation: 'resume',
+    activeMinionsCount: activeMinions.value.length,
+    totalMinionsCount: legionMinions.value.length
+  })
+}
 </script>
 
 <style scoped>

--- a/frontend/src/components/legion/FleetControlModal.vue
+++ b/frontend/src/components/legion/FleetControlModal.vue
@@ -1,0 +1,252 @@
+<template>
+  <div
+    class="modal fade"
+    id="fleetControlModal"
+    tabindex="-1"
+    aria-labelledby="fleetControlModalLabel"
+    aria-hidden="true"
+    ref="modalElement"
+  >
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="fleetControlModalLabel">
+            {{ modalTitle }}
+          </h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <!-- Loading State -->
+          <div v-if="isOperating" class="text-center py-4">
+            <div class="spinner-border text-primary mb-3" role="status">
+              <span class="visually-hidden">Processing...</span>
+            </div>
+            <p class="text-muted">{{ loadingMessage }}</p>
+          </div>
+
+          <!-- Result View (Success/Error) -->
+          <div v-else-if="resultView">
+            <div
+              class="alert mb-3"
+              :class="resultView.type === 'success' ? 'alert-success' : 'alert-danger'"
+            >
+              <strong>{{ resultView.title }}</strong>
+            </div>
+            <p class="text-muted">{{ resultView.message }}</p>
+          </div>
+
+          <!-- Halt Confirmation -->
+          <div v-else-if="confirmationView === 'halt'">
+            <div class="alert alert-warning mb-3">
+              <strong>⚠️ Emergency Halt</strong>
+            </div>
+            <p class="text-muted">
+              Are you sure you want to halt all <strong>{{ activeMinionsCount }}</strong> active minion(s) in this legion?
+            </p>
+            <p class="text-muted">
+              This will interrupt their current processing. Minions will remain in ACTIVE state but will stop processing.
+            </p>
+          </div>
+
+          <!-- Resume Confirmation -->
+          <div v-else-if="confirmationView === 'resume'">
+            <div class="alert alert-info mb-3">
+              <strong>Resume All Minions</strong>
+            </div>
+            <p class="text-muted">
+              This will send "continue" to all <strong>{{ totalMinionsCount }}</strong> minion(s) in this legion.
+            </p>
+            <p class="text-muted">
+              Minions will resume processing from where they were interrupted.
+            </p>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <!-- Result View Buttons -->
+          <template v-if="resultView">
+            <button type="button" class="btn btn-primary" data-bs-dismiss="modal">OK</button>
+          </template>
+
+          <!-- Confirmation View Buttons -->
+          <template v-else-if="confirmationView && !isOperating">
+            <button type="button" class="btn btn-secondary" @click="cancelConfirmation">Cancel</button>
+            <button
+              type="button"
+              class="btn"
+              :class="confirmationView === 'halt' ? 'btn-warning' : 'btn-success'"
+              @click="executeConfirmation"
+            >
+              {{ confirmationView === 'halt' ? 'Halt All' : 'Resume All' }}
+            </button>
+          </template>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
+import { useUIStore } from '@/stores/ui'
+import { useLegionStore } from '@/stores/legion'
+import { Modal } from 'bootstrap'
+
+const uiStore = useUIStore()
+const legionStore = useLegionStore()
+
+// State
+const isOperating = ref(false)
+const loadingMessage = ref('')
+const confirmationView = ref(null) // 'halt', 'resume', or null
+const resultView = ref(null) // { type: 'success'|'error', title: string, message: string }
+const modalElement = ref(null)
+let modalInstance = null
+
+// Data passed from parent
+const legionId = ref(null)
+const activeMinionsCount = ref(0)
+const totalMinionsCount = ref(0)
+
+// Computed
+const modalTitle = computed(() => {
+  if (resultView.value) {
+    return resultView.value.type === 'success' ? 'Success' : 'Error'
+  }
+  if (confirmationView.value === 'halt') return 'Emergency Halt All Minions'
+  if (confirmationView.value === 'resume') return 'Resume All Minions'
+  return 'Fleet Control'
+})
+
+// Initialize Bootstrap modal
+onMounted(() => {
+  if (modalElement.value) {
+    modalInstance = new Modal(modalElement.value)
+
+    // Reset state when modal is hidden
+    modalElement.value.addEventListener('hidden.bs.modal', () => {
+      confirmationView.value = null
+      resultView.value = null
+      isOperating.value = false
+    })
+  }
+})
+
+onUnmounted(() => {
+  if (modalInstance) {
+    modalInstance.dispose()
+  }
+})
+
+// Watch for modal triggers from UI store
+watch(
+  () => uiStore.currentModal,
+  (newModal) => {
+    if (!newModal || newModal.name !== 'fleet-control') return
+
+    const data = newModal.data
+    if (!data) return
+
+    // Set up modal data
+    legionId.value = data.legionId
+    activeMinionsCount.value = data.activeMinionsCount || 0
+    totalMinionsCount.value = data.totalMinionsCount || 0
+    confirmationView.value = data.operation // 'halt' or 'resume'
+    resultView.value = null
+
+    // Show modal
+    if (modalInstance) {
+      modalInstance.show()
+    }
+  }
+)
+
+// Cancel confirmation and close modal
+function cancelConfirmation() {
+  confirmationView.value = null
+  if (modalInstance) {
+    modalInstance.hide()
+  }
+}
+
+// Execute the pending confirmation action
+async function executeConfirmation() {
+  if (confirmationView.value === 'halt') {
+    await executeHaltAll()
+  } else if (confirmationView.value === 'resume') {
+    await executeResumeAll()
+  }
+}
+
+// Execute halt all operation
+async function executeHaltAll() {
+  isOperating.value = true
+  loadingMessage.value = 'Halting all minions...'
+
+  try {
+    const result = await legionStore.haltAll(legionId.value)
+
+    // Show success result
+    const failureMsg = result.failed_minions && result.failed_minions.length > 0
+      ? ` Failed to halt ${result.failed_minions.length} minion(s).`
+      : ''
+
+    resultView.value = {
+      type: 'success',
+      title: 'Halt Complete',
+      message: `Halted ${result.halted_count} of ${result.total_minions} minion(s).${failureMsg}`
+    }
+  } catch (error) {
+    console.error('Failed to halt all minions:', error)
+    resultView.value = {
+      type: 'error',
+      title: 'Halt Failed',
+      message: `Failed to halt minions: ${error.message || 'Unknown error'}`
+    }
+  } finally {
+    isOperating.value = false
+    confirmationView.value = null
+  }
+}
+
+// Execute resume all operation
+async function executeResumeAll() {
+  isOperating.value = true
+  loadingMessage.value = 'Resuming all minions...'
+
+  try {
+    const result = await legionStore.resumeAll(legionId.value)
+
+    // Show success result
+    const failureMsg = result.failed_minions && result.failed_minions.length > 0
+      ? ` Failed to resume ${result.failed_minions.length} minion(s).`
+      : ''
+
+    resultView.value = {
+      type: 'success',
+      title: 'Resume Complete',
+      message: `Resumed ${result.resumed_count} of ${result.total_minions} minion(s).${failureMsg}`
+    }
+  } catch (error) {
+    console.error('Failed to resume all minions:', error)
+    resultView.value = {
+      type: 'error',
+      title: 'Resume Failed',
+      message: `Failed to resume minions: ${error.message || 'Unknown error'}`
+    }
+  } finally {
+    isOperating.value = false
+    confirmationView.value = null
+  }
+}
+</script>
+
+<style scoped>
+/* Modal styles match SessionManageModal */
+.modal-body {
+  min-height: 150px;
+}
+
+.alert {
+  margin-bottom: 1rem;
+}
+</style>

--- a/frontend/src/components/legion/HordeView.vue
+++ b/frontend/src/components/legion/HordeView.vue
@@ -73,6 +73,9 @@
 
     <!-- Status Bar (at bottom) -->
     <HordeStatusBar :legion-id="legionId" />
+
+    <!-- Fleet Control Modal -->
+    <FleetControlModal />
   </div>
 </template>
 
@@ -85,6 +88,7 @@ import { useLegionStore } from '../../stores/legion'
 import HordeHeader from '../header/HordeHeader.vue'
 import HordeStatusBar from '../statusbar/HordeStatusBar.vue'
 import MinionTreeNode from './MinionTreeNode.vue'
+import FleetControlModal from './FleetControlModal.vue'
 import { api } from '../../utils/api'
 
 const props = defineProps({

--- a/frontend/src/stores/legion.js
+++ b/frontend/src/stores/legion.js
@@ -371,6 +371,46 @@ export const useLegionStore = defineStore('legion', () => {
   }
 
   /**
+   * Emergency halt all minions in legion
+   */
+  async function haltAll(legionId) {
+    try {
+      const data = await api.post(`/api/legions/${legionId}/halt-all`)
+
+      console.log(`Halted ${data.halted_count} of ${data.total_minions} minions in legion ${legionId}`)
+
+      if (data.failed_minions && data.failed_minions.length > 0) {
+        console.warn('Failed to halt some minions:', data.failed_minions)
+      }
+
+      return data
+    } catch (error) {
+      console.error('Failed to halt all minions:', error)
+      throw error
+    }
+  }
+
+  /**
+   * Resume all minions in legion
+   */
+  async function resumeAll(legionId) {
+    try {
+      const data = await api.post(`/api/legions/${legionId}/resume-all`)
+
+      console.log(`Resumed ${data.resumed_count} of ${data.total_minions} minions in legion ${legionId}`)
+
+      if (data.failed_minions && data.failed_minions.length > 0) {
+        console.warn('Failed to resume some minions:', data.failed_minions)
+      }
+
+      return data
+    } catch (error) {
+      console.error('Failed to resume all minions:', error)
+      throw error
+    }
+  }
+
+  /**
    * Clear all legion data
    */
   function clearLegionData(legionId) {
@@ -418,6 +458,8 @@ export const useLegionStore = defineStore('legion', () => {
     loadChannelComms,
     addMemberToChannel,
     removeMemberFromChannel,
+    haltAll,
+    resumeAll,
     clearLegionData
   }
 })

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -1039,6 +1039,62 @@ class ClaudeWebUI:
                 logger.error(f"Failed to create minion: {e}")
                 raise HTTPException(status_code=500, detail=str(e))
 
+        # ==================== FLEET CONTROL ENDPOINTS ====================
+
+        @self.app.post("/api/legions/{legion_id}/halt-all")
+        async def emergency_halt_all(legion_id: str):
+            """Emergency halt all minions in the legion"""
+            try:
+                # Validate legion exists
+                project = await self.coordinator.project_manager.get_project(legion_id)
+                if not project:
+                    raise HTTPException(status_code=404, detail="Legion not found")
+                if not project.is_multi_agent:
+                    raise HTTPException(status_code=400, detail="Project is not a legion")
+
+                # Call LegionCoordinator.emergency_halt_all()
+                result = await self.coordinator.legion_system.legion_coordinator.emergency_halt_all(legion_id)
+
+                return {
+                    "success": True,
+                    "halted_count": result["halted_count"],
+                    "failed_minions": result["failed_minions"],
+                    "total_minions": result["total_minions"]
+                }
+
+            except HTTPException:
+                raise
+            except Exception as e:
+                logger.error(f"Failed to halt all minions: {e}")
+                raise HTTPException(status_code=500, detail=str(e))
+
+        @self.app.post("/api/legions/{legion_id}/resume-all")
+        async def resume_all(legion_id: str):
+            """Resume all minions in the legion"""
+            try:
+                # Validate legion exists
+                project = await self.coordinator.project_manager.get_project(legion_id)
+                if not project:
+                    raise HTTPException(status_code=404, detail="Legion not found")
+                if not project.is_multi_agent:
+                    raise HTTPException(status_code=400, detail="Project is not a legion")
+
+                # Call LegionCoordinator.resume_all()
+                result = await self.coordinator.legion_system.legion_coordinator.resume_all(legion_id)
+
+                return {
+                    "success": True,
+                    "resumed_count": result["resumed_count"],
+                    "failed_minions": result["failed_minions"],
+                    "total_minions": result["total_minions"]
+                }
+
+            except HTTPException:
+                raise
+            except Exception as e:
+                logger.error(f"Failed to resume all minions: {e}")
+                raise HTTPException(status_code=500, detail=str(e))
+
         # ==================== CHANNEL ENDPOINTS ====================
 
         @self.app.post("/api/legions/{legion_id}/channels", status_code=201)


### PR DESCRIPTION
## Summary

Implements fleet-wide emergency halt and resume operations for Legion multi-agent system with race condition protection and message queuing.

Closes #184

## Changes

### Backend
- **LegionCoordinator**: Emergency halt/resume with atomic flag, parallel halting, and per-minion FIFO comm queuing
- **CommRouter**: Comm interception during halt, queuing with 10,000 message limit and overflow protection
- **web_server.py**: REST endpoints for `/api/legions/{id}/halt-all` and `/api/legions/{id}/resume-all`

### Frontend
- **FleetControlModal.vue**: Dedicated Vue modal for halt/resume confirmations with loading and result states
- **HordeHeader.vue**: "Halt All" and "Resume All" buttons in Horde view header
- **legion.js**: Pinia store actions for `haltAll()` and `resumeAll()`

## Race Condition Protection

Prevents cascade re-activation when minion B sends comm to minion A during halt sequence:

1. Atomic `emergency_halt_active` flag blocks comm routing IMMEDIATELY
2. Parallel halting with `asyncio.gather()` minimizes race window
3. CommRouter intercepts and queues comms during halt
4. Per-minion FIFO queues preserve message order
5. Immediate flush after "continue" to each minion

## Key Design Decisions

- HALT uses `SessionCoordinator.interrupt_session()` directly (bypasses comm protocol, equivalent to UI stop button)
- RESUME uses `SessionCoordinator.send_message("continue")` directly (bypasses comm protocol)
- Minions stay in ACTIVE state (NOT PAUSED - PAUSED is only for permission requests)
- 10,000 message queue limit per legion with ValueError on overflow
- No message loss (all comms queued and delivered after resume)

## Test Plan

- [x] Create legion with multiple active minions
- [x] Click "Halt All" button - verify confirmation modal appears
- [x] Confirm halt - verify all minions interrupted
- [x] Send comms during halt - verify queued (no immediate delivery)
- [x] Click "Resume All" - verify all minions receive "continue"
- [x] Verify queued comms delivered FIFO per-minion
- [x] Force race conditions - verify no cascade re-activation
- [x] Test queue overflow (10,000+ messages) - verify error thrown