### PR TITLE
refactor: replace __name__ with pre-configured logger names in legion modules

### DIFF
--- a/src/legion/channel_manager.py
+++ b/src/legion/channel_manager.py
@@ -171,7 +171,7 @@ class ChannelManager:
                 # Log error but don't fail channel creation
                 # Channel is already created and persisted successfully
                 from src.logging_config import get_logger
-                logger = get_logger(__name__, "CHANNEL")
+                logger = get_logger('legion', category='CHANNEL')
                 logger.error(f"Failed to broadcast channel creation for {channel_id}: {e}")
 
         return channel_id
@@ -283,7 +283,7 @@ class ChannelManager:
                 except Exception as e:
                     # Log error but continue with other channels
                     from src.logging_config import get_logger
-                    logger = get_logger(__name__, "CHANNEL")
+                    logger = get_logger('legion', category='CHANNEL')
                     logger.error(f"Failed to remove minion {minion_id} from channel {channel.channel_id} ({channel.name}): {e}")
 
         return removed_channel_names

--- a/src/legion/mcp/legion_mcp_tools.py
+++ b/src/legion/mcp/legion_mcp_tools.py
@@ -750,7 +750,7 @@ class LegionMCPTools:
         """
         from src.logging_config import get_logger
 
-        coord_logger = get_logger(__name__, "COORDINATOR")
+        coord_logger = get_logger('legion', category='MCP_TOOLS')
 
         parent_overseer_id = args.get("_parent_overseer_id")
         if not parent_overseer_id:
@@ -1052,7 +1052,7 @@ class LegionMCPTools:
         """
         from src.logging_config import get_logger
 
-        coord_logger = get_logger(__name__, "COORDINATOR")
+        coord_logger = get_logger('legion', category='MCP_TOOLS')
 
         parent_overseer_id = args.get("_parent_overseer_id")  # This is actually the CALLER's session_id
         if not parent_overseer_id:

--- a/src/legion/overseer_controller.py
+++ b/src/legion/overseer_controller.py
@@ -228,7 +228,7 @@ class OverseerController:
         from src.logging_config import get_logger
         from src.models.legion_models import Comm, CommType, InterruptPriority
 
-        coord_logger = get_logger(__name__, "COORDINATOR")
+        coord_logger = get_logger('legion', category='OVERSEER')
 
         # 1. Get parent minion session
         parent_session = await self.system.session_coordinator.session_manager.get_session_info(parent_overseer_id)
@@ -412,7 +412,7 @@ class OverseerController:
         from src.logging_config import get_logger
         from src.models.legion_models import Comm, CommType, InterruptPriority
 
-        coord_logger = get_logger(__name__, "COORDINATOR")
+        coord_logger = get_logger('legion', category='OVERSEER')
 
         # 1. Get parent session
         parent_session = await self.system.session_coordinator.session_manager.get_session_info(parent_overseer_id)


### PR DESCRIPTION
Replace incorrect `get_logger(__name__, ...)` patterns with properly
configured logger names in legion modules:

- channel_manager.py: Use `get_logger('legion', category='CHANNEL')`
- overseer_controller.py: Use `get_logger('legion', category='OVERSEER')`
- legion_mcp_tools.py: Use `get_logger('legion', category='MCP_TOOLS')`

The `__name__` pattern resolved to module paths like
`src.legion.channel_manager` which are not configured in `logger_configs`.
Using the pre-configured `legion` logger ensures proper log routing
and debug flag control.

Closes #248