### PR TITLE
fix(#480): resolve comms panel not loading communications

### DIFF
--- a/frontend/src/stores/websocket.js
+++ b/frontend/src/stores/websocket.js
@@ -814,6 +814,7 @@ export const useWebSocketStore = defineStore('websocket', () => {
     sessionRetryCount,
     legionConnected,
     legionRetryCount,
+    currentLegionId,
     overallStatus,
 
     // Actions


### PR DESCRIPTION
## Summary
Resolves #480

Fix comms panel not loading or displaying communications when sent or received by a session. The root cause was a stale local `connectedLegionId` guard variable in CommsPanel.vue that prevented reconnection after external WebSocket disconnects by other components (TimelineView, ProjectOverview).

## Changes Made
- **`frontend/src/stores/websocket.js`**: Export `currentLegionId` ref from the store return block so components can reactively check which legion WebSocket is active
- **`frontend/src/components/tasks/CommsPanel.vue`**:
  - Remove stale local `connectedLegionId` tracking variable
  - Rewrite `connectToLegion()` to use reactive `wsStore.legionConnected` and `wsStore.currentLegionId` instead of local guard
  - Only connect WebSocket if not already connected to the target legion
  - Only load timeline if data not already present for the legion
  - Remove `onUnmounted` disconnect (prevents interference with other components sharing the singleton WebSocket)
  - Add watcher on `wsStore.legionConnected` to reload timeline data on WebSocket reconnection

## Testing
- Create a multi-agent project with minions, send comms — verify they appear in the comms panel
- Navigate session view → timeline view → session view — verify comms panel still shows data
- Trigger a comm while viewing the comms panel — verify real-time display
- Refresh the page while viewing a session — verify historical comms load

🤖 Generated with [Claude Code](https://claude.com/claude-code)