### PR TITLE
fix(#521): suppress right sidebar auto-show during session switching

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -87,16 +87,18 @@ provide('pendingResourceAttachment', pendingResourceAttachment)
 const rightPanelVisible = computed(() => uiStore.rightPanelVisible)
 const isTabletOrMobile = computed(() => uiStore.windowWidth < 768)
 
-// Auto-show right panel when tasks first appear
+// Auto-show right panel when tasks first appear (suppressed during session switch, #521)
 watch(() => taskStore.currentHasTasks, (hasTasks, hadTasks) => {
-  if (hasTasks && !hadTasks) {
+  if (hasTasks && !hadTasks && !uiStore.suppressAutoShow) {
+    uiStore.setRightSidebarTab('tasks')
     uiStore.setRightPanelVisible(true)
   }
 })
 
-// Auto-show right panel when resources first appear
+// Auto-show right panel when resources first appear (suppressed during session switch, #521)
 watch(() => resourceStore.currentHasResources, (hasResources, hadResources) => {
-  if (hasResources && !hadResources) {
+  if (hasResources && !hadResources && !uiStore.suppressAutoShow) {
+    uiStore.setRightSidebarTab('resources')
     uiStore.setRightPanelVisible(true)
   }
 })

--- a/frontend/src/stores/session.js
+++ b/frontend/src/stores/session.js
@@ -1,7 +1,8 @@
 import { defineStore } from 'pinia'
-import { ref, computed } from 'vue'
+import { ref, computed, nextTick } from 'vue'
 import { useRouter } from 'vue-router'
 import { api } from '../utils/api'
+import { useUIStore } from './ui'
 
 /**
  * Session Store - Manages session state and operations
@@ -134,6 +135,10 @@ export const useSessionStore = defineStore('session', () => {
 
     // Set mutex flag
     selectingSession.value = true
+
+    // Suppress auto-show of right panel while loading existing session data (#521)
+    const uiStore = useUIStore()
+    uiStore.setSuppressAutoShow(true)
 
     try {
       // Update current session immediately to prevent UI confusion
@@ -271,6 +276,9 @@ export const useSessionStore = defineStore('session', () => {
         pendingSelectAbort = null
       }
       selectingSession.value = false
+
+      // Clear suppression after Vue processes reactive updates from loaded data (#521)
+      nextTick(() => uiStore.setSuppressAutoShow(false))
     }
   }
 

--- a/frontend/src/stores/ui.js
+++ b/frontend/src/stores/ui.js
@@ -71,6 +71,10 @@ export const useUIStore = defineStore('ui', () => {
   const restartInProgress = ref(false)
   const restartStatus = ref('idle') // idle, confirming, pulling, restarting, reconnecting, error
 
+  // Suppress auto-show of right panel during session switching (issue #521)
+  // Transient flag — not persisted to localStorage
+  const suppressAutoShow = ref(false)
+
   // ========== ACTIONS ==========
 
   function toggleRightSidebar() {
@@ -95,6 +99,10 @@ export const useUIStore = defineStore('ui', () => {
 
   function setAutoScroll(enabled) {
     autoScrollEnabled.value = enabled
+  }
+
+  function setSuppressAutoShow(value) {
+    suppressAutoShow.value = value
   }
 
   function initBackgroundColor() {
@@ -203,6 +211,7 @@ export const useUIStore = defineStore('ui', () => {
     loadingMessage,
     restartInProgress,
     restartStatus,
+    suppressAutoShow,
 
     // Actions
     toggleRightSidebar,
@@ -215,6 +224,7 @@ export const useUIStore = defineStore('ui', () => {
     toggleRightPanel,
     setRightPanelVisible,
     setAutoScroll,
+    setSuppressAutoShow,
     initBackgroundColor,
     toggleBackgroundColor,
     showModal,


### PR DESCRIPTION
## Summary

- Add `suppressAutoShow` transient flag to `ui.js` store to prevent right sidebar from auto-opening when switching sessions
- Update task/resource watchers in `App.vue` to check suppression flag and navigate to the correct tab (Tasks or Resources) on auto-show
- Set suppression flag in `session.js` `selectSession()` before async loads, clear via `nextTick` in `finally` block

Resolves #521

## Test plan

- [ ] Switch between sessions with existing tasks/resources → sidebar stays closed
- [ ] Stay on a session, trigger TaskCreate tool result → sidebar auto-opens to Tasks tab
- [ ] Stay on a session, trigger resource_registered event → sidebar auto-opens to Resources tab
- [ ] Verify correct tab selection (Tasks vs Resources)
- [ ] Test on mobile widths (375px, 480px, 600px) and desktop
- [ ] Test rapid session switching
- [ ] Test edge case: new task arrives during session switch (acceptable to suppress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)