### PR TITLE
feat(#538): add long-press and right-click manage modal on AgentChip

### DIFF
--- a/frontend/src/composables/useLongPress.js
+++ b/frontend/src/composables/useLongPress.js
@@ -1,0 +1,58 @@
+import { ref } from 'vue'
+
+/**
+ * Composable for touch-based long-press detection.
+ *
+ * @param {Function} callback - Called when long-press fires
+ * @param {Object} options - { delay: 500, moveThreshold: 10 }
+ * @returns {{ onTouchStart: Function, onTouchEnd: Function, onTouchCancel: Function, fired: import('vue').Ref<boolean> }}
+ */
+export function useLongPress(callback, options = {}) {
+  const { delay = 500, moveThreshold = 10 } = options
+
+  const fired = ref(false)
+  let timer = null
+  let startX = 0
+  let startY = 0
+
+  function clear() {
+    if (timer !== null) {
+      clearTimeout(timer)
+      timer = null
+    }
+  }
+
+  function onTouchStart(e) {
+    fired.value = false
+    const touch = e.touches[0]
+    startX = touch.clientX
+    startY = touch.clientY
+
+    clear()
+    timer = setTimeout(() => {
+      fired.value = true
+      timer = null
+      callback()
+    }, delay)
+  }
+
+  function onTouchMove(e) {
+    if (timer === null) return
+    const touch = e.touches[0]
+    const dx = touch.clientX - startX
+    const dy = touch.clientY - startY
+    if (Math.sqrt(dx * dx + dy * dy) > moveThreshold) {
+      clear()
+    }
+  }
+
+  function onTouchEnd() {
+    clear()
+  }
+
+  function onTouchCancel() {
+    clear()
+  }
+
+  return { onTouchStart, onTouchMove, onTouchEnd, onTouchCancel, fired }
+}


### PR DESCRIPTION
## Summary
Resolves #538

Add tap-and-hold (long-press) and right-click support on AgentChip to open the SessionManageModal, matching the existing ProjectPill contextmenu pattern.

## Changes Made
- Create `useLongPress.js` composable with configurable delay (500ms) and move threshold (10px) for touch-based long-press detection
- Add `@contextmenu.prevent` handler on AgentChip for desktop right-click
- Bind touch handlers (`touchstart`, `touchmove`, `touchend`, `touchcancel`) on AgentChip for mobile long-press
- Guard click handler with `fired` flag to prevent click-after-longpress interference
- Emit new `manage` event for parent component interception

## Testing
- Frontend build passes (`npm run build`)
- Unit tests: 326 passed (4 pre-existing failures unrelated to this change)
- Backend health endpoint verified on port 8538
- Vite dev server verified on port 5538
- Manual verification: right-click on AgentChip opens SessionManageModal; normal click still selects session