### PR TITLE
fix: move message loop logs to ping-pong debug category

### DIFF
--- a/src/web_server.py
+++ b/src/web_server.py
@@ -1809,17 +1809,17 @@ class ClaudeWebUI:
 
             message_loop_iteration = 0
             try:
-                ws_logger.debug(f"Starting message loop for session {session_id}")
+                ws_verbose_logger.debug(f"Starting message loop for session {session_id}")
 
                 while True:
                     message_loop_iteration += 1
                     loop_iteration_start_time = time.time()
-                    ws_logger.debug(f"Message loop iteration {message_loop_iteration} started at {loop_iteration_start_time}")
+                    ws_verbose_logger.debug(f"Message loop iteration {message_loop_iteration} started at {loop_iteration_start_time}")
 
                     # Wait for incoming messages with proper error handling
                     try:
                         message_wait_start_time = time.time()
-                        ws_logger.debug(f"WebSocket waiting for message from session {session_id} (timeout=3s)")
+                        ws_verbose_logger.debug(f"WebSocket waiting for message from session {session_id} (timeout=3s)")
 
                         message = await asyncio.wait_for(websocket.receive_text(), timeout=3.0)
 
@@ -1999,7 +1999,7 @@ class ClaudeWebUI:
                         continue
 
                     loop_iteration_end_time = time.time()
-                    ws_logger.debug(f"Message loop iteration {message_loop_iteration} completed at {loop_iteration_end_time}")
+                    ws_verbose_logger.debug(f"Message loop iteration {message_loop_iteration} completed at {loop_iteration_end_time}")
 
             except WebSocketDisconnect as disconnect_error:
                 disconnect_time = time.time()


### PR DESCRIPTION
## Summary
Resolves #277

Moves WebSocket message loop iteration logs from the WS_LIFECYCLE debug category to the WS_PING_PONG category to prevent flooding console output when `--debug-websocket` is enabled.

## Changes Made
- Changed 4 debug log statements in `src/web_server.py` from `ws_logger` to `ws_verbose_logger`
- Affected logs: "Starting message loop", "Message loop iteration started/completed", "WebSocket waiting for message"
- These logs now only appear with `--debug-ping-pong` flag (excluded from `--debug-all`)

## Testing
- Verified logs do NOT appear with `--debug-websocket` flag
- Logs now correctly route to `websocket_verbose.log` instead of `websocket_debug.log`
- No behavior changes - only logging categorization

## Impact
**Before:** Message loop logs flooded console every 3 seconds when `--debug-websocket` was enabled
**After:** Message loop logs only appear with explicit `--debug-ping-pong` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)