### PR TITLE
chore(#354): remove Spy view comment remnants

### DIFF
--- a/frontend/src/components/legion/CommComposer.vue
+++ b/frontend/src/components/legion/CommComposer.vue
@@ -136,7 +136,7 @@ const canSend = computed(() => {
 })
 
 /**
- * Get state icon for minion (matching SpySelector)
+ * Get state icon for minion (matching sidebar minion tree)
  */
 function getStateIcon(session) {
   const icons = {
@@ -152,7 +152,7 @@ function getStateIcon(session) {
 }
 
 /**
- * Get minion label with role (matching SpySelector)
+ * Get minion label with role (matching sidebar minion tree)
  */
 function getMinionLabel(session) {
   if (session.is_minion && session.role) {

--- a/frontend/src/components/session/SessionView.vue
+++ b/frontend/src/components/session/SessionView.vue
@@ -67,7 +67,7 @@ onMounted(async () => {
   }
 })
 
-// Watch for sessionId prop changes (e.g., when switching minions in Spy mode)
+// Watch for sessionId prop changes (e.g., when switching minions via sidebar)
 watch(() => props.sessionId, async (newSessionId, oldSessionId) => {
   if (newSessionId !== oldSessionId && newSessionId !== sessionStore.currentSessionId) {
     uiStore.showLoading('Loading session...')

--- a/frontend/src/stores/project.js
+++ b/frontend/src/stores/project.js
@@ -11,7 +11,7 @@ export const useProjectStore = defineStore('project', () => {
   // Projects map (projectId -> ProjectData)
   const projects = ref(new Map())
 
-  // Current project selection (for Legion timeline/spy views)
+  // Current project selection (for Legion timeline/hierarchy views)
   const currentProjectId = ref(null)
 
   // ========== COMPUTED ==========

--- a/frontend/src/stores/websocket.js
+++ b/frontend/src/stores/websocket.js
@@ -32,7 +32,7 @@ export const useWebSocketStore = defineStore('websocket', () => {
   // Reconnection tracking (detect if this is initial connection or reconnection)
   const sessionHadInitialConnection = ref(new Map()) // sessionId -> boolean
 
-  // Legion WebSocket (for timeline/spy views)
+  // Legion WebSocket (for timeline/hierarchy views)
   const legionSocket = ref(null)
   const legionConnected = ref(false)
   const legionRetryCount = ref(0)
@@ -615,7 +615,7 @@ export const useWebSocketStore = defineStore('websocket', () => {
   }
 
   /**
-   * Connect to Legion WebSocket (for timeline/spy views)
+   * Connect to Legion WebSocket (for timeline/hierarchy views)
    */
   function connectLegion(legionId) {
     disconnectLegion()

--- a/src/legion/overseer_controller.py
+++ b/src/legion/overseer_controller.py
@@ -270,7 +270,7 @@ class OverseerController:
         await self.system.comm_router.route_comm(spawn_comm)
 
         # 12. Register WebSocket message callback for child session
-        # This ensures messages from the spawned minion broadcast to WebSocket clients (Spy view)
+        # This ensures messages from the spawned minion broadcast to WebSocket clients
         if self.system.message_callback_registrar:
             self.system.message_callback_registrar(child_minion_id)
             coord_logger.info(f"Registered WebSocket message callback for spawned minion {child_minion_id} ({name})")


### PR DESCRIPTION
## Summary
- Remove outdated comments that reference the removed Spy view feature
- Update terminology to reflect current UI (sidebar hierarchy, hierarchy views)
- Affects 5 files: 1 Python backend, 4 Vue frontend

## Changes
| File | Change |
|------|--------|
| `src/legion/overseer_controller.py` | Remove "(Spy view)" from WebSocket callback comment |
| `frontend/src/stores/websocket.js` | Change "timeline/spy views" → "timeline/hierarchy views" (2 locations) |
| `frontend/src/stores/project.js` | Change "timeline/spy views" → "timeline/hierarchy views" |
| `frontend/src/components/session/SessionView.vue` | Change "in Spy mode" → "via sidebar" |
| `frontend/src/components/legion/CommComposer.vue` | Change "SpySelector" → "sidebar minion tree" (2 locations) |

## Test plan
- [x] Python linting passes (ruff check)
- [x] Frontend builds successfully
- [x] Server starts and health check passes
- [x] API endpoints respond correctly

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)