### PR TITLE
fix(#616): resolve permission callback race condition with parallel subagents

### DIFF
--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -2686,8 +2686,10 @@ class SessionCoordinator:
         param_hash = hashlib.md5(first_value.encode()).hexdigest()[:8]
         target_signature = f"{tool_name}:{param_hash}"
 
-        # Search active tools for matching signature
+        # Search active tools for matching signature — collect all matches
+        # to handle parallel subagents with identical tool signatures.
         session_tools = self._active_tool_calls.get(session_id, {})
+        matches = []
         for tool_call in session_tools.values():
             # Compute signature for this tool
             tc_first_value = ""
@@ -2701,8 +2703,24 @@ class SessionCoordinator:
             tc_hash = hashlib.md5(tc_first_value.encode()).hexdigest()[:8]
             tc_signature = f"{tool_call.name}:{tc_hash}"
 
-            if tc_signature == target_signature and tool_call.status in (ToolState.PENDING, ToolState.AWAITING_PERMISSION):
-                return tool_call
+            if tc_signature == target_signature and tool_call.status in (
+                ToolState.PENDING,
+                ToolState.AWAITING_PERMISSION,
+            ):
+                matches.append(tool_call)
+
+        if len(matches) == 1:
+            return matches[0]
+        elif len(matches) > 1:
+            # Multiple signature matches (parallel subagents with same tool).
+            # Return the most recently created one — the permission callback
+            # fires shortly after the tool is created.
+            matches.sort(key=lambda tc: tc.created_at, reverse=True)
+            coord_logger.debug(
+                f"Signature collision: {len(matches)} matches for {target_signature}, "
+                f"selecting most recent (created_at={matches[0].created_at})"
+            )
+            return matches[0]
 
         return None
 

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -3717,6 +3717,29 @@ class ClaudeWebUI:
                         session_id, tool_name, input_params
                     )
 
+                    # Issue #616: Race condition — ToolCall may not exist yet because
+                    # _process_sdk_message() hasn't finished processing the AssistantMessage.
+                    # Retry with backoff before giving up.
+                    if not tool_call:
+                        for attempt in range(10):
+                            await asyncio.sleep(0.1)
+                            tool_call = self.coordinator.find_tool_call_by_signature(
+                                session_id, tool_name, input_params
+                            )
+                            if tool_call:
+                                logger.debug(
+                                    f"[PERMISSIONS] Race condition resolved: found ToolCall "
+                                    f"for {tool_name} after {attempt + 1} retries "
+                                    f"({(attempt + 1) * 0.1:.1f}s) in session {session_id}"
+                                )
+                                break
+                        else:
+                            logger.warning(
+                                f"[PERMISSIONS] Race condition NOT resolved after 10 retries "
+                                f"(1.0s) for {tool_name} in session {session_id}. "
+                                f"Auto-denying permission to prevent deadlock."
+                            )
+
                     if tool_call:
                         # Create PermissionInfo from suggestions
                         permission_info = PermissionInfo(
@@ -3748,15 +3771,27 @@ class ClaudeWebUI:
                             await self.websocket_manager.send_message(session_id, websocket_message)
                             logger.info(f"Broadcasted tool_call awaiting_permission for {tool_name} in session {session_id}")
                     else:
-                        logger.warning(f"Could not find matching ToolCall for permission request: {tool_name}")
+                        # Issue #616: No ToolCall found after retries — auto-deny to prevent deadlock
+                        logger.warning(
+                            f"Could not find matching ToolCall for permission request: "
+                            f"{tool_name} in session {session_id}. Auto-denying."
+                        )
+                        return {"behavior": "deny"}
 
                     # Issue #491: Legacy permission_request broadcast removed.
                     # Only unified tool_call messages are emitted for permission lifecycle.
                 except Exception as ws_error:
                     logger.error(f"Failed to broadcast permission request to WebSocket: {ws_error}")
+                    # Issue #616: If broadcast failed, auto-deny rather than deadlock
+                    return {"behavior": "deny"}
 
             except Exception as e:
                 logger.error(f"Failed to store permission request message: {e}")
+                return {"behavior": "deny"}
+
+            # Issue #616: Session pause, Future creation, and await are now INSIDE the
+            # successful tool_call path. We only reach here if the permission prompt was
+            # successfully broadcast to the frontend.
 
             # Set session state to PAUSED while waiting for permission response
             # This provides visual feedback that the session is blocked on user input


### PR DESCRIPTION
## Summary
Resolves #616

Fix deadlock when the SDK fires `permission_callback` before the message consumer has created the corresponding ToolCall during parallel Task tool execution (e.g., multiple subagents spawned simultaneously).

## Changes Made
- **`src/web_server.py`** — `_create_permission_callback()`:
  - Add retry loop (10 × 0.1s) after initial `find_tool_call_by_signature()` returns `None`, allowing the message consumer time to create the ToolCall
  - Auto-deny permission when retries exhaust to prevent indefinite Future await (deadlock)
  - Return early with deny on broadcast failure instead of falling through to unconditional pause/Future
- **`src/session_coordinator.py`** — `find_tool_call_by_signature()`:
  - Collect all matching tools instead of returning the first match
  - When multiple signature matches exist (parallel subagents with identical tool + input), prefer the most recently created one

## Testing
- 389 unit tests passing
- Backend and frontend servers start cleanly with patched code
- Verified session with 3 parallel subagents and 15 permission callbacks — all resolved, including 1 confirmed concurrent overlap window
- Ruff linting clean (no new violations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)