### PR TITLE
chore(#356): remove Horde system remnants

### DIFF
--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -120,7 +120,6 @@ class SessionInfo:
         # Convert latest_message_time if present (issue #291)
         if 'latest_message_time' in data and data['latest_message_time']:
             data['latest_message_time'] = datetime.fromisoformat(data['latest_message_time'])
-        data.pop('horde_id', None)  # Remove legacy horde_id if present
         return cls(**data)
 
 

--- a/src/tests/test_legion_models.py
+++ b/src/tests/test_legion_models.py
@@ -7,7 +7,7 @@ LegionInfo and MinionInfo were consolidated into ProjectInfo and SessionInfo res
 TODO: Rewrite tests to match current architecture:
 - Legion data is in ProjectInfo with is_multi_agent=True
 - Minion data is in SessionInfo with is_minion=True
-- Test Horde and Comm models from legion_models.py
+- Test Comm models from legion_models.py
 """
 
 import pytest


### PR DESCRIPTION
## Summary
- Remove "Horde" reference from TODO comment in test_legion_models.py
- Remove `horde_id` migration code in session_manager.py that is no longer needed

The Horde system was removed months ago (PRs #281, #285, #290, #294). The migration code for `horde_id` is obsolete since any sessions would have been migrated long ago.

## Test plan
- [x] Ruff linting passes
- [x] All session_manager tests pass (19/19)
- [x] Server starts and health check passes
- [x] Sessions API responds correctly

Fixes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)