### PR TITLE
chore: remove unnecessary backward compatibility checks from SessionInfo.from_dict

### DIFF
--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -104,27 +104,7 @@ class SessionInfo:
         data['state'] = SessionState(data['state'])
         data['created_at'] = datetime.fromisoformat(data['created_at'])
         data['updated_at'] = datetime.fromisoformat(data['updated_at'])
-        # Migration: Add minion fields if missing (backward compatibility)
-        if 'is_minion' not in data:
-            data['is_minion'] = False
-        if 'child_minion_ids' not in data:
-            data['child_minion_ids'] = []
-        if 'capabilities' not in data:
-            data['capabilities'] = []
-        if 'is_overseer' not in data:
-            data['is_overseer'] = False
-        if 'overseer_level' not in data:
-            data['overseer_level'] = 0
-        # Migration: Add override_system_prompt if missing (backward compatibility)
-        if 'override_system_prompt' not in data:
-            data['override_system_prompt'] = False
-        # Migration: Rename tools to allowed_tools for backward compatibility
-        if 'allowed_tools' not in data and 'tools' in data:
-            data['allowed_tools'] = data.pop('tools')
-        elif 'allowed_tools' not in data:
-            data['allowed_tools'] = []
-        # Migration: Remove deprecated horde_id field (backward compatibility with PR #281)
-        data.pop('horde_id', None)
+        data.pop('horde_id', None)  # Remove legacy horde_id if present
         return cls(**data)
 
 


### PR DESCRIPTION
## Summary

PR #287 (channel removal) accidentally re-introduced backward compatibility code that was removed in PRs #281 (horde removal) and #285 (cleanup). This PR removes the unnecessary checks from `SessionInfo.from_dict` method.

## Changes

**Removed from `src/session_manager.py`:**
- 22 lines of unnecessary backward compatibility checks in `from_dict` method (lines 107-128)
- Field checks for: `is_minion`, `child_minion_ids`, `capabilities`, `is_overseer`, `overseer_level`, `override_system_prompt`
- Migration logic for `tools` → `allowed_tools` rename

**Kept:**
- Essential state/datetime conversions
- Legacy `horde_id` cleanup (`data.pop('horde_id', None)`)

## Rationale

PR #285 analyzed production session data and proved these backward compatibility checks are unnecessary because:
1. All production sessions already have these fields
2. Dataclass default values handle missing fields automatically
3. The checks add complexity without providing value

## Verification

✅ Server starts successfully with production data  
✅ Session loading works correctly (no errors in logs)  
✅ All Ruff linting checks pass  
✅ No `horde_id` or `channel_ids` references remain (except cleanup line)  

## Test Plan

- [x] Start server with production data on port 8288
- [x] Verify no errors in session loading logs
- [x] Confirm `grep -n "horde_id\|channel_ids" src/session_manager.py` returns only cleanup line
- [x] Run `uv run ruff check --fix src/session_manager.py`

Fixes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)