### PR TITLE
feat: add click navigation from Hierarchy View to Spy View

### DIFF
--- a/frontend/src/components/legion/HierarchyView.vue
+++ b/frontend/src/components/legion/HierarchyView.vue
@@ -66,6 +66,7 @@
             :key="minion.id"
             :minion-data="minion"
             :level="1"
+            @minion-click="handleMinionClick"
           />
         </div>
       </div>
@@ -81,6 +82,7 @@
 
 <script setup>
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
+import { useRouter } from 'vue-router'
 import { useProjectStore } from '../../stores/project'
 import { useSessionStore } from '../../stores/session'
 import { useWebSocketStore } from '../../stores/websocket'
@@ -98,6 +100,7 @@ const props = defineProps({
   }
 })
 
+const router = useRouter()
 const projectStore = useProjectStore()
 const sessionStore = useSessionStore()
 const websocketStore = useWebSocketStore()
@@ -131,6 +134,11 @@ async function loadHierarchy() {
   } finally {
     loading.value = false
   }
+}
+
+// Handle minion click - navigate to Spy View
+function handleMinionClick(minionId) {
+  router.push(`/spy/${props.legionId}/${minionId}`)
 }
 
 // Load on mount

--- a/frontend/src/components/legion/MinionTreeNode.vue
+++ b/frontend/src/components/legion/MinionTreeNode.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="minionData" class="minion-tree-node" :style="{ marginLeft: `${indent}px` }">
-    <div class="minion-card border-start border-2 mb-2">
+    <div class="minion-card minion-card-clickable border-start border-2 mb-2" @click="handleClick">
       <div class="node-row">
         <!-- Left Column: Status + Name (30%) -->
         <div class="node-left">
@@ -46,6 +46,7 @@
         :key="child.id"
         :minion-data="child"
         :level="level + 1"
+        @minion-click="$emit('minion-click', $event)"
       />
     </div>
   </div>
@@ -69,6 +70,8 @@ const props = defineProps({
     default: 0
   }
 })
+
+const emit = defineEmits(['minion-click'])
 
 // Indentation (24px per level)
 const indent = computed(() => props.level * 24)
@@ -158,6 +161,11 @@ function getCommSummary(comm) {
     return text.substring(0, 150) + '...'
   }
   return text
+}
+
+// Handle minion card click - emit event to parent
+function handleClick() {
+  emit('minion-click', props.minionData.id)
 }
 </script>
 
@@ -255,5 +263,15 @@ function getCommSummary(comm) {
   50% {
     opacity: 0.3;
   }
+}
+
+/* Clickable minion card styles */
+.minion-card-clickable {
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.minion-card-clickable:hover {
+  background-color: rgba(13, 110, 253, 0.1);
 }
 </style>


### PR DESCRIPTION
## Summary
Resolves #271

Enables users to click on minion nodes in Hierarchy View to navigate directly to that minion's session in Spy View, reducing navigation from 3 steps to a single click.

## Changes Made
- **MinionTreeNode.vue**: Added click handler that emits `minion-click` event with minion ID
- **MinionTreeNode.vue**: Added hover styles (pointer cursor, background highlight on hover)
- **MinionTreeNode.vue**: Propagate click events from nested children recursively
- **HierarchyView.vue**: Added navigation handler using Vue Router to route to `/spy/:legionId/:minionId`
- **HierarchyView.vue**: Bound click handler to all MinionTreeNode instances

## Testing
- ✅ Manual testing performed on port 8271
- ✅ Verified click navigation works for root minions
- ✅ Verified click navigation works for nested minions (recursive event propagation)
- ✅ Verified hover states display correctly (pointer cursor, background transition)
- ✅ Verified correct minion session displays in Spy View after navigation
- ✅ Verified back button navigation returns to Hierarchy View
- ✅ No console errors or warnings
- ✅ Code review completed - follows Vue 3 Composition API patterns

## Implementation Details
- Uses Vue's event emit system for clean component separation
- Routes via existing `/spy/:legionId/:minionId` path
- Hover background color: `rgba(13, 110, 253, 0.1)` (Bootstrap primary with opacity)
- Smooth 0.2s transition for professional UX

🤖 Generated with [Claude Code](https://claude.com/claude-code)