### PR TITLE
fix(#391): improve task panel resize handle responsiveness

### DIFF
--- a/frontend/src/components/layout/RightSidebar.vue
+++ b/frontend/src/components/layout/RightSidebar.vue
@@ -4,7 +4,8 @@
     class="bg-light border-start d-flex flex-column overflow-auto"
     :class="{
       'collapsed': rightSidebarCollapsed,
-      'mobile-open': !rightSidebarCollapsed && isMobile
+      'mobile-open': !rightSidebarCollapsed && isMobile,
+      'resizing': isResizing
     }"
     :style="sidebarStyle"
   >
@@ -50,6 +51,7 @@ const sidebarStyle = computed(() => {
 const isResizing = ref(false)
 
 function startResize(event) {
+  event.preventDefault()
   isResizing.value = true
   document.addEventListener('mousemove', handleResize)
   document.addEventListener('mouseup', stopResize)
@@ -80,6 +82,10 @@ function stopResize() {
   width: 0 !important;
   min-width: 0 !important;
   overflow: hidden;
+}
+
+#right-sidebar.resizing {
+  transition: none;
 }
 
 .sidebar-resize-handle {


### PR DESCRIPTION
## Summary
Resolves #391

Fixes unreliable mouse interaction with the Task Panel resize handle by disabling CSS transitions during drag operations and preventing text selection.

## Changes Made
- Add `resizing` CSS class binding that toggles during drag operations
- Add CSS rule `#right-sidebar.resizing { transition: none; }` to disable width animation during resize
- Add `event.preventDefault()` call in `startResize()` to prevent text selection during drag

## Testing
- Drag resize handle left → panel expands instantly without lag
- Drag resize handle right → panel contracts instantly
- Multiple resize operations work consistently
- No text selection occurs during drag
- Collapse/expand button animation still works (transitions preserved when not resizing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)