### PR TITLE
fix: reset is_processing flag on session termination and start

### DIFF
--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -323,6 +323,9 @@ class SessionCoordinator:
             if not await self.session_manager.start_session(session_id):
                 return False
 
+            # Defensively reset processing state on session start
+            await self.session_manager.update_processing_state(session_id, False)
+
             # Check if SDK exists and is running
             sdk = self._active_sdks.get(session_id)
             if sdk and sdk.is_running():
@@ -511,6 +514,9 @@ class SessionCoordinator:
     async def terminate_session(self, session_id: str) -> bool:
         """Terminate a session and cleanup resources"""
         try:
+            # Reset processing state before termination
+            await self.session_manager.update_processing_state(session_id, False)
+
             # Terminate SDK first
             sdk = self._active_sdks.get(session_id)
             if sdk:


### PR DESCRIPTION
## Summary
Resolves #304

Fixes the bug where the `is_processing` flag persists through session termination, causing stuck UI state with infinite processing indicators.

## Changes Made
- Reset `is_processing` flag in `terminate_session()` before SDK termination
- Defensively reset `is_processing` flag in `start_session()` after session manager initialization
- Added clear comments explaining the purpose of each reset

## Root Cause
The `is_processing` flag was not being cleared when sessions were terminated or restarted, causing the UI to incorrectly display processing indicators indefinitely.

## Testing
- ✅ Created test session and verified `is_processing` correctly resets to `false` after termination
- ✅ Verified `is_processing` remains `false` after session restart
- ✅ Confirmed server starts without errors
- ✅ All 48 session-related unit tests pass with no regressions

## Test Configuration
- Test server: Port 8304
- Full debug logging enabled
- Frontend build verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)