### PR TITLE
feat(#319): add sandbox mode support for Legion minions

### DIFF
--- a/frontend/src/components/legion/CreateMinionModal.vue
+++ b/frontend/src/components/legion/CreateMinionModal.vue
@@ -245,6 +245,25 @@
               </div>
             </div>
 
+            <!-- Sandbox Mode (issue #319) -->
+            <div class="mb-3 form-check">
+              <input
+                type="checkbox"
+                class="form-check-input"
+                id="sandboxEnabled"
+                v-model="formData.sandbox_enabled"
+              />
+              <label class="form-check-label" for="sandboxEnabled">
+                🔒 Enable Sandbox Mode
+              </label>
+              <div class="form-text text-muted" v-if="!formData.sandbox_enabled">
+                <small>Sandbox mode restricts file system and network access for added security.</small>
+              </div>
+              <div class="form-text text-info" v-if="formData.sandbox_enabled">
+                <small>🔒 Sandbox enabled: Minion will have OS-level isolation restricting file system and network access.</small>
+              </div>
+            </div>
+
             <!-- Start Immediately -->
             <div class="mb-3 form-check">
               <input
@@ -328,6 +347,7 @@ const formData = ref({
   permission_mode: 'default',
   allowed_tools: '',
   working_directory: '',
+  sandbox_enabled: false,
   startImmediately: true
 })
 
@@ -564,6 +584,7 @@ function resetForm() {
     permission_mode: 'default',
     allowed_tools: '',
     working_directory: '',
+    sandbox_enabled: false,
     startImmediately: true
   }
   capabilitiesInput.value = ''
@@ -631,7 +652,8 @@ async function createMinion() {
       capabilities: capabilities.value,
       permission_mode: formData.value.permission_mode,
       allowed_tools: allowedTools.value,
-      working_directory: formData.value.working_directory.trim() || null
+      working_directory: formData.value.working_directory.trim() || null,
+      sandbox_enabled: formData.value.sandbox_enabled
     }
 
     const response = await api.post(`/api/legions/${legionId.value}/minions`, payload)

--- a/frontend/src/components/session/SessionItem.vue
+++ b/frontend/src/components/session/SessionItem.vue
@@ -17,6 +17,7 @@
     <div class="session-info flex-grow-1">
       <div class="session-name">
         <span>{{ session.name || session.session_id }}</span>
+        <span v-if="session.sandbox_enabled" class="sandbox-indicator ms-1" title="Sandboxed">🔒</span>
         <span v-if="session.is_minion && session.role" class="text-muted small ms-1">({{ session.role }})</span>
       </div>
       <!-- Latest Activity below name - Issue #291 -->
@@ -307,6 +308,11 @@ function onDrop(event) {
 
 .session-name {
   /* Name keeps its default size */
+}
+
+.sandbox-indicator {
+  font-size: 0.9em;
+  cursor: help;
 }
 
 /* Latest activity display (issue #291) - below name, 1pt smaller */

--- a/src/legion/overseer_controller.py
+++ b/src/legion/overseer_controller.py
@@ -38,7 +38,8 @@ class OverseerController:
         permission_mode: str = "default",
         allowed_tools: list[str] | None = None,
         working_directory: str | None = None,
-        model: str | None = None
+        model: str | None = None,
+        sandbox_enabled: bool = False
     ) -> str:
         """
         Create a minion for the user (root overseer).
@@ -54,6 +55,7 @@ class OverseerController:
             allowed_tools: List of pre-authorized tools (e.g., ["edit", "read", "bash"])
             working_directory: Optional custom working directory (defaults to project directory)
             model: Model selection (sonnet, opus, haiku, opusplan)
+            sandbox_enabled: Enable OS-level sandboxing (issue #319)
 
         Returns:
             str: The created minion's session_id
@@ -102,7 +104,9 @@ class OverseerController:
             is_minion=True,  # Explicitly mark as minion
             role=role,
             capabilities=capabilities or [],
-            can_spawn_minions=True  # User-created minion can spawn by default
+            can_spawn_minions=True,  # User-created minion can spawn by default
+            # Sandbox mode (issue #319)
+            sandbox_enabled=sandbox_enabled
         )
 
         # Register capabilities in capability registry
@@ -135,7 +139,8 @@ class OverseerController:
         capabilities: list[str] | None = None,
         permission_mode: str | None = None,
         allowed_tools: list[str] | None = None,
-        working_directory: str | None = None
+        working_directory: str | None = None,
+        sandbox_enabled: bool = False
     ) -> dict[str, any]:
         """
         Spawn a child minion autonomously by a parent overseer.
@@ -151,6 +156,7 @@ class OverseerController:
             permission_mode: Permission mode (from template or safe default)
             allowed_tools: List of allowed tools (from template or safe default)
             working_directory: Optional custom working directory (defaults to parent's directory)
+            sandbox_enabled: Enable OS-level sandboxing (issue #319)
 
         Returns:
             dict: {
@@ -216,7 +222,9 @@ class OverseerController:
             capabilities=capabilities or [],
             parent_overseer_id=parent_overseer_id,
             overseer_level=overseer_level,
-            can_spawn_minions=True  # Child can spawn by default
+            can_spawn_minions=True,  # Child can spawn by default
+            # Sandbox mode (issue #319)
+            sandbox_enabled=sandbox_enabled
         )
 
         # 8. Update parent: mark as overseer, add child to child_minion_ids

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -165,6 +165,9 @@ class SessionCoordinator:
         overseer_level: int = 0,
         can_spawn_minions: bool = True,  # If False, no MCP spawn tools attached
         is_minion: bool = False,  # Explicit minion flag (for spawned minions)
+        # Sandbox mode (issue #319)
+        sandbox_enabled: bool = False,
+        sandbox_config: dict | None = None,
     ) -> str:
         """Create a new Claude Code session with integrated components (within a project)"""
         try:
@@ -204,7 +207,10 @@ class SessionCoordinator:
                 capabilities=capabilities,
                 parent_overseer_id=parent_overseer_id,
                 overseer_level=overseer_level,
-                can_spawn_minions=can_spawn_minions
+                can_spawn_minions=can_spawn_minions,
+                # Sandbox mode (issue #319)
+                sandbox_enabled=sandbox_enabled,
+                sandbox_config=sandbox_config
             )
 
             # Add session to project
@@ -269,7 +275,9 @@ class SessionCoordinator:
                 override_system_prompt=override_system_prompt,
                 tools=all_tools,
                 model=model,
-                mcp_servers=mcp_servers
+                mcp_servers=mcp_servers,
+                sandbox_enabled=sandbox_enabled,
+                sandbox_config=sandbox_config
             )
             self._active_sdks[session_id] = sdk
 
@@ -429,7 +437,9 @@ class SessionCoordinator:
                 tools=all_tools,
                 model=session_info.model,
                 resume_session_id=resume_sdk_session,  # Only resume if we have a Claude Code session ID
-                mcp_servers=mcp_servers
+                mcp_servers=mcp_servers,
+                sandbox_enabled=session_info.sandbox_enabled,
+                sandbox_config=session_info.sandbox_config
             )
             self._active_sdks[session_id] = sdk
 

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -88,6 +88,10 @@ class SessionInfo:
     latest_message_type: str | None = None  # "user", "assistant", "system"
     latest_message_time: datetime | None = None  # When the message was received
 
+    # Sandbox mode support (issue #319)
+    sandbox_enabled: bool = False  # If True, enable OS-level sandboxing via SDK
+    sandbox_config: dict | None = None  # Optional SandboxSettings config (auto_allow_bash, excluded_commands, etc.)
+
     def __post_init__(self):
         if self.allowed_tools is None:
             self.allowed_tools = ["bash", "edit", "read"]
@@ -215,7 +219,10 @@ class SessionManager:
         capabilities: list[str] = None,
         parent_overseer_id: str | None = None,
         overseer_level: int = 0,
-        can_spawn_minions: bool = True  # If False, no MCP spawn tools attached
+        can_spawn_minions: bool = True,  # If False, no MCP spawn tools attached
+        # Sandbox mode (issue #319)
+        sandbox_enabled: bool = False,
+        sandbox_config: dict | None = None
     ) -> None:
         """Create a new session with provided ID (or minion if is_minion=True)"""
         # Validate session_id is not reserved
@@ -254,7 +261,10 @@ class SessionManager:
             capabilities=capabilities if capabilities is not None else [],
             parent_overseer_id=parent_overseer_id,
             overseer_level=overseer_level,
-            can_spawn_minions=can_spawn_minions
+            can_spawn_minions=can_spawn_minions,
+            # Sandbox mode (issue #319)
+            sandbox_enabled=sandbox_enabled,
+            sandbox_config=sandbox_config
         )
 
         try:

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -143,6 +143,7 @@ class MinionCreateRequest(BaseModel):
     permission_mode: str = "default"
     allowed_tools: list[str] | None = None  # None or empty list means no pre-authorized tools
     working_directory: str | None = None  # Optional custom working directory for this minion
+    sandbox_enabled: bool = False  # Enable OS-level sandboxing (issue #319)
 
 
 
@@ -1108,7 +1109,8 @@ class ClaudeWebUI:
                     permission_mode=request.permission_mode,
                     allowed_tools=request.allowed_tools,
                     working_directory=str(working_dir),
-                    model=request.model
+                    model=request.model,
+                    sandbox_enabled=request.sandbox_enabled
                 )
 
                 # Get the created minion info


### PR DESCRIPTION
## Summary
- Add OS-level sandboxing support for minions using the Claude Agent SDK's native `sandbox` configuration
- Backend: Add `sandbox_enabled` and `sandbox_config` fields to SessionInfo, pass to ClaudeAgentOptions
- MCP Tools: Add `sandbox_enabled` parameter to `spawn_minion` tool
- API: Accept `sandbox_enabled` in minion creation endpoint
- Frontend: Add sandbox checkbox in CreateMinionModal, show 🔒 icon for sandboxed minions

## Test plan
- [x] Frontend builds successfully
- [x] Server starts on test port without errors
- [x] API returns `sandbox_enabled` field in session responses
- [x] CreateMinionModal displays sandbox checkbox
- [x] SessionItem shows lock icon when `sandbox_enabled=true`

Closes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)