### PR TITLE
chore(#349): remove deprecated is_minion field

### DIFF
--- a/frontend/src/components/header/HierarchyHeader.vue
+++ b/frontend/src/components/header/HierarchyHeader.vue
@@ -49,10 +49,10 @@ const uiStore = useUIStore()
 const legion = computed(() => projectStore.projects.get(props.legionId))
 const legionName = computed(() => legion.value?.name || 'Legion')
 
-// Get all minions for this legion
+// Get all minions for this legion (issue #349: all sessions are minions)
 const legionMinions = computed(() => {
   const sessions = Array.from(sessionStore.sessions.values())
-  return sessions.filter(s => s.is_minion && s.project_id === props.legionId)
+  return sessions.filter(s => s.project_id === props.legionId)
 })
 
 // Count active minions

--- a/frontend/src/components/legion/CommComposer.vue
+++ b/frontend/src/components/legion/CommComposer.vue
@@ -122,12 +122,13 @@ const isMobile = computed(() => windowWidth.value < 768)
 
 // Get minions for this legion
 const minions = computed(() => {
+  // Issue #349: All sessions are minions
   const project = projectStore.projects.get(props.legionId)
   if (!project || !project.session_ids) return []
 
   return project.session_ids
     .map(sid => sessionStore.sessions.get(sid))
-    .filter(s => s && s.is_minion)
+    .filter(s => s)
 })
 
 // Can send if recipient and content are provided
@@ -153,9 +154,10 @@ function getStateIcon(session) {
 
 /**
  * Get minion label with role (matching sidebar minion tree)
+ * Issue #349: All sessions are minions - always show role if present
  */
 function getMinionLabel(session) {
-  if (session.is_minion && session.role) {
+  if (session.role) {
     return `${session.name} (${session.role})`
   }
   return session.name

--- a/frontend/src/components/legion/HierarchyView.vue
+++ b/frontend/src/components/legion/HierarchyView.vue
@@ -238,8 +238,9 @@ onMounted(() => {
       if (!hierarchy.value) return
 
       // Update all minion states, is_processing, and latest_message in our hierarchy
+      // Issue #349: All sessions are minions
       for (const [sessionId, session] of sessions) {
-        if (session.is_minion && session.project_id === props.legionId) {
+        if (session.project_id === props.legionId) {
           const minion = findMinionInTree(hierarchy.value, sessionId)
           if (minion && minion.type === 'minion') {
             // Update state if changed

--- a/frontend/src/components/legion/MinionViewModal.vue
+++ b/frontend/src/components/legion/MinionViewModal.vue
@@ -93,8 +93,9 @@
               <div v-if="session.parent_overseer_id" class="font-monospace small">
                 {{ session.parent_overseer_id }}
               </div>
+              <!-- Issue #349: All sessions are minions -->
               <div v-else class="text-muted small">
-                {{ session.is_minion ? 'Root overseer (user-created)' : 'N/A' }}
+                Root overseer (user-created)
               </div>
             </div>
 

--- a/frontend/src/components/project/ProjectItem.vue
+++ b/frontend/src/components/project/ProjectItem.vue
@@ -215,10 +215,9 @@ const projectSessions = computed(() => {
     .filter(session => session !== null && session !== undefined) // Remove any null/undefined values if session not found
 })
 
-// Issue #313: Progressive disclosure - check if project has any minions
+// Issue #349: All sessions are minions - check if project has any sessions
 const hasMinions = computed(() => {
-  // Check if any session in this project is a minion
-  return projectSessions.value.some(session => session.is_minion)
+  return projectSessions.value.length > 0
 })
 
 const isTimelineActive = computed(() => {
@@ -360,8 +359,9 @@ onMounted(() => {
       if (!minionHierarchy.value || !isExpanded.value) return
 
       // Update all minion states, is_processing, and latest_message in our hierarchy
+      // Issue #349: All sessions are minions
       for (const [sessionId, session] of sessions) {
-        if (session.is_minion && session.project_id === props.project.project_id) {
+        if (session.project_id === props.project.project_id) {
           const minion = findMinionInTree(minionHierarchy.value, sessionId)
           if (minion && minion.type === 'minion') {
             // Update state if changed
@@ -393,10 +393,10 @@ onMounted(() => {
       if (!isExpanded.value) return
 
       // Check for new minion creation (size increased)
+      // Issue #349: All sessions are minions
       if (newSize > oldSize) {
         const sessions = Array.from(sessionStore.sessions.values())
         const hasNewMinion = sessions.some(s =>
-          s.is_minion &&
           s.project_id === props.project.project_id &&
           (!minionHierarchy.value || !findMinionInTree(minionHierarchy.value, s.session_id))
         )

--- a/frontend/src/components/project/ProjectOverview.vue
+++ b/frontend/src/components/project/ProjectOverview.vue
@@ -63,15 +63,7 @@
               </div>
             </div>
           </div>
-          <div v-if="hasMinions" class="col-md-4">
-            <div class="card h-100">
-              <div class="card-body">
-                <h6 class="card-subtitle mb-2 text-muted">Minions</h6>
-                <h3 class="card-title mb-0">{{ minionCount }}</h3>
-                <small class="text-muted">{{ activeMinionCount }} active</small>
-              </div>
-            </div>
-          </div>
+          <!-- Issue #349: Removed redundant Minions card - all sessions are minions -->
           <div class="col-md-4">
             <div class="card h-100">
               <div class="card-body">
@@ -122,8 +114,8 @@
               >
                 <div class="flex-grow-1">
                   <div class="d-flex align-items-center">
-                    <span v-if="session.is_minion" class="me-2">🤖</span>
-                    <span v-else class="me-2">💬</span>
+                    <!-- Issue #349: All sessions are minions, always show robot icon -->
+                    <span class="me-2">🤖</span>
                     <strong>{{ session.name || 'Unnamed Session' }}</strong>
                     <span
                       class="badge ms-2"
@@ -214,9 +206,9 @@ const projectSessions = computed(() => {
     .filter(s => s !== null && s !== undefined)
 })
 
-// Check if project has minions
+// Issue #349: All sessions are minions - check if project has any sessions
 const hasMinions = computed(() =>
-  projectSessions.value.some(s => s.is_minion)
+  projectSessions.value.length > 0
 )
 
 // Stats
@@ -226,13 +218,8 @@ const activeSessionCount = computed(() =>
   projectSessions.value.filter(s => s.state === 'ACTIVE').length
 )
 
-const minionCount = computed(() =>
-  projectSessions.value.filter(s => s.is_minion).length
-)
-
-const activeMinionCount = computed(() =>
-  projectSessions.value.filter(s => s.is_minion && s.state === 'ACTIVE').length
-)
+// Issue #349: minionCount and activeMinionCount removed - all sessions are minions
+// Use sessionCount and activeSessionCount instead
 
 // Overall status
 const overallStatus = computed(() => {

--- a/frontend/src/components/project/ProjectStatusLine.vue
+++ b/frontend/src/components/project/ProjectStatusLine.vue
@@ -76,7 +76,8 @@ function getTooltip(session) {
   const state = getDisplayState(session)
   const stateLabel = state.charAt(0).toUpperCase() + state.slice(1)
   const nameLabel = session.name || 'Unnamed Session'
-  const roleLabel = session.is_minion && session.role ? ` (${session.role})` : ''
+  // Issue #349: All sessions are minions - always show role if present
+  const roleLabel = session.role ? ` (${session.role})` : ''
   return `${nameLabel}${roleLabel}: ${stateLabel}`
 }
 </script>

--- a/frontend/src/components/session/SessionStateStatusLine.vue
+++ b/frontend/src/components/session/SessionStateStatusLine.vue
@@ -91,7 +91,8 @@ const statusTooltip = computed(() => {
   const state = displayState.value
   const stateLabel = state.charAt(0).toUpperCase() + state.slice(1).replace('-', ' ')
   const nameLabel = session.value.name || 'Unnamed Session'
-  const roleLabel = session.value.is_minion && session.value.role ? ` (${session.value.role})` : ''
+  // Issue #349: All sessions are minions - always show role if present
+  const roleLabel = session.value.role ? ` (${session.value.role})` : ''
 
   return `${nameLabel}${roleLabel}: ${stateLabel}`
 })

--- a/src/legion/mcp/legion_mcp_tools.py
+++ b/src/legion/mcp/legion_mcp_tools.py
@@ -1000,13 +1000,13 @@ class LegionMCPTools:
                     "is_error": True
                 }
 
-            # Scope to caller's immediate hierarchy group
+            # Scope to caller's immediate hierarchy group (issue #349: all sessions are minions)
             session_manager = self.system.session_coordinator.session_manager
             visible_ids = await self.system.comm_router.get_visible_minions(from_minion_id)
             minions = []
             for vid in visible_ids:
                 session = await session_manager.get_session_info(vid)
-                if session and (session.is_minion or session.is_overseer):
+                if session:
                     minions.append(session)
 
             # Format minion list
@@ -1457,13 +1457,13 @@ class LegionMCPTools:
             creation_timestamp = session.created_at.isoformat()
 
         # Build comprehensive identity response (Option B from issue #320)
+        # Issue #349: is_minion removed - all sessions are minions
         identity = {
             # Basic identity
             "minion_id": session.session_id,
             "minion_name": session.name,
             "role": session.role or "",
             # Hierarchy info
-            "is_minion": session.is_minion,
             "is_overseer": session.is_overseer,
             "overseer_level": session.overseer_level,
             "parent_overseer_id": session.parent_overseer_id,

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -9,7 +9,7 @@ Includes:
 
 NOTE: LegionInfo and MinionInfo have been consolidated:
 - Legions are ProjectInfo (all projects support minions - issue #313)
-- Minions are SessionInfo with is_minion=True (see src/session_manager.py)
+- All sessions are minions (is_minion field removed - issue #349)
 """
 
 from src.models.archive_models import (

--- a/src/models/legion_models.py
+++ b/src/models/legion_models.py
@@ -5,7 +5,7 @@ This module defines data structures for Legion communications.
 
 NOTE: Legion and Minion data models have been consolidated:
 - Legions are ProjectInfo (all projects support minions - issue #313)
-- Minions are SessionInfo with is_minion=True (see src/session_manager.py)
+- All sessions are minions (is_minion field removed - issue #349)
 """
 
 from dataclasses import dataclass, field

--- a/src/project_manager.py
+++ b/src/project_manager.py
@@ -27,7 +27,7 @@ class ProjectInfo:
     """Project metadata and state information.
 
     Issue #313: All projects now support Legion (multi-agent) capabilities.
-    Use session.is_minion to check if a session is a minion.
+    Issue #349: All sessions are minions (is_minion field removed).
     """
     project_id: str
     name: str

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -78,13 +78,12 @@ async def legion_test_env(request):
         # Generate session_id
         session_id = str(uuid.uuid4())
 
-        # Create session as minion (returns None)
+        # Create session (issue #349: is_minion removed - all sessions are minions)
         await session_coordinator.session_manager.create_session(
             session_id=session_id,
             working_directory=str(Path.cwd()),
             name=name,
             role=role,
-            is_minion=True,
             project_id=legion_id,
             **kwargs
         )

--- a/src/tests/integration/test_comm_tools.py
+++ b/src/tests/integration/test_comm_tools.py
@@ -38,10 +38,9 @@ async def test_create_minion_helper(legion_test_env):
     # Create test minion
     minion = await env["create_minion"]("test_minion", role="Test Role")
 
-    # Verify minion was created
+    # Verify minion was created (issue #349: is_minion removed - all sessions are minions)
     assert minion.name == "test_minion"
     assert minion.role == "Test Role"
-    assert minion.is_minion is True
     assert minion.project_id == env["legion_id"]
 
     # Verify minion session directory exists

--- a/src/tests/integration/test_lifecycle_tools.py
+++ b/src/tests/integration/test_lifecycle_tools.py
@@ -81,10 +81,10 @@ async def test_spawn_minion_minimal(legion_test_env):
 
         await asyncio.sleep(poll_interval)
 
+    # Issue #349: is_minion removed - all sessions are minions
     assert child_info is not None
     assert child_info.name == "child"
     assert child_info.role == "Child Worker"
-    assert child_info.is_minion is True
     assert child_info.project_id == legion_id
     assert child_info.parent_overseer_id == parent.session_id
 

--- a/src/tests/test_archive_manager.py
+++ b/src/tests/test_archive_manager.py
@@ -37,6 +37,7 @@ def sample_session_info():
     """Create sample SessionInfo for testing."""
     from datetime import UTC, datetime
 
+    # Issue #349: is_minion field removed - all sessions are minions
     return SessionInfo(
         session_id="test-minion-123",
         state=SessionState.ACTIVE,
@@ -45,7 +46,6 @@ def sample_session_info():
         name="TestMinion",
         role="Test Role",
         project_id="test-legion-456",
-        is_minion=True,
         overseer_level=1,
         child_minion_ids=["child-1", "child-2"]
     )

--- a/src/tests/test_capability_registry.py
+++ b/src/tests/test_capability_registry.py
@@ -22,13 +22,12 @@ from src.session_manager import SessionInfo, SessionState
 
 @pytest.fixture
 def sample_minion_1():
-    """Create a sample minion SessionInfo (DatabaseExpert)."""
+    """Create a sample minion SessionInfo (DatabaseExpert). Issue #349: is_minion removed."""
     mock = Mock(spec=SessionInfo)
     mock.session_id = "minion-db-123"
     mock.name = "DatabaseExpert"
     mock.project_id = "legion-456"
     mock.role = "Database architecture and schema design"
-    mock.is_minion = True
     mock.state = SessionState.ACTIVE
     mock.capabilities = ["postgresql", "database_design", "sql_optimization"]
     mock.expertise_score = 0.9
@@ -37,13 +36,12 @@ def sample_minion_1():
 
 @pytest.fixture
 def sample_minion_2():
-    """Create a sample minion SessionInfo (BackendDev)."""
+    """Create a sample minion SessionInfo (BackendDev). Issue #349: is_minion removed."""
     mock = Mock(spec=SessionInfo)
     mock.session_id = "minion-backend-456"
     mock.name = "BackendDev"
     mock.project_id = "legion-456"
     mock.role = "Python backend development"
-    mock.is_minion = True
     mock.state = SessionState.ACTIVE
     mock.capabilities = ["python", "fastapi", "database"]
     mock.expertise_score = 0.6
@@ -52,13 +50,12 @@ def sample_minion_2():
 
 @pytest.fixture
 def sample_minion_3():
-    """Create a sample minion SessionInfo (FrontendDev)."""
+    """Create a sample minion SessionInfo (FrontendDev). Issue #349: is_minion removed."""
     mock = Mock(spec=SessionInfo)
     mock.session_id = "minion-frontend-789"
     mock.name = "FrontendDev"
     mock.project_id = "legion-456"
     mock.role = "Vue.js frontend development"
-    mock.is_minion = True
     mock.state = SessionState.ACTIVE
     mock.capabilities = ["vue", "javascript", "frontend"]
     mock.expertise_score = 0.7
@@ -67,13 +64,12 @@ def sample_minion_3():
 
 @pytest.fixture
 def sample_minion_zero_score():
-    """Create a sample minion with zero expertise score."""
+    """Create a sample minion with zero expertise score. Issue #349: is_minion removed."""
     mock = Mock(spec=SessionInfo)
     mock.session_id = "minion-zero-999"
     mock.name = "ZeroScoreMinion"
     mock.project_id = "legion-456"
     mock.role = "Unproven minion"
-    mock.is_minion = True
     mock.state = SessionState.ACTIVE
     mock.capabilities = ["python"]
     mock.expertise_score = 0.0
@@ -107,12 +103,9 @@ def legion_coordinator(mock_legion_system):
     """Create LegionCoordinator with mocked dependencies."""
     coordinator = LegionCoordinator(mock_legion_system)
 
-    # Mock get_minion_info to delegate to session_manager
+    # Mock get_minion_info to delegate to session_manager (issue #349: all sessions are minions)
     async def mock_get_minion_info(minion_id):
-        session = await mock_legion_system.session_coordinator.session_manager.get_session_info(minion_id)
-        if session and session.is_minion:
-            return session
-        return None
+        return await mock_legion_system.session_coordinator.session_manager.get_session_info(minion_id)
 
     coordinator.get_minion_info = AsyncMock(side_effect=mock_get_minion_info)
 

--- a/src/tests/test_comm_router.py
+++ b/src/tests/test_comm_router.py
@@ -18,12 +18,11 @@ def legion_system():
     """Create mock LegionSystem for testing."""
     from src.session_manager import SessionInfo, SessionState
 
-    # Create a default active minion for tests
+    # Create a default active minion for tests (issue #349: is_minion removed)
     default_minion = Mock(spec=SessionInfo)
     default_minion.session_id = "test-minion-123"
     default_minion.name = "TestMinion"
     default_minion.project_id = "test-legion-456"
-    default_minion.is_minion = True
     default_minion.state = SessionState.ACTIVE
 
     mock_session_coordinator = Mock()
@@ -53,13 +52,12 @@ def comm_router(legion_system):
 
 @pytest.fixture
 def sample_minion():
-    """Create a sample minion SessionInfo."""
+    """Create a sample minion SessionInfo (issue #349: is_minion removed)."""
     from src.session_manager import SessionInfo, SessionState
     mock = Mock(spec=SessionInfo)
     mock.session_id = "test-minion-123"
     mock.name = "TestMinion"
     mock.project_id = "test-legion-456"
-    mock.is_minion = True
     mock.state = SessionState.ACTIVE
     return mock
 


### PR DESCRIPTION
## Summary

- Removes `is_minion` field from `SessionInfo` since all sessions are now minions (Universal Legion - issue #313)
- The field was always `True`, making it dead code
- Follows same pattern as #366 for `is_multi_agent` removal

## Changes

### Backend
- Remove `is_minion` field from `SessionInfo` dataclass
- Keep `from_dict()` silently ignoring old data for backward compatibility
- Remove `is_minion` parameter from `create_session` methods
- Simplify conditionals that were always true
- Remove `is_minion` from `whoami` MCP tool response (breaking change for MCP clients)
- Update `get_minion_info()` and `get_minion_by_name()` to return all sessions

### Frontend
- Change `hasMinions` computed property to check `projectSessions.length > 0`
- Remove `is_minion` checks in watch filters
- Remove redundant "Minions" stats card (same as "Sessions" now)
- Always show robot icon for sessions
- Simplify role display (always show if present)

### Tests
- Remove `is_minion` from mock session fixtures
- Update test assertions to not check `is_minion`
- Update test names/docstrings

## Test plan
- [x] All session manager tests pass (38/38)
- [x] MCP tools tests pass
- [x] Frontend builds successfully
- [x] Server starts and API responds without is_minion field

## Breaking Changes
- `whoami` MCP tool no longer returns `is_minion` field
- Clients that check `is_minion` will need to update

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)