### PR TITLE
revert(#351): remove comm buffering system from PR #344

### DIFF
--- a/src/legion_system.py
+++ b/src/legion_system.py
@@ -92,8 +92,3 @@ class LegionSystem:
         # Higher-level components (depend on above)
         self.legion_coordinator = LegionCoordinator(self)
         self.mcp_tools = LegionMCPTools(self)
-
-        # Register comm buffer flush on processing completion
-        self.session_coordinator.session_manager.add_processing_complete_callback(
-            self.comm_router.flush_buffered_comms
-        )


### PR DESCRIPTION
## Summary
- Reverts the comm buffering system introduced in PR #344
- Returns to direct comm delivery where comms are sent immediately to minions
- Removes ~61 lines of buffering code across 3 files

## Changes
- **CommRouter**: Remove `_comm_buffer` dict, buffering logic in `_send_to_minion()`, and `flush_buffered_comms()` method
- **SessionManager**: Remove `_processing_complete_callbacks` list and callback invocation in `update_processing_state()`
- **LegionSystem**: Remove callback wiring in `__post_init__`

## What's Retained
- SDK 0.1.23 and `CLAUDE_CODE_ENABLE_TASKS` env var (enables native Tasks system, unrelated to comm buffering)

## Test plan
- [x] Server starts successfully
- [x] Ruff linting passes
- [x] Test suite passes (pre-existing failures unrelated to changes)
- [ ] Verify comms are delivered directly to minions
- [ ] Verify HALT/PIVOT priority comms still interrupt immediately

Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)