### PR TITLE
feat(#454): replace GitHub-based plan storage with file-based system

### DIFF
--- a/.claude/skills/custom-plan-manager/SKILL.md
+++ b/.claude/skills/custom-plan-manager/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: custom-plan-manager
+description: GitHub-based plan storage for the Planner/Builder workflow (marketplace plugin)
+disable-model-invocation: true
+argument-hint: <operation> <issue_number> [stage]
+allowed-tools:
+  - Bash(gh issue:*)
+  - Bash(ls:*)
+  - Skill(github-issue-reader)
+---
+
+## Custom Plan Manager (GitHub)
+
+GitHub-based plan storage using issue comments and labels. This is a marketplace plugin that overrides the default file-based `plan-manager` when placed in a project's `.claude/skills/` directory.
+
+When this skill is present, all workflow skills (`plan_issue`, `approve_plan`, `approve_issue`) and templates will use GitHub for plan storage instead of local files.
+
+### Operations
+
+The first argument (`$1`) is the operation. The second argument (`$2`) is the issue number. The optional third argument (`$3`) is the stage name.
+
+**Supported operations:**
+- `fetch-issue` - Retrieve issue details from GitHub
+- `write-plan` - Post plan as GitHub comment and add `ready-to-build` label
+- `read-plan` - Read latest plan comment from GitHub issue
+- `verify-plan` - Check for `ready-to-build` label on issue
+- `delete-plan` - Remove `ready-to-build` label from issue
+
+---
+
+### Operation: fetch-issue
+
+**Usage:** `custom-plan-manager fetch-issue <issue_number>`
+
+Delegates to `github-issue-reader` skill to fetch issue details from GitHub.
+
+**Steps:**
+1. Invoke the `github-issue-reader` skill with issue number $2
+2. Return the issue details to the caller
+
+---
+
+### Operation: write-plan
+
+**Usage:** `custom-plan-manager write-plan <issue_number> [stage]`
+
+Posts the plan as a GitHub issue comment and marks the issue as ready to build.
+
+**Steps:**
+
+1. **Post plan as comment:**
+   ```bash
+   gh issue comment $2 --body "<plan_content>"
+   ```
+   The plan content should be the finalized implementation plan approved by the user.
+   If a stage is specified, prefix the comment with `## Stage: $3` for clarity.
+
+2. **Add ready-to-build label:**
+   ```bash
+   gh issue edit $2 --add-label "ready-to-build"
+   ```
+
+3. **Report result:**
+   Output confirmation that the plan was posted to the issue.
+
+---
+
+### Operation: read-plan
+
+**Usage:** `custom-plan-manager read-plan <issue_number> [stage]`
+
+Reads the latest plan comment from the GitHub issue.
+
+**Steps:**
+
+1. **Fetch latest comment:**
+   ```bash
+   gh issue view $2 --comments
+   ```
+
+2. **Extract plan:**
+   Find the most recent comment containing `## Implementation Plan` (or `## Stage: $3` if stage provided).
+
+3. **Handle missing plan:**
+   If no plan comment found, report:
+   ```
+   Error: No plan comment found on issue #$2. Has the Planner posted the plan yet?
+   ```
+
+4. **Return content:**
+   Return the full plan content to the caller.
+
+---
+
+### Operation: verify-plan
+
+**Usage:** `custom-plan-manager verify-plan <issue_number> [stage]`
+
+Checks for the `ready-to-build` label on the issue.
+
+**Steps:**
+
+1. **Check label:**
+   ```bash
+   gh issue view $2 --json labels --jq '.labels[].name' | grep -q "ready-to-build"
+   ```
+
+2. **Report result:**
+   - If label present: `Plan verified: issue #$2 has ready-to-build label`
+   - If label missing: `Warning: issue #$2 does not have ready-to-build label. Planner may not have marked the plan as approved.`
+
+---
+
+### Operation: delete-plan
+
+**Usage:** `custom-plan-manager delete-plan <issue_number> [stage]`
+
+Removes the `ready-to-build` label during cleanup. Does not delete the comment (preserves history).
+
+**Steps:**
+
+1. **Remove label:**
+   ```bash
+   gh issue edit $2 --remove-label "ready-to-build"
+   ```
+
+2. **Report result:**
+   ```
+   Removed ready-to-build label from issue #$2
+   ```
+
+---
+
+### Important Notes
+
+- This is a **marketplace plugin** — place in `.claude/skills/custom-plan-manager/` to activate
+- When present, it overrides the default file-based `plan-manager`
+- Preserves the original GitHub-based workflow for teams that prefer it
+- Requires `gh` CLI to be authenticated (`gh auth status`)
+- Stage parameter is informational for GitHub (used in comment headers, not file paths)
+- Comment history is preserved even after `delete-plan` (only label is removed)
+- To switch back to file-based storage, simply remove this skill directory

--- a/src/default_skills/approve_issue/SKILL.md
+++ b/src/default_skills/approve_issue/SKILL.md
@@ -2,38 +2,58 @@
 name: approve_issue
 description: Approve completed issue work, merge PR, and clean up resources
 disable-model-invocation: true
-argument-hint: <issue_number>
+argument-hint: <issue_number> [stage]
 allowed-tools:
   - Bash(git branch -d:*)
   - Bash(git checkout:*)
   - Bash(git pull:*)
   - Bash(gh pr:*)
+  - Bash(rm:*)
   - Bash(ls:*)
   - Skill(github-pr-manager)
   - Skill(custom-cleanup-process)
+  - Skill(custom-plan-manager)
+  - Skill(plan-manager)
   - Skill(worktree-manager)
 ---
 
 ## Approve Issue
 
-This skill is called when the user is satisfied with the completed work. It merges the PR, runs project-specific cleanup, disposes the Builder, and removes the worktree.
+This skill is called when the user is satisfied with the completed work. It merges the PR, runs project-specific cleanup, disposes both the Planner and Builder, deletes the plan file, and removes the worktree.
+
+### Arguments
+
+- `$1` — Issue number (required)
+- `$2` — Stage name (optional, must match the stage used in `/plan_issue`)
+
+### Suffix Convention
+
+Compute the suffix (same as plan_issue):
+- If `$2` (stage) is provided: suffix = `$1-$2`
+- If no stage: suffix = `$1`
 
 ### Workflow
 
 You are approving and cleaning up issue #$1. Follow these steps:
 
-#### 1. Verify Builder Status
+#### 1. Compute Suffix
 
-**Invoke `mcp__legion__get_minion_info`** for `Builder-$1`:
+Determine the naming suffix:
+- If `$2` is provided: suffix = `$1-$2`
+- If `$2` is not provided: suffix = `$1`
+
+#### 2. Verify Builder Status
+
+**Invoke `mcp__legion__get_minion_info`** for `Builder-{suffix}`:
 - Verify Builder exists and has completed work
 - Get worktree path and PR information
 
 If Builder doesn't exist, check if work was done manually.
 
-#### 2. Verify PR Status
+#### 3. Verify PR Status
 
 **Invoke the `github-pr-manager` skill** to check PR status:
-- Find PR for branch `feature/issue-$1`
+- Find PR for branch `feat/issue-{suffix}`
 - Verify PR is open and mergeable
 - Check CI checks are passing
 - Verify no merge conflicts
@@ -43,7 +63,7 @@ If PR is not ready:
 - Ask user to resolve issues first
 - Exit without merging
 
-#### 3. Run Project-Specific Cleanup (if custom skill exists)
+#### 4. Run Project-Specific Cleanup (if custom skill exists)
 
 Check if `custom-cleanup-process` skill exists:
 ```bash
@@ -58,7 +78,7 @@ The custom skill handles project-specific cleanup such as:
 
 If it does not exist, skip project-specific cleanup and proceed with generic cleanup.
 
-#### 4. Merge PR
+#### 5. Merge PR
 
 **Invoke the `github-pr-manager` skill** to merge:
 - Squash merge the PR only
@@ -68,19 +88,42 @@ If it does not exist, skip project-specific cleanup and proceed with generic cle
 gh pr merge --squash
 ```
 
-#### 5. Dispose Builder
+#### 6. Dispose Planner
 
 **Invoke `mcp__legion__dispose_minion`** with:
-- **minion_name**: `Builder-$1`
+- **minion_name**: `Planner-{suffix}`
+- **delete**: true
+
+If Planner doesn't exist (already disposed or manual workflow), warn but continue.
+
+#### 7. Dispose Builder
+
+**Invoke `mcp__legion__dispose_minion`** with:
+- **minion_name**: `Builder-{suffix}`
 - **delete**: true
 
 The Builder's knowledge is archived before deletion.
 
-#### 6. Remove Worktree
+If Builder doesn't exist (manual workflow), warn but continue.
+
+#### 8. Delete Plan File
+
+Check if `custom-plan-manager` skill exists:
+```bash
+ls .claude/skills/custom-plan-manager/SKILL.md 2>/dev/null
+```
+
+If it exists, **invoke the `custom-plan-manager` skill** with operation=`delete-plan`, issue_number=$1, and stage=$2 (if provided).
+
+If it does not exist, **invoke the `plan-manager` skill** with operation=`delete-plan`, issue_number=$1, and stage=$2 (if provided).
+
+This removes the plan file from `~/.cc_webui/plans/` (or removes the `ready-to-build` label if using GitHub).
+
+#### 9. Remove Worktree
 
 **Invoke the `worktree-manager` skill** to remove worktree:
-- Worktree: `issue-$1`
-- Location: `worktrees/issue-$1/`
+- Worktree: `issue-{suffix}`
+- Location: `worktrees/issue-{suffix}/`
 
 The skill will:
 - Verify worktree exists
@@ -88,14 +131,14 @@ The skill will:
 - Clean up any locks if needed
 - Prune worktree references
 
-#### 7. Clean Up Local Branch
+#### 10. Clean Up Local Branch
 
 Delete the local branch (if exists):
 ```bash
-git branch -d feature/issue-$1 2>/dev/null || true
+git branch -d feat/issue-{suffix} 2>/dev/null || true
 ```
 
-#### 8. Pull Latest Main
+#### 11. Pull Latest Main
 
 Update main with the merged changes:
 ```bash
@@ -103,27 +146,31 @@ git checkout main
 git pull origin main
 ```
 
-#### 9. Confirm Cleanup
+#### 12. Confirm Cleanup
 
 Inform user:
 ```
-Issue #$1 approved and cleaned up!
+Issue #$1 approved and cleaned up!{" (stage: $2)" if stage provided}
 
 Completed Actions:
 - PR merged (squash merge)
 - Project-specific cleanup completed (if configured)
-- Builder disposed (knowledge archived)
-- Worktree removed: worktrees/issue-$1/
+- Planner disposed: Planner-{suffix} (knowledge archived)
+- Builder disposed: Builder-{suffix} (knowledge archived)
+- Plan file deleted: ~/.cc_webui/plans/issue-{suffix}.md
+- Worktree removed: worktrees/issue-{suffix}/
 - Branch cleaned up with worktree
 - Main branch updated
 
-Ready to start new issues with /plan_issue <number>
+Ready to start new issues with /plan_issue <number> [stage]
 ```
 
 ### Skills Used
 
 - **mcp__legion__get_minion_info** - Verify Builder status
-- **mcp__legion__dispose_minion** - Dispose Builder
+- **mcp__legion__dispose_minion** - Dispose Planner and Builder
+- **custom-plan-manager** - Delete plan (if exists, overrides plan-manager)
+- **plan-manager** - Delete plan file (default)
 - **custom-cleanup-process** - Project-specific cleanup (if exists)
 - **github-pr-manager** - Check and merge PR
 - **worktree-manager** - Remove worktree
@@ -143,15 +190,24 @@ Ready to start new issues with /plan_issue <number>
 - Warn but continue with cleanup
 - May have been cleaned up manually
 
+**Planner not found:**
+- Warn but continue with cleanup
+- May have been disposed manually or was never spawned
+
 **Builder not found:**
 - Warn but continue with PR merge and cleanup
 - Manual work doesn't require minion disposal
+
+**Plan file not found:**
+- Warn but continue with cleanup
+- May have been deleted manually
 
 ### Important Notes
 
 - This is a destructive operation - resources are permanently removed
 - PR is squash-merged for clean history
 - Project-specific cleanup runs before merge (via custom-cleanup-process)
-- All minions are disposed
+- Both Planner and Builder are disposed (Planner was kept alive since /approve_plan)
+- Plan file is deleted from ~/.cc_webui/plans/
 - Worktree is permanently deleted
 - Main branch is updated with merged changes

--- a/src/default_skills/approve_plan/SKILL.md
+++ b/src/default_skills/approve_plan/SKILL.md
@@ -2,62 +2,73 @@
 name: approve_plan
 description: Approve a plan and spawn a Builder to implement it
 disable-model-invocation: true
-argument-hint: <issue_number>
+argument-hint: <issue_number> [stage]
 allowed-tools:
   - Bash(git worktree:*)
-  - Bash(gh issue view:*)
   - Bash(ls:*)
   - Skill(custom-plan-manager)
+  - Skill(plan-manager)
   - Skill(custom-environment-setup)
 ---
 
 ## Approve Plan
 
-This skill is called when a Planner has finished and the user approves the plan. It disposes the Planner and spawns a Builder to implement the approved plan.
+This skill is called when a Planner has finished and the user approves the plan. It spawns a Builder to implement the approved plan. The Planner remains alive (idle) until `/approve_issue`.
+
+### Arguments
+
+- `$1` — Issue number (required)
+- `$2` — Stage name (optional, must match the stage used in `/plan_issue`)
+
+### Suffix Convention
+
+Compute the suffix (same as plan_issue):
+- If `$2` (stage) is provided: suffix = `$1-$2`
+- If no stage: suffix = `$1`
 
 ### Workflow
 
 You are transitioning from planning to building for issue #$1. Follow these steps:
 
-#### 1. Verify Planner Status
+#### 1. Compute Suffix
 
-**Invoke `mcp__legion__get_minion_info`** for `Planner-$1`:
+Determine the naming suffix:
+- If `$2` is provided: suffix = `$1-$2`
+- If `$2` is not provided: suffix = `$1`
+
+#### 2. Verify Planner Status
+
+**Invoke `mcp__legion__get_minion_info`** for `Planner-{suffix}`:
 - Verify Planner exists
 - Confirm Planner's work is complete
 
 If Planner doesn't exist, check if planning was done manually and proceed to spawn Builder.
 
-#### 2. Verify Plan Exists
+#### 3. Verify Plan Exists
 
 Check if `custom-plan-manager` skill exists:
 ```bash
 ls .claude/skills/custom-plan-manager/SKILL.md 2>/dev/null
 ```
 
-If it exists, **invoke the `custom-plan-manager` skill** with operation=`verify-plan` and issue_number=$1.
+If it exists, **invoke the `custom-plan-manager` skill** with operation=`verify-plan`, issue_number=$1, and stage=$2 (if provided).
 The custom skill handles checking that the plan was posted and marked as approved.
 
-If it does not exist, fall back to GitHub verification:
-```bash
-gh issue view $1 --json comments --jq '.comments[-1].body' | head -20
-```
+If it does not exist, **invoke the `plan-manager` skill** with operation=`verify-plan`, issue_number=$1, and stage=$2 (if provided).
+The default skill checks that the plan file exists at `~/.cc_webui/plans/issue-{suffix}.md`.
 
-Also verify `ready-to-build` label:
-```bash
-gh issue view $1 --json labels --jq '.labels[].name' | grep -q "ready-to-build"
-```
+If plan is not found, warn user and ask if they want to proceed anyway.
 
-If plan is not posted or not marked as approved, warn user and ask if they want to proceed anyway.
+#### 4. Get Plan File Path
 
-#### 3. Dispose Planner
+The plan file path for the Builder is:
+- `$HOME/.cc_webui/plans/issue-{suffix}.md`
 
-**Invoke `mcp__legion__dispose_minion`** with:
-- **minion_name**: `Planner-$1`
-- **delete**: true
+This path will be passed to the Builder in its initialization context so it can read the plan directly.
 
-The Planner's knowledge is archived before deletion.
+If using `custom-plan-manager`, the Builder will use the custom skill's `read-plan` operation instead.
 
-#### 4. Get Environment Configuration (if custom skill exists)
+#### 5. Get Environment Configuration (if custom skill exists)
 
 Check if `custom-environment-setup` skill exists:
 ```bash
@@ -72,34 +83,36 @@ Store the returned environment info for Builder initialization context.
 
 If it does not exist, proceed without project-specific environment configuration.
 
-#### 5. Get Worktree Path
+#### 6. Get Worktree Path
 
 Verify worktree exists:
 ```bash
-git worktree list | grep "issue-$1"
+git worktree list | grep "issue-{suffix}"
 ```
 
 Extract the absolute path for the Builder's working directory.
 
-#### 6. Spawn Builder Minion
+#### 7. Spawn Builder Minion
 
 **Invoke `mcp__legion__spawn_minion`** with:
-- **name**: `Builder-$1`
+- **name**: `Builder-{suffix}`
 - **template_name**: `Issue Builder`
-- **working_directory**: Full absolute path to `worktrees/issue-$1/`
-- **role**: `Issue Builder for #$1 - Implementation specialist`
+- **working_directory**: Full absolute path to `worktrees/issue-{suffix}/`
+- **role**: `Issue Builder for #{suffix} - Implementation specialist`
 - **initialization_context**:
   ```
-  You are Builder-$1, responsible for implementing issue #$1.
+  You are Builder-{suffix}, responsible for implementing issue #$1.
 
   Working Directory: [worktree path]
-  Branch: feature/issue-$1
+  Branch: feat/issue-{suffix}
   Issue: #$1
+  Stage: {$2 if provided, else "default"}
+  Plan File: $HOME/.cc_webui/plans/issue-{suffix}.md
 
   [Include environment info from custom-environment-setup if available]
 
   Your mission:
-  1. Retrieve the approved plan (use custom-plan-manager read-plan if available, else github-issue-reader + read from comments)
+  1. Retrieve the approved plan (use custom-plan-manager read-plan if available, else plan-manager read-plan)
   2. Create task list from the plan using TaskCreate
   3. Implement changes systematically
   4. Run custom-build-process skill if it exists (project-specific build)
@@ -110,29 +123,30 @@ Extract the absolute path for the Builder's working directory.
   9. Send comm to Orchestrator with PR link
 
   CRITICAL: If custom-test-process leaves servers running, leave them for user review.
-  The user will use /approve_issue $1 when satisfied.
+  The user will use /approve_issue $1 {$2 if provided} when satisfied.
   ```
 
-#### 7. Start Builder Working
+#### 8. Start Builder Working
 
 **Invoke `mcp__legion__send_comm`** to the new Builder:
-- to_minion_name: `Builder-$1`
+- to_minion_name: `Builder-{suffix}`
 - summary: "Begin building issue #$1"
 - content: "Start the building workflow for issue #$1. Retrieve the approved plan and begin implementation."
 - comm_type: "task"
 - interrupt_priority: "none"
 
-#### 8. Confirm to User
+#### 9. Confirm to User
 
 Inform user:
 ```
-Plan approved for issue #$1
-- Planner disposed (knowledge archived)
-- Builder spawned: Builder-$1
-- Worktree: worktrees/issue-$1/
+Plan approved for issue #$1{" (stage: $2)" if stage provided}
+- Planner: Planner-{suffix} (remains alive for reference)
+- Builder spawned: Builder-{suffix}
+- Worktree: worktrees/issue-{suffix}/
+- Plan file: ~/.cc_webui/plans/issue-{suffix}.md
 
 The Builder will:
-1. Retrieve the approved plan
+1. Retrieve the approved plan from file
 2. Create task list and implement changes
 3. Run project-specific build, quality, and test steps (if configured)
 4. Create PR and report completion
@@ -141,23 +155,24 @@ When the Builder reports completion, you can:
 - Test using any running servers
 - Review the PR on GitHub
 - Iterate with the Builder if needed
-- Run /approve_issue $1 when satisfied
+- Run /approve_issue $1 {$2 if provided} when satisfied
 ```
 
 ### Skills Used
 
 - **mcp__legion__get_minion_info** - Verify Planner status
-- **mcp__legion__dispose_minion** - Dispose Planner
-- **custom-plan-manager** - Verify plan exists (if exists, replaces GitHub verification)
+- **custom-plan-manager** - Verify plan exists (if exists, overrides plan-manager)
+- **plan-manager** - Verify plan exists (default, checks file at ~/.cc_webui/plans/)
 - **custom-environment-setup** - Get project-specific environment config (if exists)
 - **mcp__legion__spawn_minion** - Create Builder minion
 - **mcp__legion__send_comm** - Start Builder working
 
 ### Important Notes
 
-- Planner is disposed before Builder is spawned
-- Builder retrieves plan via custom-plan-manager or GitHub, not filesystem
-- Plan verification uses custom-plan-manager if available, else GitHub labels
+- **Planner is NOT disposed** — it remains alive (idle) until `/approve_issue`
+- Builder receives plan file path in initialization context
+- Builder reads plan via custom-plan-manager read-plan or plan-manager read-plan
+- Plan verification uses custom-plan-manager if available, else plan-manager (file check)
 - Environment configuration is project-specific via custom-environment-setup
 - Test servers may be left running for user review (project-dependent)
-- User uses /approve_issue when satisfied
+- User uses /approve_issue when satisfied (disposes both Planner and Builder)

--- a/src/default_skills/plan-manager/SKILL.md
+++ b/src/default_skills/plan-manager/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: plan-manager
+description: File-based plan storage for the Planner/Builder workflow
+disable-model-invocation: true
+argument-hint: <operation> <issue_number> [stage]
+allowed-tools:
+  - Bash(mkdir:*)
+  - Bash(rm:*)
+  - Bash(cat:*)
+  - Bash(ls:*)
+  - Read
+  - Write
+  - Skill(github-issue-reader)
+  - mcp__resources__register_resource
+---
+
+## Plan Manager
+
+File-based plan storage at `~/.cc_webui/plans/`. This is the default plan manager used by the Planner/Builder workflow. Projects can override this by providing a `custom-plan-manager` skill in `.claude/skills/`.
+
+### Operations
+
+The first argument (`$1`) is the operation. The second argument (`$2`) is the issue number. The optional third argument (`$3`) is the stage name.
+
+**Supported operations:**
+- `fetch-issue` - Retrieve issue details from the issue tracker
+- `write-plan` - Write plan content to file and register as resource
+- `read-plan` - Read plan content from file
+- `verify-plan` - Check that plan file exists and return its path
+- `delete-plan` - Delete plan file
+
+### Path Convention
+
+Plan files are stored at:
+- Without stage: `$HOME/.cc_webui/plans/issue-{N}.md`
+- With stage: `$HOME/.cc_webui/plans/issue-{N}-{stage}.md`
+
+Stage names are sanitized to `[a-zA-Z0-9-]` only.
+
+---
+
+### Operation: fetch-issue
+
+**Usage:** `plan-manager fetch-issue <issue_number>`
+
+Delegates to `github-issue-reader` skill to fetch issue details. This thin wrapper exists so that custom plan managers can replace the issue fetching mechanism (e.g., for Jira, Azure DevOps).
+
+**Steps:**
+1. Invoke the `github-issue-reader` skill with issue number $2
+2. Return the issue details to the caller
+
+---
+
+### Operation: write-plan
+
+**Usage:** `plan-manager write-plan <issue_number> [stage]`
+
+Writes the plan content to a file and registers it as a resource for the Resource Gallery.
+
+**Steps:**
+
+1. **Compute file path:**
+   - If `$3` (stage) is provided: `$HOME/.cc_webui/plans/issue-$2-$3.md`
+   - If no stage: `$HOME/.cc_webui/plans/issue-$2.md`
+
+2. **Ensure directory exists:**
+   ```bash
+   mkdir -p "$HOME/.cc_webui/plans"
+   ```
+
+3. **Write plan content:**
+   Use the Write tool to write the plan content to the computed file path.
+   The plan content should be the finalized implementation plan that was approved by the user.
+
+4. **Register as resource:**
+   Invoke `mcp__resources__register_resource` with:
+   - **file_path**: The absolute path to the plan file
+   - **title**: `Plan: Issue #$2` (or `Plan: Issue #$2 - $3` if stage provided)
+   - **description**: `Implementation plan for issue #$2`
+
+5. **Report path:**
+   Output the file path so the caller knows where the plan was stored.
+
+---
+
+### Operation: read-plan
+
+**Usage:** `plan-manager read-plan <issue_number> [stage]`
+
+Reads and returns the plan content from file.
+
+**Steps:**
+
+1. **Compute file path:**
+   - If `$3` (stage) is provided: `$HOME/.cc_webui/plans/issue-$2-$3.md`
+   - If no stage: `$HOME/.cc_webui/plans/issue-$2.md`
+
+2. **Read plan file:**
+   Use the Read tool to read the file at the computed path.
+
+3. **Handle missing file:**
+   If the file does not exist, report an error:
+   ```
+   Error: Plan file not found at [path]. Has the Planner written the plan yet?
+   ```
+
+4. **Return content:**
+   Return the full plan content to the caller.
+
+---
+
+### Operation: verify-plan
+
+**Usage:** `plan-manager verify-plan <issue_number> [stage]`
+
+Checks that the plan file exists and returns its absolute path.
+
+**Steps:**
+
+1. **Compute file path:**
+   - If `$3` (stage) is provided: `$HOME/.cc_webui/plans/issue-$2-$3.md`
+   - If no stage: `$HOME/.cc_webui/plans/issue-$2.md`
+
+2. **Check existence:**
+   ```bash
+   ls "$HOME/.cc_webui/plans/issue-$2.md" 2>/dev/null || ls "$HOME/.cc_webui/plans/issue-$2-$3.md" 2>/dev/null
+   ```
+
+3. **Report result:**
+   - If file exists: `Plan verified at [path]`
+   - If file missing: `Warning: Plan file not found at [path]. Planner may not have written the plan yet.`
+
+4. **Return path:**
+   Always return the expected path regardless of existence, so callers can use it.
+
+---
+
+### Operation: delete-plan
+
+**Usage:** `plan-manager delete-plan <issue_number> [stage]`
+
+Deletes the plan file during cleanup (typically called by `/approve_issue`).
+
+**Steps:**
+
+1. **Compute file path:**
+   - If `$3` (stage) is provided: `$HOME/.cc_webui/plans/issue-$2-$3.md`
+   - If no stage: `$HOME/.cc_webui/plans/issue-$2.md`
+
+2. **Delete file:**
+   ```bash
+   rm -f "$HOME/.cc_webui/plans/issue-$2.md"
+   ```
+   Or with stage:
+   ```bash
+   rm -f "$HOME/.cc_webui/plans/issue-$2-$3.md"
+   ```
+
+3. **Report result:**
+   - If file existed and was deleted: `Plan file deleted: [path]`
+   - If file was already missing: `Plan file already removed: [path]`
+
+---
+
+### Important Notes
+
+- All paths use `$HOME` (not `~`) to avoid shell expansion issues
+- Stage names are sanitized — only `[a-zA-Z0-9-]` characters allowed
+- The `write-plan` operation registers the plan as a resource for the Resource Gallery
+- The `fetch-issue` operation delegates to `github-issue-reader` by default
+- This skill is deployed automatically via the SkillManager symlink system
+- Projects can override by placing a `custom-plan-manager` in `.claude/skills/`

--- a/src/default_skills/plan_issue/SKILL.md
+++ b/src/default_skills/plan_issue/SKILL.md
@@ -2,11 +2,12 @@
 name: plan_issue
 description: Start planning phase for an issue by spawning a Planner minion
 disable-model-invocation: true
-argument-hint: <issue_number>
+argument-hint: <issue_number> [stage]
 allowed-tools:
   - Bash(ls:*)
   - Bash(git worktree:*)
   - Skill(custom-plan-manager)
+  - Skill(plan-manager)
   - Skill(custom-environment-setup)
   - Skill(worktree-manager)
   - Task
@@ -16,11 +17,34 @@ allowed-tools:
 
 This skill creates an isolated git worktree for an issue and spawns a Planner minion to collaborate with the user on requirements and design.
 
+### Arguments
+
+- `$1` — Issue number (required)
+- `$2` — Stage name (optional, e.g., `backend`, `frontend`, `stage1`)
+
+### Suffix Convention
+
+Compute the suffix used for worktree, branch, minion, and plan file naming:
+- If `$2` (stage) is provided: suffix = `$1-$2` (e.g., `437-backend`)
+- If no stage: suffix = `$1` (e.g., `437`)
+
+This suffix is used consistently:
+- Worktree: `worktrees/issue-{suffix}/`
+- Branch: `feat/issue-{suffix}`
+- Minion: `Planner-{suffix}`
+- Plan file: `~/.cc_webui/plans/issue-{suffix}.md`
+
 ### Workflow
 
 You are starting the planning phase for issue #$1. Follow these steps:
 
-#### 1. Fetch Issue Details
+#### 1. Compute Suffix
+
+Determine the naming suffix:
+- If `$2` is provided: suffix = `$1-$2`
+- If `$2` is not provided: suffix = `$1`
+
+#### 2. Fetch Issue Details
 
 Check if `custom-plan-manager` skill exists:
 ```bash
@@ -29,9 +53,9 @@ ls .claude/skills/custom-plan-manager/SKILL.md 2>/dev/null
 
 If it exists, **invoke the `custom-plan-manager` skill** with operation=`fetch-issue` and issue_number=$1.
 
-If it does not exist, **invoke the `github-issue-reader` skill** with issue number $1 to fetch details from GitHub.
+If it does not exist, **invoke the `plan-manager` skill** with operation=`fetch-issue` and issue_number=$1.
 
-#### 2. Get Environment Configuration (if custom skill exists)
+#### 3. Get Environment Configuration (if custom skill exists)
 
 Check if `custom-environment-setup` skill exists:
 ```bash
@@ -46,12 +70,12 @@ Store the returned environment info for minion initialization context.
 
 If it does not exist, proceed without project-specific environment configuration.
 
-#### 3. Create Git Worktree
+#### 4. Create Git Worktree
 
 **Invoke the `worktree-manager` skill** to create isolated worktree:
-- Worktree name: `issue-$1`
-- Location: `worktrees/issue-$1/`
-- Branch: `feature/issue-$1` (or appropriate prefix based on issue type)
+- Worktree name: `issue-{suffix}`
+- Location: `worktrees/issue-{suffix}/`
+- Branch: `feat/issue-{suffix}`
 - Based on: latest `main` branch
 
 The skill will:
@@ -60,30 +84,32 @@ The skill will:
 - Create worktree from main branch
 - Switch to new feature branch in worktree
 
-#### 4. Spawn Planner Minion
+#### 5. Spawn Planner Minion
 
 **Invoke `mcp__legion__spawn_minion`** with:
-- **name**: `Planner-$1`
+- **name**: `Planner-{suffix}`
 - **template_name**: `Issue Planner`
-- **working_directory**: Full absolute path to `worktrees/issue-$1/`
-- **role**: `Issue Planner for #$1 - User story and design specialist`
+- **working_directory**: Full absolute path to `worktrees/issue-{suffix}/`
+- **role**: `Issue Planner for #{suffix} - User story and design specialist`
 - **initialization_context**:
   ```
-  You are Planner-$1, responsible for planning issue #$1.
+  You are Planner-{suffix}, responsible for planning issue #$1.
 
   Working Directory: [worktree path]
   Issue: #$1
+  Stage: {$2 if provided, else "default"}
+  Plan File: $HOME/.cc_webui/plans/issue-{suffix}.md
 
   Your mission:
-  1. Fetch issue details (use custom-plan-manager fetch-issue if available, else github-issue-reader)
+  1. Fetch issue details (use custom-plan-manager fetch-issue if available, else plan-manager fetch-issue)
   2. Explore current implementation using Task tool with Explore subagent
   3. Build user stories from requirements
   4. Create design artifacts (diagrams, flows) as appropriate
   5. Present to user and iterate based on feedback
-  6. When user approves, post plan (use custom-plan-manager write-plan if available, else gh issue comment + ready-to-build label)
-  7. Send comm to Orchestrator: "Plan posted to issue #$1, awaiting user approval"
+  6. When user approves, write plan using custom-plan-manager write-plan (if available) or plan-manager write-plan
+  7. Send comm to Orchestrator: "Plan written for issue #$1, awaiting user approval"
      IMPORTANT: Your comm is informational only. The Orchestrator will NOT
-     auto-transition to building. The user must explicitly invoke /approve_plan $1 when ready.
+     auto-transition to building. The user must explicitly invoke /approve_plan $1 {$2 if provided} when ready.
 
   CRITICAL - Codebase Exploration:
   When you need to understand the codebase structure, find relevant files, or
@@ -105,66 +131,67 @@ The skill will:
   explicitly requests it. Focus on research, analysis, and user collaboration.
 
   When the user is satisfied with the plan:
-  1. Post the approved plan (use custom-plan-manager write-plan if available,
-     else post as GitHub comment with gh issue comment and add ready-to-build label)
+  1. Write the approved plan using custom-plan-manager write-plan (if available)
+     or plan-manager write-plan with issue_number=$1 and stage={$2 if provided}
   2. Send completion comm to Orchestrator
 
-  The Orchestrator will acknowledge the plan is posted. You remain active for
-  potential user iteration. Only when the user explicitly invokes /approve_plan $1
-  will the Orchestrator dispose you and spawn a Builder.
+  The Orchestrator will acknowledge the plan is written. You remain active for
+  potential user iteration. Only when the user explicitly invokes /approve_plan $1 {$2 if provided}
+  will the Orchestrator spawn a Builder. You will remain alive until /approve_issue.
   ```
 
-#### 5. Start Planner Working
+#### 6. Start Planner Working
 
 **Invoke `mcp__legion__send_comm`** to the new Planner:
-- to_minion_name: `Planner-$1`
+- to_minion_name: `Planner-{suffix}`
 - summary: "Begin planning issue #$1"
 - content: "Start the planning workflow for issue #$1. Fetch the issue, analyze requirements, and begin user collaboration."
 - comm_type: "task"
 - interrupt_priority: "none"
 
-#### 6. Confirm to User
+#### 7. Confirm to User
 
 Inform user:
 ```
-Planning started for issue #$1
-- Planner: Planner-$1
-- Worktree: worktrees/issue-$1/
-- Branch: feature/issue-$1
+Planning started for issue #$1{" (stage: $2)" if stage provided}
+- Planner: Planner-{suffix}
+- Worktree: worktrees/issue-{suffix}/
+- Branch: feat/issue-{suffix}
+- Plan file: ~/.cc_webui/plans/issue-{suffix}.md
 
 The Planner will:
 1. Fetch and analyze the issue
 2. Build user stories from requirements
 3. Create design artifacts as needed
 4. Collaborate with you on requirements
-5. Post approved plan (via custom-plan-manager or GitHub)
+5. Write approved plan to file (viewable in Resource Gallery)
 
 Speak directly with the Planner to refine the plan.
-When satisfied, use /approve_plan $1 to transition to the Building phase.
+When satisfied, use /approve_plan $1 {$2 if provided} to transition to the Building phase.
 ```
 
-#### 7. Await Explicit Approval
+#### 8. Await Explicit Approval
 
-**CRITICAL:** The Orchestrator must wait for the user to explicitly invoke `/approve_plan $1` before transitioning to the Building phase.
+**CRITICAL:** The Orchestrator must wait for the user to explicitly invoke `/approve_plan $1 {$2 if provided}` before transitioning to the Building phase.
 
 **Correct workflow:**
-1. Planner posts plan to GitHub and sends informational comm
-2. Orchestrator acknowledges: "Plan ready for issue #$1 - review and use /approve_plan $1 when ready"
+1. Planner writes plan to file and sends informational comm
+2. Orchestrator acknowledges: "Plan ready for issue #$1 - review and use /approve_plan $1 {$2 if provided} when ready"
 3. User may iterate with Planner (ask for revisions, clarifications)
-4. When satisfied, user invokes: `/approve_plan $1`
-5. Only then: Orchestrator disposes Planner and spawns Builder
+4. When satisfied, user invokes: `/approve_plan $1 {$2 if provided}`
+5. Only then: Orchestrator spawns Builder (Planner stays alive)
 
 **Anti-pattern to avoid:**
 - Planner: "Plan ready for issue #5"
 - Orchestrator: *immediately disposes Planner and spawns Builder*
 - User: "Wait, I wanted to change something!"
 
-**Key principle:** Planner comms saying "plan ready" or "plan posted" are informational status updates, NOT approval signals. Only explicit `/approve_plan` invocation indicates user approval.
+**Key principle:** Planner comms saying "plan ready" or "plan written" are informational status updates, NOT approval signals. Only explicit `/approve_plan` invocation indicates user approval.
 
 ### Skills Used
 
-- **custom-plan-manager** - Fetch issue details (if exists, replaces github-issue-reader)
-- **github-issue-reader** - Fetch and validate issue (fallback when no custom-plan-manager)
+- **custom-plan-manager** - Fetch issue details (if exists, overrides plan-manager)
+- **plan-manager** - Fetch issue details (default, delegates to github-issue-reader)
 - **custom-environment-setup** - Get project-specific environment config (if exists)
 - **worktree-manager** - Create isolated worktree
 - **mcp__legion__spawn_minion** - Create Planner minion
@@ -180,9 +207,11 @@ The Planner uses Task tool with Explore subagent for codebase investigation. Thi
 ### Important Notes
 
 - Each issue gets its own isolated worktree
+- Stage parameter enables parallel work on the same issue (e.g., backend + frontend)
 - Planner is READ-ONLY by default
 - User collaborates directly with Planner
-- Plan is posted via custom-plan-manager or GitHub for Builder to consume
+- Plan is written to file via plan-manager (or custom-plan-manager override)
+- Plan is registered as resource for Resource Gallery viewing
 - Worktree cleaned up after issue is merged
 - Environment configuration is project-specific via custom-environment-setup
-- Issue tracking is project-specific via custom-plan-manager (falls back to GitHub)
+- Issue tracking is project-specific via custom-plan-manager (falls back to plan-manager)

--- a/src/default_skills/status_workers/SKILL.md
+++ b/src/default_skills/status_workers/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools:
 
 ## Status Workers
 
-This skill displays the status of all active Planners, Builders, and their worktrees.
+This skill displays the status of all active Planners, Builders, and their worktrees, including stage information and plan file paths.
 
 ### Workflow
 
@@ -23,7 +23,14 @@ Filter for minions matching patterns:
 - `Planner-*` - Planning phase
 - `Builder-*` - Building phase
 
-Extract issue numbers and build list of active workers.
+Parse the minion name to extract issue number and optional stage:
+- `Planner-42` → issue 42, no stage
+- `Planner-501-backend` → issue 501, stage "backend"
+- `Builder-501-frontend` → issue 501, stage "frontend"
+
+Pattern: `{Role}-{issue_number}[-{stage}]`
+
+Build list of active workers with their parsed issue numbers and stages.
 
 #### 3. Get Detailed Status
 
@@ -40,7 +47,20 @@ For each worker, **invoke `mcp__legion__get_minion_info`**:
 - Check for orphaned worktrees (no minion)
 - Check for branch status
 
-#### 5. Check Running Servers (if custom skill exists)
+#### 5. Check Plan Files
+
+For each active worker, check for plan file:
+```bash
+ls "$HOME/.cc_webui/plans/" 2>/dev/null
+```
+
+Match plan files to workers:
+- `issue-42.md` → issue 42, no stage
+- `issue-501-backend.md` → issue 501, stage "backend"
+
+Identify orphaned plan files (plan exists but no active worker).
+
+#### 6. Check Running Servers (if custom skill exists)
 
 Check if `custom-environment-setup` skill exists:
 ```bash
@@ -53,7 +73,7 @@ If it exists, **invoke the `custom-environment-setup` skill** to get environment
 
 If it does not exist, skip server/port status display.
 
-#### 6. Display Summary
+#### 7. Display Summary
 
 Show formatted status:
 ```
@@ -65,21 +85,33 @@ Active Workers: <count>
 Issue #42 - Planner-42 (Planning Phase)
   Status: Collaborating with user
   Worktree: worktrees/issue-42/
-  Branch: feature/issue-42
+  Branch: feat/issue-42
+  Plan: ~/.cc_webui/plans/issue-42.md (exists/pending)
 
-Issue #123 - Builder-123 (Building Phase)
+Issue #501 - Planner-501-backend (Planning Phase, stage: backend)
+  Status: Idle (awaiting /approve_plan 501 backend)
+  Worktree: worktrees/issue-501-backend/
+  Branch: feat/issue-501-backend
+  Plan: ~/.cc_webui/plans/issue-501-backend.md (exists)
+
+Issue #501 - Builder-501-frontend (Building Phase, stage: frontend)
   Status: Implementing
-  Worktree: worktrees/issue-123/
-  Branch: feature/issue-123
+  Worktree: worktrees/issue-501-frontend/
+  Branch: feat/issue-501-frontend
+  Plan: ~/.cc_webui/plans/issue-501-frontend.md (exists)
   [Environment info from custom-environment-setup if available]
 
-Issue #456 - Builder-456 (Building Phase)
+Issue #123 - Builder-123 (Building Phase)
   Status: Testing
-  Worktree: worktrees/issue-456/
-  Branch: fix/issue-456
+  Worktree: worktrees/issue-123/
+  Branch: feat/issue-123
+  Plan: ~/.cc_webui/plans/issue-123.md (exists)
 
 Orphaned Worktrees: <count if any>
   - worktrees/issue-789/ (no minion found)
+
+Orphaned Plan Files: <count if any>
+  - ~/.cc_webui/plans/issue-800.md (no active worker)
 ```
 
 ### Skills Used
@@ -92,7 +124,9 @@ Orphaned Worktrees: <count if any>
 ### Important Notes
 
 - Shows real-time status of all Planners and Builders
+- Parses stage suffix from minion names for multi-stage display
+- Shows plan file path and existence status per worker
 - Identifies which phase each issue is in (Planning vs Building)
 - Shows running servers and ports if custom-environment-setup is available
-- Identifies orphaned resources for cleanup
-- Helps coordinate multiple parallel issues
+- Identifies orphaned worktrees (no minion) and orphaned plan files (no worker)
+- Helps coordinate multiple parallel issues and stages

--- a/src/default_templates/issue_builder.md
+++ b/src/default_templates/issue_builder.md
@@ -16,13 +16,11 @@ You are an Issue Builder minion responsible for implementing an approved plan fo
    ```bash
    ls .claude/skills/custom-plan-manager/SKILL.md 2>/dev/null
    ```
-   If it exists, invoke `custom-plan-manager` with operation=`read-plan` and issue_number=${ISSUE_NUMBER}.
+   If it exists, invoke `custom-plan-manager` with operation=`read-plan` and issue_number=${ISSUE_NUMBER} and stage=${STAGE} (if provided in init context).
    The custom skill retrieves the approved plan from the configured issue tracker.
 
-   If it does not exist, fall back to GitHub:
-   - Use `github-issue-reader` skill to get issue #${ISSUE_NUMBER}
-   - Find the approved implementation plan in comments
-   - Look for `ready-to-build` label as confirmation
+   If it does not exist, invoke `plan-manager` with operation=`read-plan` and issue_number=${ISSUE_NUMBER} and stage=${STAGE} (if provided in init context).
+   The plan-manager reads the plan from `${PLAN_FILE}` (path provided in your initialization context).
 
    Extract all user stories, steps, and acceptance criteria from the plan.
 

--- a/src/default_templates/issue_planner.json
+++ b/src/default_templates/issue_planner.json
@@ -2,10 +2,12 @@
   "name": "Issue Planner",
   "permission_mode": "default",
   "allowed_tools": [
-    "Read", "Grep", "Glob", "WebFetch", "WebSearch", "Task",
+    "Read", "Write", "Grep", "Glob", "WebFetch", "WebSearch", "Task",
+    "Bash(mkdir:*)", "Bash(ls:*)",
     "mcp__legion__send_comm", "mcp__legion__list_minions", "mcp__legion__get_minion_info",
-    "mcp__legion__search_capability"
+    "mcp__legion__search_capability",
+    "mcp__resources__register_resource"
   ],
   "default_role": "Issue Planner - User story and design specialist",
-  "description": "Read-only focus for planning phase. Conducts user Q&A, builds user stories, creates diagrams, and posts finalized plans to GitHub. No file modification unless user explicitly requests."
+  "description": "Read-only focus for planning phase. Conducts user Q&A, builds user stories, creates diagrams, and writes finalized plans to file. Write access limited to ~/.cc_webui/plans/ directory. No project file modification unless user explicitly requests."
 }

--- a/src/default_templates/orchestrator.json
+++ b/src/default_templates/orchestrator.json
@@ -3,9 +3,10 @@
   "permission_mode": "default",
   "allowed_tools": [
     "Read", "Grep", "Glob", "Task",
+    "Bash(rm:*)", "Bash(ls:*)", "Bash(mkdir:*)",
     "mcp__legion__spawn_minion", "mcp__legion__dispose_minion", "mcp__legion__send_comm",
     "mcp__legion__list_minions", "mcp__legion__get_minion_info", "mcp__legion__search_capability"
   ],
   "default_role": "Coordinates complex workflows by delegating to specialist minions",
-  "description": "Read-only code access with full delegation capabilities. No direct code modification. Skills: codebase-explorer, git-branch-manager, github-issue-reader, github-pr-manager, worktree-manager, process-manager"
+  "description": "Read-only code access with full delegation capabilities. No direct code modification. Can delete plan files from ~/.cc_webui/plans/. Skills: codebase-explorer, git-branch-manager, github-issue-reader, github-pr-manager, worktree-manager, process-manager"
 }

--- a/src/default_templates/orchestrator.md
+++ b/src/default_templates/orchestrator.md
@@ -6,29 +6,31 @@ You do NOT implement issues yourself. You manage the Planner -> Builder workflow
 
 ### Phase 1: Planning
 When user requests work on an issue:
-1. Use `/plan_issue <number>` command (or invoke manually):
-   - Creates isolated git worktree: `worktrees/issue-<number>/`
-   - Branch: `feature/issue-<number>` based on latest main
+1. Use `/plan_issue <number> [stage]` command (or invoke manually):
+   - Creates isolated git worktree: `worktrees/issue-{suffix}/`
+   - Branch: `feat/issue-{suffix}` based on latest main
    - Invokes `custom-environment-setup` if available (for project-specific config)
    - Spawns **Planner** minion with "Issue Planner" template
+   - Plan will be written to `~/.cc_webui/plans/issue-{suffix}.md`
 2. Planner collaborates with user:
    - Builds user stories from requirements
    - Creates design artifacts (diagrams, flows)
    - Iterates based on user feedback
-   - Posts approved plan (via custom-plan-manager or GitHub)
-   - Marks plan as approved
+   - Writes approved plan to file (via custom-plan-manager or plan-manager)
+   - Plan registered as resource (viewable in Resource Gallery)
 3. Planner signals completion via comm
 
-⚠️ **CRITICAL: Do NOT proceed to the Build phase until the user explicitly runs `/approve_plan <number>`.** Planner comms saying "plan ready" or "plan posted" are **informational status updates**, NOT approval signals. The user may want to iterate with the Planner, request revisions, or ask clarifying questions. Only the explicit `/approve_plan` command from the user indicates approval. Do not dispose the Planner or spawn a Builder until this command is received.
+**CRITICAL: Do NOT proceed to the Build phase until the user explicitly runs `/approve_plan <number> [stage]`.** Planner comms saying "plan ready" or "plan written" are **informational status updates**, NOT approval signals. The user may want to iterate with the Planner, request revisions, or ask clarifying questions. Only the explicit `/approve_plan` command from the user indicates approval. Do not spawn a Builder until this command is received.
 
 ### Phase 2: Building
 When user has explicitly approved the plan via `/approve_plan`:
-1. Use `/approve_plan <number>` command:
-   - Disposes Planner minion (knowledge archived)
+1. Use `/approve_plan <number> [stage]` command:
+   - **Planner stays alive** (idle, for reference during build)
    - Invokes `custom-environment-setup` if available (for Builder config)
    - Spawns **Builder** minion with "Issue Builder" template in same worktree
+   - Builder receives plan file path in initialization context
 2. Builder implements the plan:
-   - Retrieves approved plan (via custom-plan-manager or GitHub)
+   - Reads approved plan from file (via custom-plan-manager or plan-manager)
    - Creates task list and implements changes
    - Runs `custom-build-process`, `custom-quality-check`, `custom-test-process` if available
    - Creates PR and reports completion
@@ -45,22 +47,31 @@ When build is complete:
 
 ### Phase 4: Cleanup
 When user approves:
-1. Use `/approve_issue <number>` command:
+1. Use `/approve_issue <number> [stage]` command:
    - Runs `custom-cleanup-process` if available (project-specific cleanup)
    - Merges PR (squash merge)
-   - Disposes Builder minion
+   - Disposes **both** Planner and Builder minions
+   - Deletes plan file from `~/.cc_webui/plans/`
    - Removes worktree
    - Deletes branch
    - Updates main
+
+## Suffix Convention
+
+All commands support an optional stage parameter for multi-stage workflows:
+- Without stage: suffix = `<number>` (e.g., `42`)
+- With stage: suffix = `<number>-<stage>` (e.g., `501-backend`)
+
+The suffix is used consistently for: worktree, branch, minion names, and plan file.
 
 ## Key Commands
 
 | Command | Action |
 |---------|--------|
-| `/plan_issue <n>` | Create worktree, spawn Planner |
-| `/approve_plan <n>` | Dispose Planner, spawn Builder |
-| `/approve_issue <n>` | Merge PR, clean up everything |
-| `/status_workers` | Show all active Planners/Builders |
+| `/plan_issue <n> [stage]` | Create worktree, spawn Planner |
+| `/approve_plan <n> [stage]` | Spawn Builder (Planner stays alive) |
+| `/approve_issue <n> [stage]` | Merge PR, dispose both, delete plan, clean up |
+| `/status_workers` | Show all active Planners/Builders with stages |
 
 ## Custom Skill Injection Points
 
@@ -68,20 +79,25 @@ The workflow engine calls these custom skills at defined checkpoints if they exi
 
 | Custom Skill | Called By | Purpose |
 |-------------|-----------|---------|
-| `custom-plan-manager` | Planner, Builder, plan_issue, approve_plan | Issue tracking & plan storage (falls back to GitHub) |
+| `custom-plan-manager` | Planner, Builder, plan_issue, approve_plan, approve_issue | Issue tracking & plan storage (overrides default plan-manager) |
 | `custom-environment-setup` | plan_issue, approve_plan, status_workers | Project-specific port/env config |
 | `custom-build-process` | Builder | Project-specific build (e.g., frontend) |
 | `custom-quality-check` | Builder | Project-specific linting/quality |
 | `custom-test-process` | Builder | Project-specific test cycle |
 | `custom-cleanup-process` | approve_issue | Project-specific cleanup |
 
-If a custom skill does not exist, that step is skipped gracefully.
+Default skill `plan-manager` provides file-based plan storage. If `custom-plan-manager` exists, it overrides this.
+
+If a custom skill does not exist, that step is skipped gracefully (or falls back to default).
 
 ## Key Principles
 
 - Each issue gets its own isolated worktree (no conflicts)
+- Stage parameter enables parallel work on the same issue (e.g., backend + frontend)
 - Planners are READ-ONLY (focus on user collaboration)
+- Planners stay alive until `/approve_issue` (not just `/approve_plan`)
 - Builders have full code access (implementation focus)
+- Plans stored in files at `~/.cc_webui/plans/` (not in GitHub comments)
 - Test servers may stay running for user review (project-dependent)
 - Workers operate independently in parallel
 - You relay results to user, escalate blockers
@@ -95,8 +111,8 @@ If a custom skill does not exist, that step is skipped gracefully.
 
 ## Minion Templates
 
-- **Issue Planner**: Read-only, user Q&A, design, posts approved plan
-- **Issue Builder**: Full code access, implements plan, creates PR
+- **Issue Planner**: Read-only, user Q&A, design, writes plan to file, registers resource
+- **Issue Builder**: Full code access, reads plan from file, implements, creates PR
 
 ## Workflow Summary
 
@@ -107,11 +123,30 @@ User: "Work on issue #42"
      |
 User <-> Planner (Q&A, design)
      |
-/approve_plan 42 -> Builder-42 spawned
+Planner writes plan to ~/.cc_webui/plans/issue-42.md
      |
-Builder implements, tests, creates PR
+/approve_plan 42 -> Builder-42 spawned (Planner-42 stays alive)
+     |
+Builder reads plan, implements, tests, creates PR
      |
 User reviews via test servers
      |
-/approve_issue 42 -> Merged, cleaned up
+/approve_issue 42 -> Merged, Planner-42 + Builder-42 disposed, plan deleted
+```
+
+### Multi-Stage Example
+
+```
+/plan_issue 501 backend  -> Planner-501-backend in worktrees/issue-501-backend/
+/plan_issue 501 frontend -> Planner-501-frontend in worktrees/issue-501-frontend/
+     |
+(parallel planning)
+     |
+/approve_plan 501 backend  -> Builder-501-backend spawned
+/approve_plan 501 frontend -> Builder-501-frontend spawned
+     |
+(parallel building)
+     |
+/approve_issue 501 backend  -> Merged, cleaned up
+/approve_issue 501 frontend -> Merged, cleaned up
 ```


### PR DESCRIPTION
## Summary

Resolves #454

Replace GitHub-dependent plan storage (`gh issue comment` + `ready-to-build` label) with a file-based system at `~/.cc_webui/plans/`, enabling the Planner/Builder workflow to work independently of any specific issue tracker.

### Changes

**New files (2):**
- `src/default_skills/plan-manager/SKILL.md` — Default file-based plan CRUD (fetch-issue, write-plan, read-plan, verify-plan, delete-plan)
- `.claude/skills/custom-plan-manager/SKILL.md` — GitHub-based marketplace plugin preserving original behavior

**Modified skills (4):**
- `plan_issue` — Add `[stage]` param, stage-aware naming, fall back to `plan-manager`
- `approve_plan` — Keep Planner alive, pass plan file path to Builder, use `plan-manager` verify
- `approve_issue` — Dispose both Planner + Builder, invoke `delete-plan`, stage-aware cleanup
- `status_workers` — Parse stage from minion names, show plan file paths, detect orphaned plans

**Modified templates (5):**
- `issue_planner.md/.json` — Write plan via `plan-manager`, add Write/mkdir/register_resource permissions
- `issue_builder.md` — Read plan via `plan-manager` from file path in init context
- `orchestrator.md/.json` — Planner stays alive until `/approve_issue`, add `Bash(rm:*)`, multi-stage docs

### Key Design Decisions

- **Storage**: `~/.cc_webui/plans/issue-{N}[-{stage}].md` — outside git repo, user-visible
- **Planner lifecycle**: Stays alive after `/approve_plan`, disposed on `/approve_issue`
- **Multi-stage**: Suffix convention (`501-backend`, `501-frontend`) for parallel work
- **Backward compat**: `custom-plan-manager` plugin preserves GitHub behavior for teams that want it
- **Skill resolution**: All workflow files check `custom-plan-manager` first, fall back to `plan-manager`

### Test Scenarios

- [ ] Single-stage: `/plan_issue 500` → plan at `~/.cc_webui/plans/issue-500.md`
- [ ] Multi-stage: `/plan_issue 501 backend` + `/plan_issue 501 frontend` → separate files/worktrees
- [ ] Resource Gallery: Plan visible after Planner writes it
- [ ] Planner persistence: After `/approve_plan`, Planner alive, Builder working
- [ ] Full cleanup: `/approve_issue` disposes both, deletes plan, removes worktree
- [ ] Custom override: Install `custom-plan-manager` → uses GitHub instead of files