### PR TITLE
fix: hide recipient selector in channel view CommComposer

### DIFF
--- a/frontend/src/components/legion/ChannelView.vue
+++ b/frontend/src/components/legion/ChannelView.vue
@@ -60,6 +60,7 @@
       v-if="channel"
       :legion-id="legionId"
       :default-channel-id="channelId"
+      :hide-recipient-selector="true"
     />
 
     <!-- Channel Status Bar (fixed at bottom) -->

--- a/frontend/src/components/legion/CommComposer.vue
+++ b/frontend/src/components/legion/CommComposer.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="comm-composer border-top p-3">
     <!-- Top Row: Recipient and Comm Type -->
-    <div class="d-flex gap-2 mb-2">
+    <div v-if="!hideRecipientSelector" class="d-flex gap-2 mb-2">
       <!-- Recipient Selection -->
       <div class="flex-grow-1">
         <select v-model="recipient" class="form-select form-select-sm" :disabled="sending">
@@ -105,6 +105,10 @@ const props = defineProps({
   defaultChannelId: {
     type: String,
     default: ''
+  },
+  hideRecipientSelector: {
+    type: Boolean,
+    default: false
   }
 })
 


### PR DESCRIPTION
## Summary
Fixes #191 - Hides the recipient selector dropdown in ChannelView's CommComposer to prevent accidental misrouting.

## Changes
- **CommComposer.vue**: Added `hideRecipientSelector` prop (Boolean, default: false)
- **CommComposer.vue**: Wrapped recipient/comm type selector row with `v-if="!hideRecipientSelector"`
- **ChannelView.vue**: Passed `:hide-recipient-selector="true"` to CommComposer

## Behavior
- **ChannelView**: Recipient selector hidden, messages automatically target current channel (via existing `defaultChannelId` prop)
- **TimelineView**: Recipient selector visible (prop not passed)
- **SpyView**: Not affected (uses SessionView, not CommComposer)

## Test Plan
- [x] Navigate to channel view - verify recipient dropdown is hidden
- [x] Compose and send message in channel view - verify it targets channel correctly
- [x] Navigate to timeline view - verify recipient dropdown is visible
- [x] Navigate to spy view - verify no changes (uses SessionView)
- [x] Send messages in timeline view - verify dropdown works normally

## Visual Changes
**Before**: Channel view showed recipient dropdown with potential for misrouting  
**After**: Channel view hides dropdown, only shows message textarea and send button

Closes #191