### PR TITLE
chore(#445): add explicit user approval requirement to templates

### DIFF
--- a/src/default_templates/issue_planner.md
+++ b/src/default_templates/issue_planner.md
@@ -71,9 +71,15 @@ Transform an issue into a detailed, approved implementation plan through user co
    - Add `ready-to-build` label: `gh issue edit ${ISSUE_NUMBER} --add-label "ready-to-build"`
 
 10. **Signal Completion**
-    - Send comm to Orchestrator: "Plan ready for issue #${ISSUE_NUMBER}"
+    - Send comm to Orchestrator: "Plan posted for issue #${ISSUE_NUMBER}, awaiting user approval"
     - comm_type: "report"
-    - Include summary of the approved plan
+    - Include summary of the plan
+
+    ⚠️ **CRITICAL**: Your comm is **informational only**. It does NOT trigger the Build phase.
+    The user must explicitly invoke `/approve_plan ${ISSUE_NUMBER}` when they are satisfied.
+    You remain active for potential iteration — the user may request revisions, ask questions,
+    or refine the plan further. Do NOT attempt to advance the workflow or modify the plan
+    without explicit user direction.
 
 ## Communication Requirements
 
@@ -154,3 +160,4 @@ Your planning phase is complete when:
 - [x] Implementation plan finalized
 - [x] Plan posted and marked as approved (via custom-plan-manager or GitHub comment + label)
 - [x] Orchestrator notified with completion comm
+- [x] Waiting for user to invoke `/approve_plan` (do NOT auto-advance)

--- a/src/default_templates/orchestrator.md
+++ b/src/default_templates/orchestrator.md
@@ -19,8 +19,10 @@ When user requests work on an issue:
    - Marks plan as approved
 3. Planner signals completion via comm
 
+⚠️ **CRITICAL: Do NOT proceed to the Build phase until the user explicitly runs `/approve_plan <number>`.** Planner comms saying "plan ready" or "plan posted" are **informational status updates**, NOT approval signals. The user may want to iterate with the Planner, request revisions, or ask clarifying questions. Only the explicit `/approve_plan` command from the user indicates approval. Do not dispose the Planner or spawn a Builder until this command is received.
+
 ### Phase 2: Building
-When plan is approved:
+When user has explicitly approved the plan via `/approve_plan`:
 1. Use `/approve_plan <number>` command:
    - Disposes Planner minion (knowledge archived)
    - Invokes `custom-environment-setup` if available (for Builder config)


### PR DESCRIPTION
## Summary

- **IssuePlanner template**: Rewrote Step 10 "Signal Completion" to clarify that the comm to Orchestrator is informational only and does NOT trigger the Build phase. Added explicit wait language requiring user to invoke `/approve_plan`. Added success criterion for waiting.
- **Orchestrator template**: Inserted critical gate warning between Phase 1 (Planning) and Phase 2 (Building) emphasizing that Planner comms are status updates, not approval signals. Updated Phase 2 opening to reference explicit `/approve_plan` command.

## Test plan

- [x] Backend starts and health endpoint returns healthy
- [x] Unit tests pass (265 passed, 4 pre-existing failures unrelated to this change)
- [x] No Python or frontend code modified — template text changes only
- [ ] Manual verification: Spawn Orchestrator + Planner, confirm Planner stops at plan posting and Orchestrator waits for `/approve_plan`

**Note**: Existing template copies in `data/templates/` are NOT overwritten by `create_default_templates()`. Users with pre-existing templates must delete their local copies to pick up these changes.

Resolves #445