### PR TITLE
docs: add comment explaining SDK-permissions logging coupling

### DIFF
--- a/src/logging_config.py
+++ b/src/logging_config.py
@@ -133,6 +133,8 @@ def configure_logging(
             'console': _log_config['debug_websocket_verbose'],
             'level': logging.DEBUG
         },
+        # Enable SDK logging when either SDK or permissions debugging is active,
+        # since permission callbacks are processed through the SDK message stream
         'sdk_debug': {
             'file': f"{log_dir}/sdk_debug.log",
             'enabled': _log_config['debug_sdk'] or _log_config['debug_permissions'],


### PR DESCRIPTION
## Summary
- Add inline comment to `src/logging_config.py` explaining why SDK logging is enabled when permissions debugging is active

## Details
The `sdk_debug` logger's enabled state uses: `_log_config['debug_sdk'] or _log_config['debug_permissions']`

This coupling is intentional because permission callbacks are processed through the SDK message stream. Without documentation, future maintainers might think this is a bug rather than a design decision.

The added comment clarifies this relationship:
> Enable SDK logging when either SDK or permissions debugging is active, since permission callbacks are processed through the SDK message stream

Fixes #242

## Test plan
- [x] Ruff linting passes
- [x] Verify comment is correctly placed at line 136-137 in `src/logging_config.py`
