### PR TITLE
chore(#411): update claude-agent-sdk to 0.1.31

### DIFF
--- a/main.py
+++ b/main.py
@@ -60,6 +60,9 @@ Debug Flags:
     parser.add_argument('--debug-template-manager', action='store_true', help='Enable template manager debugging')
     parser.add_argument('--debug-all', action='store_true', help='Enable all debug logging (excludes ping/pong)')
 
+    # Experimental features
+    parser.add_argument('--experimental', action='store_true', help='Enable experimental features (Agent Teams)')
+
     args = parser.parse_args()
 
     # Validate and create data directory
@@ -88,7 +91,7 @@ Debug Flags:
     )
 
     # Create FastAPI app
-    app = create_app(data_dir=data_dir_path)
+    app = create_app(data_dir=data_dir_path, experimental=args.experimental)
 
     # Add startup/shutdown events
     app.add_event_handler("startup", startup_event)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "uvicorn>=0.24.0",
     "websockets>=12.0",
     "pydantic>=2.5.0",
-    "claude-agent-sdk==0.1.23",
+    "claude-agent-sdk==0.1.31",
 ]
 
 [project.optional-dependencies]

--- a/src/claude_sdk.py
+++ b/src/claude_sdk.py
@@ -139,7 +139,8 @@ class ClaudeSDK:
         mcp_servers: list[Any] | None = None,
         sandbox_enabled: bool = False,
         sandbox_config: dict | None = None,
-        setting_sources: list[str] | None = None
+        setting_sources: list[str] | None = None,
+        experimental: bool = False
     ):
         """
         Initialize enhanced Claude Code SDK wrapper.
@@ -160,6 +161,7 @@ class ClaudeSDK:
             sandbox_enabled: Enable OS-level sandboxing (issue #319)
             sandbox_config: Optional SandboxSettings configuration dict
             setting_sources: List of settings sources to load (issue #36)
+            experimental: Enable experimental features like Agent Teams (issue #411)
         """
         self.session_id = session_id
         self.working_directory = Path(working_directory)
@@ -183,6 +185,7 @@ class ClaudeSDK:
         self.sandbox_enabled = sandbox_enabled
         self.sandbox_config = sandbox_config
         self.setting_sources = setting_sources  # Issue #36: which settings files to load
+        self.experimental = experimental  # Issue #411: Enable experimental features
 
         self.info = SessionInfo(session_id=session_id, working_directory=str(self.working_directory))
 
@@ -737,7 +740,12 @@ class ClaudeSDK:
             sdk_logger.info(f"Sandbox enabled for session {self.session_id}: {sandbox_settings}")
 
         # Enable native Tasks system (Claude Code 2.1+)
-        options_kwargs["env"] = {"CLAUDE_CODE_ENABLE_TASKS": "true"}
+        env_vars = {"CLAUDE_CODE_ENABLE_TASKS": "true"}
+        # Issue #411: Enable Agent Teams when experimental flag is set
+        if self.experimental:
+            env_vars["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"] = "1"
+            sdk_logger.info(f"Experimental Agent Teams enabled for session {self.session_id}")
+        options_kwargs["env"] = env_vars
 
         # Add stderr callback to capture SDK CLI errors
         def stderr_handler(output: str) -> None:

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -51,8 +51,9 @@ class SessionCoordinator:
     - Real-time communication pipeline
     """
 
-    def __init__(self, data_dir: Path = None):
+    def __init__(self, data_dir: Path = None, experimental: bool = False):
         self.data_dir = data_dir or Path("data")
+        self.experimental = experimental
         self.session_manager = SessionManager(self.data_dir)
         self.project_manager = ProjectManager(self.data_dir)
         self.message_parser = MessageParser()
@@ -309,7 +310,8 @@ class SessionCoordinator:
                 model=model,
                 mcp_servers=mcp_servers if mcp_servers else None,
                 sandbox_enabled=sandbox_enabled,
-                sandbox_config=sandbox_config
+                sandbox_config=sandbox_config,
+                experimental=self.experimental
             )
             self._active_sdks[session_id] = sdk
 
@@ -620,7 +622,8 @@ class SessionCoordinator:
                 mcp_servers=mcp_servers if mcp_servers else None,
                 sandbox_enabled=session_info.sandbox_enabled,
                 sandbox_config=session_info.sandbox_config,
-                setting_sources=session_info.setting_sources  # Issue #36
+                setting_sources=session_info.setting_sources,  # Issue #36
+                experimental=self.experimental
             )
             self._active_sdks[session_id] = sdk
 

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -344,9 +344,9 @@ class LegionWebSocketManager:
 class ClaudeWebUI:
     """Main WebUI application class"""
 
-    def __init__(self, data_dir: Path = None):
+    def __init__(self, data_dir: Path = None, experimental: bool = False):
         self.app = FastAPI(title="Claude Code WebUI", version="1.0.0")
-        self.coordinator = SessionCoordinator(data_dir)
+        self.coordinator = SessionCoordinator(data_dir, experimental=experimental)
         self.websocket_manager = WebSocketManager()
         self.ui_websocket_manager = UIWebSocketManager()
         self.legion_websocket_manager = LegionWebSocketManager()
@@ -2615,10 +2615,10 @@ class ClaudeWebUI:
 # Global application instance
 webui_app = None
 
-def create_app(data_dir: Path = None) -> FastAPI:
+def create_app(data_dir: Path = None, experimental: bool = False) -> FastAPI:
     """Create and configure the FastAPI application"""
     global webui_app
-    webui_app = ClaudeWebUI(data_dir)
+    webui_app = ClaudeWebUI(data_dir, experimental=experimental)
     return webui_app.app
 
 async def startup_event():

--- a/uv.lock
+++ b/uv.lock
@@ -124,18 +124,18 @@ wheels = [
 
 [[package]]
 name = "claude-agent-sdk"
-version = "0.1.23"
+version = "0.1.31"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "mcp" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/45/760b2f3292b7de21108d15bfc1fcab2da0ddbf4ff2590dd8b114f89dfe6a/claude_agent_sdk-0.1.23.tar.gz", hash = "sha256:c3002869e3e9e6868d195aaf475166a3ddef0a78b78eb1585220142657ccb3c6", size = 57112, upload-time = "2026-01-27T01:46:16.843Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/df/071dce5803c4db8cd53708bcda3b6022c1c4b68fc00e9007593309515286/claude_agent_sdk-0.1.31.tar.gz", hash = "sha256:b68c681083d7cc985dd3e48f73aabf459f056c1a7e1c5b9c47033c6af94da1a1", size = 61191, upload-time = "2026-02-06T02:01:51.043Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/bb/35f6cebabc94beaa81042fc195f2fbc6a586498d18700f657e5acd434433/claude_agent_sdk-0.1.23-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d91e1d431c5b7ba41791068d63f883b579d7314cb7cb4d9e401b68bf6440c1a2", size = 54527103, upload-time = "2026-01-27T01:46:01.621Z" },
-    { url = "https://files.pythonhosted.org/packages/28/33/0511fdf5b21d10947ab5e839a63b60034bf4cff31777e5237e9dc99fea14/claude_agent_sdk-0.1.23-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:2575f38a39e7e64a84cbd7144b4485b5cdcef88e35aab6ef42ceb919747d0e2d", size = 68705060, upload-time = "2026-01-27T01:46:07.024Z" },
-    { url = "https://files.pythonhosted.org/packages/76/6e/0e41f496ac979243e8bb2ee80899587377ecfda2979fb8a994861b9857b2/claude_agent_sdk-0.1.23-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:a392700455741d0ad0ef50412f6babd56657ba0ebc7a5bd26a13b82d4c4ae078", size = 70420014, upload-time = "2026-01-27T01:46:10.669Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/92/bb00bd631c4d88d9fbf1417a864c2645b992259886123c0e44ccfe87f355/claude_agent_sdk-0.1.23-py3-none-win_amd64.whl", hash = "sha256:05a44208a199cbd7c6cce034d3f91be3cb1a2b11df8e85bedb7c0e31c783d8c7", size = 72624773, upload-time = "2026-01-27T01:46:14.094Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/7c/e249a3b4215e28a9722b3d9ab6057bceeeaa2b948530f022065ef2154555/claude_agent_sdk-0.1.31-py3-none-macosx_11_0_arm64.whl", hash = "sha256:801bacfe4192782a7cc7b61b0d23a57f061c069993dd3dfa8109aa2e7050a530", size = 54284257, upload-time = "2026-02-06T02:01:35.61Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a8/1a8288736aeafcc48e3dcb3326ec7f487dbf89ebba77d526e9464786a299/claude_agent_sdk-0.1.31-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:0b608e0cbfcedcb827427e6d16a73fe573d58e7f93e15f95435066feacbe6511", size = 68462461, upload-time = "2026-02-06T02:01:40.074Z" },
+    { url = "https://files.pythonhosted.org/packages/26/7a/7dcd0b77263ed55b17554fa3a67a6772b788e7048a524fd06c9baa970564/claude_agent_sdk-0.1.31-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:d0cb30e026a22246e84d9237d23bb4df20be5146913a04d2802ddd37d4f8b8c9", size = 70173234, upload-time = "2026-02-06T02:01:44.486Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a5/4a8de7a9738f454b54aa97557f0fba9c74b0901ea418597008c668243fea/claude_agent_sdk-0.1.31-py3-none-win_amd64.whl", hash = "sha256:8ceca675c2770ad739bd1208362059a830e91c74efcf128045b5a7af14d36f2b", size = 72366975, upload-time = "2026-02-06T02:01:48.647Z" },
 ]
 
 [[package]]
@@ -168,7 +168,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
-    { name = "claude-agent-sdk", specifier = "==0.1.23" },
+    { name = "claude-agent-sdk", specifier = "==0.1.31" },
     { name = "fastapi", specifier = ">=0.104.0" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.7.0" },


### PR DESCRIPTION
## Summary
Resolves #411

Update claude-agent-sdk from 0.1.23 to 0.1.31 and add `--experimental` CLI flag for opt-in experimental features (Agent Teams).

## Changes Made
- Update SDK version in `pyproject.toml` (0.1.23 → 0.1.31)
- Add `--experimental` CLI argument to `main.py`
- Propagate experimental flag through `ClaudeWebUI` → `SessionCoordinator` → `ClaudeSDK`
- Set `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` env var when experimental mode enabled
- Update `uv.lock` with new SDK version

## SDK Changes (0.1.23 → 0.1.31)
| Version | Key Changes |
|---------|-------------|
| 0.1.31 | MCP tool annotations (`ToolAnnotations`), large agent definitions fix |
| 0.1.30 | Agent Teams research preview (CLI 2.1.32) |
| 0.1.29 | New hook events (`Notification`, `SubagentStart`, `PermissionRequest`) |
| 0.1.28 | `AssistantMessage.error` field bugfix |
| 0.1.26 | `PostToolUseFailure` hook event |

No breaking changes - all existing imports remain compatible.

## Testing
- All 265 tests pass (4 pre-existing failures unrelated to this change)
- Backend starts successfully without `--experimental` flag (normal mode)
- Backend starts successfully with `--experimental` flag (Agent Teams enabled)
- Frontend builds successfully
- Health endpoint responds correctly

Test servers running on:
- Backend: http://localhost:8411
- Frontend: Production build served from backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)