### PR TITLE
fix: sort tool footer tools chronologically by timestamp (#223)

### DIFF
--- a/frontend/src/components/messages/ToolFooter.vue
+++ b/frontend/src/components/messages/ToolFooter.vue
@@ -66,23 +66,49 @@ const isExpanded = ref(false)
 // ========== COMPUTED PROPERTIES ==========
 
 /**
+ * Sort tools by timestamp (chronological order)
+ * Primary: timestamp, Fallback: original array index
+ */
+function sortToolsChronologically(tools) {
+  return tools
+    .map((tool, index) => ({ tool, originalIndex: index }))
+    .sort((a, b) => {
+      // Primary sort: timestamp (if both have timestamps)
+      if (a.tool.timestamp && b.tool.timestamp) {
+        const timeA = new Date(a.tool.timestamp).getTime()
+        const timeB = new Date(b.tool.timestamp).getTime()
+        if (timeA !== timeB) {
+          return timeA - timeB
+        }
+      }
+      // Fallback: original array order (stable sort)
+      return a.originalIndex - b.originalIndex
+    })
+    .map(({ tool }) => tool)
+}
+
+/**
  * Active tools: Only executing or permission_required
  * These appear in the active tools area above the footer
+ * Sorted chronologically by timestamp
  */
 const activeTools = computed(() => {
-  return props.tools.filter(tool =>
+  const filtered = props.tools.filter(tool =>
     tool.status === 'executing' || tool.status === 'permission_required'
   )
+  return sortToolsChronologically(filtered)
 })
 
 /**
  * Completed tools: All tools that are NOT executing or permission_required
  * These appear in the expanded footer
+ * Sorted chronologically by timestamp
  */
 const completedTools = computed(() => {
-  return props.tools.filter(tool =>
+  const filtered = props.tools.filter(tool =>
     tool.status !== 'executing' && tool.status !== 'permission_required'
   )
+  return sortToolsChronologically(filtered)
 })
 
 /**


### PR DESCRIPTION
## Summary
- Fixed tool ordering in assistant message footer to display chronologically
- Tools now appear in execution order instead of arbitrary order
- Sort uses timestamp (primary) with array index fallback (stable sort)

## Changes
**frontend/src/components/messages/ToolFooter.vue**:
- Added `sortToolsChronologically()` helper function
- Updated `activeTools` computed to sort chronologically
- Updated `completedTools` computed to sort chronologically

## Implementation
```javascript
function sortToolsChronologically(tools) {
  return tools
    .map((tool, index) => ({ tool, originalIndex: index }))
    .sort((a, b) => {
      // Primary sort: timestamp
      if (a.tool.timestamp && b.tool.timestamp) {
        const timeA = new Date(a.tool.timestamp).getTime()
        const timeB = new Date(b.tool.timestamp).getTime()
        if (timeA !== timeB) {
          return timeA - timeB
        }
      }
      // Fallback: original array order (stable sort)
      return a.originalIndex - b.originalIndex
    })
    .map(({ tool }) => tool)
}
```

## Testing
- ✅ Vite HMR confirmed changes deployed to dev server
- ✅ Backend server running on port 8001
- ✅ Stable sort ensures consistent ordering
- ✅ Order preserved across expand/collapse/refresh

## Resolves
Closes #223