### PR TITLE
deps: upgrade claude-agent-sdk to v0.1.22

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "uvicorn>=0.24.0",
     "websockets>=12.0",
     "pydantic>=2.5.0",
-    "claude-agent-sdk>=0.1.9",
+    "claude-agent-sdk>=0.1.22",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 
 [[package]]
@@ -119,17 +119,18 @@ wheels = [
 
 [[package]]
 name = "claude-agent-sdk"
-version = "0.1.9"
+version = "0.1.22"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "mcp" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/c5/ffb02e51f6fc5e5516a52f8f1e338c16830ee616caa5e140d6c0c3f77e7e/claude_agent_sdk-0.1.9.tar.gz", hash = "sha256:5dcf04a4639bd3dd76145b5067851febe515f5540abd90e3af26a4aa22ed91b1", size = 51067, upload-time = "2025-11-21T20:24:32.613Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e1/8f1eea736d83aff7b6924f59461410fe7a4b2fcfa5232d5dbab61c877d86/claude_agent_sdk-0.1.22.tar.gz", hash = "sha256:99edd1a82098bdf0514553e5726186810e1331c9467cb5c88891928ce1c8589b", size = 56854, upload-time = "2026-01-23T22:12:47.325Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/71/4d99c86f14754ea3998d8a59abf9db4f10498988d45fab102faa6c909fc4/claude_agent_sdk-0.1.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d692baac86d5d0dbf0729121e85bcbd390c4413b7aa5a988f7dd5aa7c4237afb", size = 49323542, upload-time = "2025-11-21T20:24:20.053Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/08/5894220578a000f3e2c7d02911ff4196fd9ddf1e77b26ea4b7a1be294639/claude_agent_sdk-0.1.9-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:d826a8afabc5e2d4edca5eb65771f4293a5d9df0eeebcbb5171fdce93d4fea1b", size = 65196329, upload-time = "2025-11-21T20:24:24.666Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/fd/810628f5e020171cbaa48e82de14fccd66383f5e77d0f3fdd8859fef796e/claude_agent_sdk-0.1.9-py3-none-win_amd64.whl", hash = "sha256:37e0cff2d277e617c5597f7bb0eb160c12ca57409d36060f7020fc9893f6337c", size = 68083295, upload-time = "2025-11-21T20:24:30.133Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/e5/3ae471bdd8efa51ea8bb0bba77b3276bf6b1412106a8aabd405e0edb3715/claude_agent_sdk-0.1.22-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1728cc26d8403adad98f048b002a6ea9e7db4b0b56affcc8cdfe91c2b66e4306", size = 54348090, upload-time = "2026-01-23T22:12:27.533Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/ed/3c26e4a77043c723add75e25aeb6cbc0a573bd177f2f2e0f7cc71af052ed/claude_agent_sdk-0.1.22-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:8fb3567d5fbdbd455cfa6e123e0e6249888dac43ab7b89152fde87c2f6b08880", size = 68543942, upload-time = "2026-01-23T22:12:31.913Z" },
+    { url = "https://files.pythonhosted.org/packages/19/5f/e02cfb9fcc22a270002a27001ffd34f259ea3a7546129bbf72ec381fcabd/claude_agent_sdk-0.1.22-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:2e25ce12e0366672b575ae900bc6422ebe9fa53627e043b299e681fce07be134", size = 70252610, upload-time = "2026-01-23T22:12:37.137Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/eb/4ac597368f41d7daf6896babcf68f2d96b74e7b2a32c61deb4acb0509812/claude_agent_sdk-0.1.22-py3-none-win_amd64.whl", hash = "sha256:59b755feb7fb67a1131cc022fa1b33b6b40661b63c6abaea02cc45d8e1a73c3b", size = 72444297, upload-time = "2026-01-23T22:12:43.639Z" },
 ]
 
 [[package]]
@@ -162,7 +163,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
-    { name = "claude-agent-sdk", specifier = ">=0.1.9" },
+    { name = "claude-agent-sdk", specifier = ">=0.1.22" },
     { name = "fastapi", specifier = ">=0.104.0" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.7.0" },


### PR DESCRIPTION
## Summary
Upgrades claude-agent-sdk from v0.1.9 to v0.1.22.

Resolves #315

## Changes
- Updated `pyproject.toml`: `claude-agent-sdk>=0.1.22`
- Updated `uv.lock` with new dependency resolution

## Testing Completed
- ✅ 223/228 automated tests passed (3 pre-existing failures unrelated to SDK)
- ✅ Server starts successfully on port 8315
- ✅ SDK integration verified (sessions, messages, tools, permissions)
- ✅ Health endpoint responding correctly
- ✅ WebSocket connections working properly

## Breaking Changes
None detected. All SDK parameters remain compatible.

## Version Analysis
Analyzed versions v0.1.10 through v0.1.22 - all contain additive enhancements only. No API deprecations or breaking changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)