### PR TITLE
fix(#323): include overseer sessions in minion visibility filters

### DIFF
--- a/src/legion/legion_coordinator.py
+++ b/src/legion/legion_coordinator.py
@@ -109,9 +109,11 @@ class LegionCoordinator:
             return None
 
         # Search through legion's sessions for matching minion name
+        # Include both is_minion=True AND is_overseer=True sessions
+        # This allows children to send comms to parent overseers
         for session_id in legion.session_ids:
             session = await self.session_manager.get_session_info(session_id)
-            if session and session.is_minion and session.name == name:
+            if session and (session.is_minion or session.is_overseer) and session.name == name:
                 return session
 
         return None

--- a/src/legion/mcp/legion_mcp_tools.py
+++ b/src/legion/mcp/legion_mcp_tools.py
@@ -901,11 +901,13 @@ class LegionMCPTools:
                 }
 
             # Get minions in this legion (project_id matches legion_id)
+            # Include both is_minion=True AND is_overseer=True sessions
+            # This allows children to see and communicate with parent overseers
             session_manager = self.system.session_coordinator.session_manager
             minions = []
             for session_id in legion.session_ids:
                 session = await session_manager.get_session_info(session_id)
-                if session and session.is_minion:
+                if session and (session.is_minion or session.is_overseer):
                     minions.append(session)
 
             # Format minion list

--- a/src/tests/test_legion_mcp_tools.py
+++ b/src/tests/test_legion_mcp_tools.py
@@ -131,3 +131,174 @@ def test_mcp_tools_has_system_reference(mcp_tools):
     """Test that MCP tools has reference to LegionSystem."""
     assert hasattr(mcp_tools, 'system')
     assert mcp_tools.system is not None
+
+
+# Regression tests for issue #323: list_minions and send_comm visibility
+# These tests verify that overseer sessions are included in visibility filters
+
+
+@pytest.mark.asyncio
+async def test_list_minions_includes_overseer_sessions():
+    """
+    Issue #323 regression test: list_minions should include sessions with is_overseer=True.
+
+    When a minion spawns a child, the parent becomes an overseer (is_overseer=True).
+    The child should be able to see the parent in list_minions results.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from src.session_manager import SessionState
+
+    # Create mock session manager
+    session_manager = MagicMock()
+
+    # Create mock sessions:
+    # - caller_session: the child minion calling list_minions
+    # - parent_session: parent overseer (is_overseer=True, but may not have is_minion=True)
+    # - sibling_session: another minion
+    caller_session = MagicMock()
+    caller_session.session_id = "child-session-id"
+    caller_session.project_id = "legion-123"
+    caller_session.is_minion = True
+    caller_session.is_overseer = False
+    caller_session.name = "ChildMinion"
+    caller_session.role = "Test Role"
+    caller_session.state = SessionState.ACTIVE
+    caller_session.capabilities = []
+
+    parent_session = MagicMock()
+    parent_session.session_id = "parent-session-id"
+    parent_session.project_id = "legion-123"
+    parent_session.is_minion = True  # Parent is also a minion (was spawned by user/another minion)
+    parent_session.is_overseer = True  # Parent has spawned children
+    parent_session.name = "ParentOverseer"
+    parent_session.role = "Parent Role"
+    parent_session.state = SessionState.ACTIVE
+    parent_session.capabilities = []
+
+    # Case where parent is NOT marked as minion but IS overseer
+    # This can happen when a regular session spawns a minion
+    non_minion_overseer = MagicMock()
+    non_minion_overseer.session_id = "non-minion-overseer-id"
+    non_minion_overseer.project_id = "legion-123"
+    non_minion_overseer.is_minion = False  # Not marked as minion
+    non_minion_overseer.is_overseer = True  # But is an overseer (has children)
+    non_minion_overseer.name = "RegularOverseer"
+    non_minion_overseer.role = "Overseer Role"
+    non_minion_overseer.state = SessionState.ACTIVE
+    non_minion_overseer.capabilities = []
+
+    # Mock get_session_info to return appropriate session based on ID
+    async def mock_get_session_info(session_id):
+        sessions = {
+            "child-session-id": caller_session,
+            "parent-session-id": parent_session,
+            "non-minion-overseer-id": non_minion_overseer,
+        }
+        return sessions.get(session_id)
+
+    session_manager.get_session_info = mock_get_session_info
+
+    # Create mock legion/project
+    mock_legion = MagicMock()
+    mock_legion.session_ids = ["child-session-id", "parent-session-id", "non-minion-overseer-id"]
+
+    # Create mock legion coordinator
+    legion_coordinator = MagicMock()
+    legion_coordinator.get_legion = AsyncMock(return_value=mock_legion)
+
+    # Create mock session coordinator
+    session_coordinator = MagicMock()
+    session_coordinator.session_manager = session_manager
+
+    # Create mock system
+    mock_system = MagicMock()
+    mock_system.session_coordinator = session_coordinator
+    mock_system.legion_coordinator = legion_coordinator
+
+    # Create MCP tools with mock system
+    from src.legion.mcp.legion_mcp_tools import LegionMCPTools
+    mcp_tools = LegionMCPTools(mock_system)
+
+    # Call list_minions as the child
+    result = await mcp_tools._handle_list_minions({
+        "_from_minion_id": "child-session-id"
+    })
+
+    # Verify no error
+    assert result.get("is_error") is False, f"Got error: {result}"
+
+    # Parse result text
+    result_text = result["content"][0]["text"]
+
+    # Verify parent overseer is visible (is_minion=True AND is_overseer=True)
+    assert "ParentOverseer" in result_text, \
+        f"Parent overseer should be visible to child. Result: {result_text}"
+
+    # Verify non-minion overseer is visible (is_minion=False BUT is_overseer=True)
+    # This is the key fix from issue #323
+    assert "RegularOverseer" in result_text, \
+        f"Non-minion overseer should be visible to child. Result: {result_text}"
+
+
+@pytest.mark.asyncio
+async def test_get_minion_by_name_includes_overseer():
+    """
+    Issue #323 regression test: get_minion_by_name_in_legion should find overseers.
+
+    When a child tries to send_comm to parent, the lookup should find the parent
+    even if is_minion=False but is_overseer=True.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from src.session_manager import SessionState
+
+    # Create mock session manager
+    session_manager = MagicMock()
+
+    # Non-minion overseer (regular session that spawned a child)
+    overseer_session = MagicMock()
+    overseer_session.session_id = "overseer-session-id"
+    overseer_session.project_id = "legion-123"
+    overseer_session.is_minion = False  # Not marked as minion
+    overseer_session.is_overseer = True  # But is an overseer
+    overseer_session.name = "MyOverseer"
+    overseer_session.role = "Overseer Role"
+    overseer_session.state = SessionState.ACTIVE
+
+    async def mock_get_session_info(session_id):
+        if session_id == "overseer-session-id":
+            return overseer_session
+        return None
+
+    session_manager.get_session_info = mock_get_session_info
+
+    # Create mock legion/project
+    mock_legion = MagicMock()
+    mock_legion.session_ids = ["overseer-session-id"]
+
+    # Create mock project manager
+    project_manager = MagicMock()
+    project_manager.get_project = AsyncMock(return_value=mock_legion)
+
+    # Create mock session coordinator
+    session_coordinator = MagicMock()
+    session_coordinator.session_manager = session_manager
+    session_coordinator.project_manager = project_manager
+
+    # Create mock system
+    mock_system = MagicMock()
+    mock_system.session_coordinator = session_coordinator
+
+    # Create LegionCoordinator with mock system
+    from src.legion.legion_coordinator import LegionCoordinator
+    legion_coord = LegionCoordinator(mock_system)
+
+    # Try to find overseer by name
+    result = await legion_coord.get_minion_by_name_in_legion("legion-123", "MyOverseer")
+
+    # Should find the overseer even though is_minion=False
+    assert result is not None, \
+        "get_minion_by_name_in_legion should find overseer sessions (is_overseer=True)"
+    assert result.session_id == "overseer-session-id"
+    assert result.name == "MyOverseer"


### PR DESCRIPTION
## Summary
- Fixed `list_minions` tool to include sessions with `is_overseer=True` (not just `is_minion=True`)
- Fixed `get_minion_by_name_in_legion` lookup for `send_comm` to find overseer sessions
- Added regression tests for both visibility scenarios

## Root Cause
When a session spawns a child, it becomes `is_overseer=True` but may not have `is_minion=True`. The visibility filters only checked `is_minion=True`, causing children to be unable to see or communicate with their parent overseers.

## Test plan
- [x] All 10 Legion MCP tools tests pass (including 2 new regression tests)
- [x] All Legion system tests pass
- [x] Server starts successfully
- [x] Ruff linting passes

Closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)