### PR TITLE
fix: accept null for allowed_tools and capabilities in session/minion creation

### DIFF
--- a/src/web_server.py
+++ b/src/web_server.py
@@ -97,7 +97,7 @@ class SessionCreateRequest(BaseModel):
     permission_mode: str = "acceptEdits"
     system_prompt: str | None = None
     override_system_prompt: bool = False
-    allowed_tools: list[str] = []
+    allowed_tools: list[str] | None = None
     model: str | None = None
     name: str | None = None
 
@@ -131,9 +131,9 @@ class MinionCreateRequest(BaseModel):
     role: str | None = ""
     initialization_context: str | None = ""
     override_system_prompt: bool = False
-    capabilities: list[str] = []
+    capabilities: list[str] | None = None
     permission_mode: str = "default"
-    allowed_tools: list[str] = []  # Empty list means no pre-authorized tools (prompts for everything)
+    allowed_tools: list[str] | None = None  # None or empty list means no pre-authorized tools
     working_directory: str | None = None  # Optional custom working directory for this minion
 
 


### PR DESCRIPTION
Fixes #207

## Problem
When creating sessions or minions with empty "Allowed Tools" field, frontend sends `null` for `allowed_tools`, causing a 422 Unprocessable Entity error from FastAPI/Pydantic validation.

## Root Cause
Pydantic models `SessionCreateRequest` and `MinionCreateRequest` had `allowed_tools: list[str] = []`, which rejects `null` values even though empty list is the default.

## Solution
Changed type definitions to accept `None`:
- `SessionCreateRequest.allowed_tools`: `list[str] | None = None`
- `MinionCreateRequest.allowed_tools`: `list[str] | None = None`
- `MinionCreateRequest.capabilities`: `list[str] | None = None`

Backend code already handles `None` properly by converting to empty lists at multiple levels (overseer_controller, session_coordinator, claude_sdk).

## Testing
- Verified 422 error with `{"allowed_tools": null}` payload
- Confirmed backend has existing `None` → `[]` conversion logic
- No new linting violations introduced

## Changes
- `src/web_server.py`: Updated Pydantic model type hints for optional list fields