### PR TITLE
fix(#548): use local timezone for cron schedule evaluation

### DIFF
--- a/src/legion/mcp/legion_mcp_tools.py
+++ b/src/legion/mcp/legion_mcp_tools.py
@@ -1701,11 +1701,11 @@ class LegionMCPTools:
                 timeout_seconds=timeout_seconds,
             )
 
-            from datetime import UTC, datetime
+            from datetime import datetime
             next_run_str = "N/A"
             if schedule.next_run:
-                next_run_str = datetime.fromtimestamp(schedule.next_run, tz=UTC).strftime(
-                    "%Y-%m-%d %H:%M UTC"
+                next_run_str = datetime.fromtimestamp(schedule.next_run).astimezone().strftime(
+                    "%Y-%m-%d %H:%M %Z"
                 )
 
             return {
@@ -1774,13 +1774,13 @@ class LegionMCPTools:
                     "is_error": False,
                 }
 
-            from datetime import UTC, datetime
+            from datetime import datetime
             lines = [f"**Your Schedules** ({len(schedules)} total):\n"]
             for s in schedules:
                 next_run_str = "N/A"
                 if s.next_run:
-                    next_run_str = datetime.fromtimestamp(s.next_run, tz=UTC).strftime(
-                        "%Y-%m-%d %H:%M UTC"
+                    next_run_str = datetime.fromtimestamp(s.next_run).astimezone().strftime(
+                        "%Y-%m-%d %H:%M %Z"
                     )
                 lines.append(
                     f"\n- **{s.name}** (ID: {s.schedule_id[:8]}...)\n"
@@ -1877,11 +1877,11 @@ class LegionMCPTools:
         try:
             updated = await self.system.scheduler_service.resume_schedule(schedule_id)
 
-            from datetime import UTC, datetime
+            from datetime import datetime
             next_run_str = "N/A"
             if updated.next_run:
-                next_run_str = datetime.fromtimestamp(updated.next_run, tz=UTC).strftime(
-                    "%Y-%m-%d %H:%M UTC"
+                next_run_str = datetime.fromtimestamp(updated.next_run).astimezone().strftime(
+                    "%Y-%m-%d %H:%M %Z"
                 )
 
             return {

--- a/src/models/schedule_models.py
+++ b/src/models/schedule_models.py
@@ -134,9 +134,9 @@ def get_next_run(cron_expression: str, base_time: float | None = None) -> float:
         Unix timestamp of next execution.
     """
     if base_time is not None:
-        base = datetime.fromtimestamp(base_time, tz=UTC)
+        base = datetime.fromtimestamp(base_time).astimezone()
     else:
-        base = datetime.now(UTC)
+        base = datetime.now().astimezone()
     cron = croniter(cron_expression, base)
     next_dt = cron.get_next(datetime)
     return next_dt.timestamp()


### PR DESCRIPTION
## Summary
Resolves #548

Use server local timezone instead of UTC for cron schedule evaluation and display, so that `0 9 * * 1-5` runs at 9:00 AM local time rather than 9:00 AM UTC.

## Changes Made
- **`src/models/schedule_models.py`**: Changed `get_next_run()` to use `datetime.now().astimezone()` instead of `datetime.now(UTC)` so croniter interprets cron fields in server local time
- **`src/legion/mcp/legion_mcp_tools.py`**: Updated 3 MCP tool response locations (create_schedule, list_schedules, resume_schedule) to display `next_run` in local timezone with dynamic `%Z` abbreviation instead of hardcoded "UTC"

## Testing
- All 301 unit tests pass (`uv run pytest src/tests/ -v`)
- Ruff linting passes on both modified files
- Backend health endpoint verified on port 8548
- No migration needed: `next_run` is recalculated from cron expressions on load

🤖 Generated with [Claude Code](https://claude.com/claude-code)