### PR TITLE
chore: remove legacy history.json migration code and references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -505,7 +505,6 @@ npm run build  # Output: frontend/dist/
 
 **Files Managed**:
 - `messages.jsonl`: Append-only message log
-- `history.json`: Command history
 - `state.json`: Session metadata (managed by SessionManager)
 
 **Key Methods**:
@@ -600,8 +599,7 @@ data/
 │
 ├── sessions/{uuid}/                # One folder per session
 │   ├── state.json                  # SessionInfo serialized
-│   ├── messages.jsonl              # Append-only message log
-│   └── history.json                # Command history
+│   └── messages.jsonl              # Append-only message log
 │
 └── legions/{uuid}/                 # One folder per legion (multi-agent project)
     ├── timeline.jsonl              # Unified comm log

--- a/README.md
+++ b/README.md
@@ -275,8 +275,7 @@ data/
 ├── projects/{uuid}/state.json      # Project metadata
 ├── sessions/{uuid}/                # Session data
 │   ├── state.json                  # Session state
-│   ├── messages.jsonl              # Append-only message log
-│   └── history.json                # Command history
+│   └── messages.jsonl              # Append-only message log
 └── legions/{uuid}/                 # Multi-agent legions
     ├── timeline.jsonl              # Unified comm log
     ├── hordes/{uuid}/              # Hierarchical groups

--- a/legion_proposal/legion_technical_design.md
+++ b/legion_proposal/legion_technical_design.md
@@ -1925,8 +1925,7 @@ data/
 │       ├── comms.jsonl                 # Comms involving this minion
 │       ├── short_term_memory.json      # List[MemoryEntry]
 │       ├── long_term_memory.json       # List[MemoryEntry]
-│       ├── capability_evidence.json    # Dict[capability, List[task_id]]
-│       └── history.json                # Command history (existing)
+│       └── capability_evidence.json    # Dict[capability, List[task_id]]
 │
 └── logs/                               # Existing debug logs
     ├── coordinator.log


### PR DESCRIPTION
## Summary

- Remove obsolete migration code that deleted `history.json` files during `DataStorageManager` initialization
- Update documentation (CLAUDE.md, README.md, legion_proposal/legion_technical_design.md) to remove `history.json` from data directory structure diagrams
- Includes ruff auto-fixes for modernized type hints and import ordering in `data_storage.py`

## Background

The migration code was added in commit `eb48b90` to transition from the old `history.json` format. Since all data has already been converted and no legacy files remain, this code executes during every session initialization but performs no useful function.

## Changes

| File | Change |
|------|--------|
| `src/data_storage.py` | Removed 5-line migration block (lines 43-47) |
| `CLAUDE.md` | Removed `history.json` from "Files Managed" list and data directory structure |
| `README.md` | Removed `history.json` from storage architecture diagram |
| `legion_proposal/legion_technical_design.md` | Removed `history.json` from minion data directory structure |

## Verification

- Confirmed no `history.json` files exist in the repository: `find . -name "history.json"` returns empty
- All ruff linting checks pass

## Test plan

- [x] Run existing tests: `uv run pytest src/tests/ -v`
- [x] Start a new session and verify it initializes correctly
- [x] Verify no errors in storage logs during session creation

Closes #261
