### PR TITLE
fix: bind to localhost by default and remove --lockdown-mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,10 +198,13 @@ __Longer-term Goals__
 
 ### Command-Line Options
 ```bash
+# Default: binds to localhost only (127.0.0.1:8000)
+uv run python main.py
+
 # Custom port (default: 8000)
 uv run python main.py --port 8080
 
-# Network access (bind to all interfaces)
+# Allow remote access (bind to all interfaces)
 uv run python main.py --host 0.0.0.0
 
 # Custom data directory (default: ./data)
@@ -211,7 +214,7 @@ uv run python main.py --data-dir /path/to/data
 uv run python main.py --debug-all
 uv run python main.py --debug-sdk --debug-websocket --debug-permissions
 
-# Combined example
+# Combined example: remote access + custom port + debug
 uv run python main.py --host 0.0.0.0 --port 8080 --debug-all
 ```
 
@@ -230,13 +233,13 @@ Choose the right permission level for your workflow:
 
 ### Network Access
 
-Access Claude WebUI from any device on your network:
+By default, the server binds to `127.0.0.1` (localhost only) for security. To access from other devices on your network:
 
-1. Start with `--host 0.0.0.0`
-2. Find your machine's IP address (`ipconfig` on Windows, `ifconfig` on Mac/Linux)
+1. Start with `--host 0.0.0.0` to bind to all interfaces
+2. Find your machine's IP address (`ip addr` on Linux, `ipconfig` on Windows, `ifconfig` on Mac)
 3. Access from other devices at `http://<your-ip>:8000`
 
-**Security Note**: This exposes the server to your local network. Use VPN or firewall rules for internet access.
+**Security Note**: Using `--host 0.0.0.0` exposes the server to your local network. Use VPN or firewall rules for internet access.
 
 ## Documentation
 

--- a/main.py
+++ b/main.py
@@ -41,13 +41,12 @@ Debug Flags:
     )
 
     # Server options
-    parser.add_argument('--host', default='0.0.0.0', help='Host to bind to (default: 0.0.0.0)')
+    parser.add_argument(
+        '--host', default='127.0.0.1',
+        help='Bind address (default: 127.0.0.1, localhost only). Use --host 0.0.0.0 to allow remote access.'
+    )
     parser.add_argument('--port', type=int, default=8000, help='Port to bind to (default: 8000)')
     parser.add_argument('--data-dir', default='./data', help='Data directory location (default: ./data)')
-    parser.add_argument(
-        '--lockdown-mode', action='store_true',
-        help='Restrict server to localhost only (127.0.0.1) for security'
-    )
 
     # Debug flags
     parser.add_argument('--debug-websocket', action='store_true', help='Enable WebSocket lifecycle debugging')
@@ -137,18 +136,10 @@ Debug Flags:
     app.add_event_handler("startup", startup_event)
     app.add_event_handler("shutdown", shutdown_event)
 
-    # Handle lockdown mode - restrict to localhost only
-    effective_host = args.host
-    if args.lockdown_mode:
-        if args.host != '0.0.0.0' and args.host != '127.0.0.1':
-            print(f"WARNING: Lockdown mode overriding --host {args.host} to 127.0.0.1")
-        effective_host = '127.0.0.1'
-        print("Running in lockdown mode - listening on 127.0.0.1 only")
-
     # Run the server
     uvicorn.run(
         app,
-        host=effective_host,
+        host=args.host,
         port=args.port,
         log_level="info",
         access_log=True


### PR DESCRIPTION
## Summary
Resolves #627

Change the default bind address from `0.0.0.0` to `127.0.0.1` so the server is secure by default on untrusted networks. Remove the now-redundant `--lockdown-mode` flag. Users who need remote access can explicitly opt in with `--host 0.0.0.0`.

## Changes Made
- Change `--host` default from `0.0.0.0` to `127.0.0.1` in `main.py`
- Remove `--lockdown-mode` argument definition and handling block
- Pass `args.host` directly to `uvicorn.run()` (remove `effective_host` indirection)
- Update README.md to document new default and clarify remote access opt-in

## Testing
- `uv run ruff check --fix main.py` — all checks passed
- `uv run pytest src/tests/ -v` — 389 passed
- Backend health endpoint verified on test port

🤖 Generated with [Claude Code](https://claude.com/claude-code)