### PR TITLE
fix: use pre-configured sdk_debug logger instead of __name__ in SDKErrorDetectionHandler

### DIFF
--- a/src/claude_sdk.py
+++ b/src/claude_sdk.py
@@ -66,7 +66,7 @@ class SDKErrorDetectionHandler(logging.Handler):
         super().__init__()
         self.session_id = session_id
         self.error_callback = error_callback
-        self.logger = get_logger(__name__)
+        self.logger = get_logger('sdk_debug', category='SDK_ERROR_HANDLER')
 
     def emit(self, record):
         """Handle log records from claude_code_sdk._internal.query."""


### PR DESCRIPTION
## Summary
- Fixed logger configuration in `SDKErrorDetectionHandler.__init__` to use the pre-configured `sdk_debug` logger instead of `__name__`

## Changes
Changed `src/claude_sdk.py` line 69 from:
```python
self.logger = get_logger(__name__)
