### PR TITLE
chore: add --host 0.0.0.0 to dev server commands

### DIFF
--- a/.claude/skills/custom-environment-setup/SKILL.md
+++ b/.claude/skills/custom-environment-setup/SKILL.md
@@ -37,6 +37,7 @@ Return this context fragment for inclusion in minion initialization:
 ```
 Test Server Configuration:
 - Backend Port: ${BACKEND_PORT} (8000 + issue_number % 1000)
+- Backend Host: 0.0.0.0 (required for network-accessible dev server)
 - Vite Port: ${VITE_PORT} (5000 + issue_number % 1000)
 - Data Directory: Default (data/) - DO NOT use --data-dir flag
 ```

--- a/.claude/skills/custom-test-process/SKILL.md
+++ b/.claude/skills/custom-test-process/SKILL.md
@@ -32,7 +32,7 @@ This skill owns the full test lifecycle in a single invocation:
 **CRITICAL:** Unset the `CLAUDECODE` environment variable before starting the backend. The Claude Agent SDK includes an undocumented safety check that prevents it from running inside another Claude Code instance. Since the builder agent runs inside Claude Code, this env var is inherited by child processes. Our application launches its own Claude Code SDK instances, so if `CLAUDECODE` is set, those SDK sessions will halt prematurely.
 
 ```bash
-env -u CLAUDECODE uv run python main.py --debug-all --port ${BACKEND_PORT} &
+env -u CLAUDECODE uv run python main.py --host 0.0.0.0 --debug-all --port ${BACKEND_PORT} &
 ```
 
 Wait for server to be ready:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,7 +195,7 @@ frontend/
 
 ```bash
 # Terminal 1: Backend (use port 8001 to avoid conflicts with production on 8000)
-uv run python main.py --debug-all --port 8001
+uv run python main.py --host 0.0.0.0 --debug-all --port 8001
 
 # Terminal 2: Frontend dev server with HMR
 cd frontend
@@ -852,7 +852,7 @@ main.py
 
 ```bash
 # Test run
-uv run python main.py --debug-all --data-dir test_data --port 8001
+uv run python main.py --host 0.0.0.0 --debug-all --data-dir test_data --port 8001
 
 # Production run
 uv run python main.py --port 8000
@@ -898,7 +898,7 @@ uv run pytest src/tests/ --cov=src --cov-report=html
 
 ```bash
 # Terminal 1: Backend
-uv run python main.py --port 8001 --debug-all
+uv run python main.py --host 0.0.0.0 --port 8001 --debug-all
 
 # Terminal 2: Frontend dev server
 cd frontend

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -302,7 +302,7 @@ See [TOOL_HANDLERS.md](../TOOL_HANDLERS.md) for detailed documentation.
 
 ```bash
 # Terminal 1: Backend
-uv run python main.py --port 8001 --debug-all
+uv run python main.py --host 0.0.0.0 --port 8001 --debug-all
 
 # Terminal 2: Frontend dev server with HMR
 cd frontend && npm run dev   # http://localhost:5173


### PR DESCRIPTION
## Summary
Resolves #640

Add `--host 0.0.0.0` flag to all development backend startup commands so that test servers are network-accessible.

## Changes Made
- `.claude/skills/custom-test-process/SKILL.md`: Added `--host 0.0.0.0` to backend startup command
- `.claude/skills/custom-environment-setup/SKILL.md`: Added Backend Host binding note to initialization context fragment
- `CLAUDE.md`: Added `--host 0.0.0.0` to 3 dev commands (frontend dev server, test run, frontend development); production command left unchanged
- `frontend/CLAUDE.md`: Added `--host 0.0.0.0` to dev workflow backend command

## Testing
- Grepped all modified files for `main.py` commands — all dev commands include `--host 0.0.0.0`
- Confirmed production command on CLAUDE.md line 858 does NOT have `--host 0.0.0.0`
- Verified only documentation/skill files modified — no src/ code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)