### PR TITLE
refactor(#355): remove Channel system remnants from tests

### DIFF
--- a/src/tests/integration/test_lifecycle_tools.py
+++ b/src/tests/integration/test_lifecycle_tools.py
@@ -350,7 +350,6 @@ async def test_dispose_minion_direct_child(legion_test_env):
     - Child session terminated (TERMINATED state)
     - Parent's child_minion_ids updated (child removed)
     - DISPOSE comm logged to timeline
-    - Channel cleanup (child removed from channels)
     """
     env = legion_test_env
     legion_system = env["legion_system"]

--- a/src/tests/test_legion_models.py
+++ b/src/tests/test_legion_models.py
@@ -7,7 +7,7 @@ LegionInfo and MinionInfo were consolidated into ProjectInfo and SessionInfo res
 TODO: Rewrite tests to match current architecture:
 - Legion data is in ProjectInfo with is_multi_agent=True
 - Minion data is in SessionInfo with is_minion=True
-- Test Horde, Channel, and Comm models from legion_models.py
+- Test Horde and Comm models from legion_models.py
 """
 
 import pytest


### PR DESCRIPTION
## Summary
- Remove leftover Channel system references from test comments
- Follows Channel removal in PR #287
- Part of deprecated code audit (#350)

## Test plan
- [x] Verified changes are comment-only
- [x] Confirmed pre-existing test failure in `test_dispose_minion_direct_child` is unrelated (parent's child_minion_ids not updated after dispose - separate issue)
- [x] 8 tests passed, 1 skipped (expected), 1 pre-existing failure

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)