### PR TITLE
fix(#511): add missing fields to MinionCreateRequest model

### DIFF
--- a/src/web_server.py
+++ b/src/web_server.py
@@ -183,6 +183,9 @@ class MinionCreateRequest(BaseModel):
     allowed_tools: list[str] | None = None  # None or empty list means no pre-authorized tools
     disallowed_tools: list[str] | None = None  # Issue #461: tools to deny
     working_directory: str | None = None  # Optional custom working directory for this minion
+    sandbox_enabled: bool | None = None  # Enable OS-level sandboxing (issue #319)
+    sandbox_config: dict | None = None  # Issue #458: sandbox configuration settings
+    setting_sources: list[str] | None = None  # Issue #36: which settings files to load
 
 
 class ScheduleCreateRequest(BaseModel):


### PR DESCRIPTION
## Summary
Resolves #511

Add three missing fields (`sandbox_enabled`, `sandbox_config`, `setting_sources`) to the `MinionCreateRequest` Pydantic model in `src/web_server.py`. These fields were already accessed by the `create_minion` endpoint but absent from the request model, causing 422 validation errors when creating minions via the UI with these parameters.

## Changes Made
- Added `sandbox_enabled: bool | None = None` to `MinionCreateRequest`
- Added `sandbox_config: dict | None = None` to `MinionCreateRequest`
- Added `setting_sources: list[str] | None = None` to `MinionCreateRequest`

## Testing
- Unit tests: 326 passed (4 pre-existing failures unrelated to this change)
- Backend health endpoint verified on port 8511
- Ruff lint: no new violations introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)