### PR TITLE
feat(security): add --lockdown-mode to restrict WebUI to localhost only

### DIFF
--- a/main.py
+++ b/main.py
@@ -43,6 +43,10 @@ Debug Flags:
     parser.add_argument('--host', default='0.0.0.0', help='Host to bind to (default: 0.0.0.0)')
     parser.add_argument('--port', type=int, default=8000, help='Port to bind to (default: 8000)')
     parser.add_argument('--data-dir', default='./data', help='Data directory location (default: ./data)')
+    parser.add_argument(
+        '--lockdown-mode', action='store_true',
+        help='Restrict server to localhost only (127.0.0.1) for security'
+    )
 
     # Debug flags
     parser.add_argument('--debug-websocket', action='store_true', help='Enable WebSocket lifecycle debugging')
@@ -94,10 +98,18 @@ Debug Flags:
     app.add_event_handler("startup", startup_event)
     app.add_event_handler("shutdown", shutdown_event)
 
+    # Handle lockdown mode - restrict to localhost only
+    effective_host = args.host
+    if args.lockdown_mode:
+        if args.host != '0.0.0.0' and args.host != '127.0.0.1':
+            print(f"WARNING: Lockdown mode overriding --host {args.host} to 127.0.0.1")
+        effective_host = '127.0.0.1'
+        print("Running in lockdown mode - listening on 127.0.0.1 only")
+
     # Run the server
     uvicorn.run(
         app,
-        host=args.host,
+        host=effective_host,
         port=args.port,
         log_level="info",
         access_log=True


### PR DESCRIPTION
## Summary

- Adds `--lockdown-mode` CLI flag to restrict server binding to `127.0.0.1`
- Prevents network access from other machines when enabled
- Logs warning if `--host` flag is explicitly set and overridden
- Displays "Running in lockdown mode" message on startup

## Test Plan

- [x] Run `uv run python main.py --lockdown-mode --port 8409` - verify server binds to 127.0.0.1
- [x] Verify lockdown mode message appears in startup output
- [x] Test `--lockdown-mode --host 192.168.1.100` - verify warning message appears
- [x] Run without `--lockdown-mode` - verify default behavior (0.0.0.0) unchanged
- [x] Ruff linting passes

Resolves #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)