### PR TITLE
fix: correct Skill tool summary to display actual skill name

### DIFF
--- a/frontend/src/components/messages/ToolCallCard.vue
+++ b/frontend/src/components/messages/ToolCallCard.vue
@@ -378,7 +378,7 @@ const toolSummary = computed(() => {
     }
 
     case 'Skill': {
-      const skillName = input.command || 'Unknown'
+      const skillName = input.skill || 'Unknown'
       if (status === 'completed' && result) {
         return result.error ? `Skill: ${skillName} (error)` : `Skill: ${skillName} (completed)`
       }


### PR DESCRIPTION
## Summary
Fixed bug where Skill tool summary was displaying "Unknown" instead of the actual skill name.

## Root Cause
Line 381 in `ToolCallCard.vue` was accessing `input.command` instead of `input.skill`, causing the fallback "Unknown" value to always be used.

## Changes
- Changed `input.command` to `input.skill` in Skill tool summary generator (line 381)

## Testing
- Verified frontend compiles without errors
- Change is minimal and directly addresses the property access issue

Fixes #216