### PR TITLE
fix(#466): coerce null ruleContent to empty string in permission suggestions

### DIFF
--- a/src/web_server.py
+++ b/src/web_server.py
@@ -2944,7 +2944,7 @@ class ClaudeWebUI:
                                 # SDK uses snake_case (tool_name, rule_content) but suggestions come in camelCase
                                 rule_obj = PermissionRuleValue(
                                     tool_name=rule_dict.get('toolName', ''),
-                                    rule_content=rule_dict.get('ruleContent')
+                                    rule_content=rule_dict.get('ruleContent') or ""
                                 )
                                 rules_param.append(rule_obj)
 


### PR DESCRIPTION
## Summary
Resolves #466

Fixes ZodError validation failure in Claude Code CLI when approving MCP server tool permissions with suggested rules that have null `ruleContent`.

## Changes Made
- Coerce `ruleContent` from `None` to `""` (empty string) when building `PermissionRuleValue` objects in `src/web_server.py`

## Testing
- 289 unit tests pass (4 pre-existing failures unrelated to this change)
- Backend health endpoint verified
- Manual verification: approve MCP server tool permissions with suggestions applied — no ZodError

🤖 Generated with [Claude Code](https://claude.com/claude-code)