### PR TITLE
fix(#476): auto-expand permission tool cards loaded from history

### DIFF
--- a/frontend/src/components/messages/tools/ActivityTimeline.vue
+++ b/frontend/src/components/messages/tools/ActivityTimeline.vue
@@ -127,7 +127,7 @@ watch(sortedTools, (tools) => {
       expandedNodeId.value = null
     }
   }
-}, { deep: true })
+}, { deep: true, immediate: true })
 
 // Status counts
 const runningCount = computed(() => {


### PR DESCRIPTION
## Summary
Resolves #476

Permission tool cards did not auto-expand when returning to a paused session with a pending permission prompt. The `sortedTools` watcher in `ActivityTimeline.vue` lacked `immediate: true`, so it never fired on mount when tool data was already populated from history.

## Changes Made
- Added `immediate: true` to the `sortedTools` watcher in `ActivityTimeline.vue` so the permission_required check runs on initial render, not only on subsequent changes

## Testing
- Return to a paused session with a pending permission prompt — tool card auto-expands immediately
- Multiple pending permissions — first permission_required tool auto-expands
- Session with no pending permissions — no unintended auto-expansion
- Real-time permission prompt during active session — behavior unchanged
- Permission resolved (allowed/denied) — auto-collapse still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)