### PR TITLE
chore: remove unused _configured_loggers global variable

### DIFF
--- a/src/logging_config.py
+++ b/src/logging_config.py
@@ -50,9 +50,6 @@ class CategoryAdapter(logging.LoggerAdapter):
         kwargs['extra'] = extra
         return msg, kwargs
 
-
-# Global registry of configured loggers
-_configured_loggers = {}
 _log_config = {}
 
 


### PR DESCRIPTION
## Summary
- Remove the unused `_configured_loggers` dictionary from `src/logging_config.py`
- The variable was declared at line 55 but never referenced anywhere in the codebase

## Test plan
- [x] Verified variable is not used anywhere with grep search
- [x] Ruff linting passes with no violations

Closes #245
