### PR TITLE
docs: document error handler behavior in configure_logging()

### DIFF
--- a/src/logging_config.py
+++ b/src/logging_config.py
@@ -81,6 +81,14 @@ def configure_logging(
         debug_legion: Enable Legion multi-agent system debugging
         debug_all: Enable all debug logging
         log_dir: Directory for log files
+
+    Behavior:
+        - Debug logs for specific categories are written to their respective
+          files only when the corresponding debug flag is enabled.
+        - ERROR-level and above messages are always routed to both error.log
+          and console output, regardless of debug flag settings.
+        - This ensures critical errors are never lost due to disabled debug
+          settings.
     """
     global _log_config
 


### PR DESCRIPTION
## Summary
- Add "Behavior" section to `configure_logging()` docstring in `src/logging_config.py`
- Document that ERROR-level and above messages are always routed to both `error.log` and console, regardless of debug flag settings
- Clarify that debug logs for specific categories only appear when their respective flags are enabled

## Test plan
- [ ] Verify docstring renders correctly in IDE tooltips
- [ ] Confirm ruff linting passes

Fixes #244
