### PR TITLE
fix: cancel active schedules when deleting sessions

### DIFF
--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -1190,6 +1190,19 @@ class SessionCoordinator:
                 else:
                     coord_logger.warning(f"Parent overseer {parent_id} not found for minion {session_id}")
 
+            # Step 1.55: Cancel active schedules for deleted session (Issue #671)
+            if self.legion_system:
+                try:
+                    cancelled = await self.legion_system.scheduler_service.cancel_schedules_for_minion(session_id)
+                    if cancelled:
+                        coord_logger.info(
+                            f"Cancelled {cancelled} schedules for deleted session {session_id}"
+                        )
+                except Exception as e:
+                    coord_logger.warning(
+                        f"Failed to cancel schedules for session {session_id}: {e}"
+                    )
+
             # Step 1.6: Clean up capability registry if session has capabilities (issue #349: all sessions are minions)
             if session_info and session_info.capabilities:
                 # Clean up capability registry

--- a/src/tests/test_session_coordinator.py
+++ b/src/tests/test_session_coordinator.py
@@ -511,3 +511,94 @@ class TestSessionCoordinator:
         assert storage_manager is not None
         assert storage_manager.session_dir.exists()
         assert storage_manager.messages_file.exists()
+
+
+class TestDeleteSessionScheduleCancellation:
+    """Tests for schedule cancellation when deleting sessions (Issue #671)."""
+
+    @pytest.mark.asyncio
+    async def test_issue_671_delete_session_cancels_schedules(self, temp_coordinator, sample_session_config):
+        """Deleting a session with active schedules cancels them."""
+        coordinator = temp_coordinator
+        session_id = await coordinator.create_session(**sample_session_config)
+
+        # Mock the legion system with scheduler_service
+        mock_scheduler = AsyncMock()
+        mock_scheduler.cancel_schedules_for_minion = AsyncMock(return_value=2)
+        mock_legion = MagicMock()
+        mock_legion.scheduler_service = mock_scheduler
+        mock_legion.legion_coordinator = MagicMock()
+        mock_legion.legion_coordinator.unregister_minion_capabilities = MagicMock()
+        mock_legion.archive_manager = AsyncMock()
+        mock_legion.archive_manager.archive_minion = AsyncMock(
+            return_value=MagicMock(success=True, archive_path="/tmp/archive")
+        )
+        coordinator.legion_system = mock_legion
+
+        result = await coordinator.delete_session(session_id)
+
+        assert result["success"] is True
+        mock_scheduler.cancel_schedules_for_minion.assert_awaited_once_with(session_id)
+
+    @pytest.mark.asyncio
+    async def test_issue_671_delete_session_no_schedules(self, temp_coordinator, sample_session_config):
+        """Deleting a session with no schedules completes without error."""
+        coordinator = temp_coordinator
+        session_id = await coordinator.create_session(**sample_session_config)
+
+        # Mock legion system where cancel returns 0 (no schedules)
+        mock_scheduler = AsyncMock()
+        mock_scheduler.cancel_schedules_for_minion = AsyncMock(return_value=0)
+        mock_legion = MagicMock()
+        mock_legion.scheduler_service = mock_scheduler
+        mock_legion.legion_coordinator = MagicMock()
+        mock_legion.legion_coordinator.unregister_minion_capabilities = MagicMock()
+        mock_legion.archive_manager = AsyncMock()
+        mock_legion.archive_manager.archive_minion = AsyncMock(
+            return_value=MagicMock(success=True, archive_path="/tmp/archive")
+        )
+        coordinator.legion_system = mock_legion
+
+        result = await coordinator.delete_session(session_id)
+
+        assert result["success"] is True
+        mock_scheduler.cancel_schedules_for_minion.assert_awaited_once_with(session_id)
+
+    @pytest.mark.asyncio
+    async def test_issue_671_delete_session_schedule_error_non_blocking(self, temp_coordinator, sample_session_config):
+        """Schedule cancellation failure does not block session deletion."""
+        coordinator = temp_coordinator
+        session_id = await coordinator.create_session(**sample_session_config)
+
+        # Mock legion system where cancel raises an exception
+        mock_scheduler = AsyncMock()
+        mock_scheduler.cancel_schedules_for_minion = AsyncMock(
+            side_effect=RuntimeError("Scheduler unavailable")
+        )
+        mock_legion = MagicMock()
+        mock_legion.scheduler_service = mock_scheduler
+        mock_legion.legion_coordinator = MagicMock()
+        mock_legion.legion_coordinator.unregister_minion_capabilities = MagicMock()
+        mock_legion.archive_manager = AsyncMock()
+        mock_legion.archive_manager.archive_minion = AsyncMock(
+            return_value=MagicMock(success=True, archive_path="/tmp/archive")
+        )
+        coordinator.legion_system = mock_legion
+
+        result = await coordinator.delete_session(session_id)
+
+        # Deletion should still succeed despite scheduler error
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_issue_671_delete_session_no_legion_system(self, temp_coordinator, sample_session_config):
+        """Deleting a session without legion system skips schedule cancellation."""
+        coordinator = temp_coordinator
+        session_id = await coordinator.create_session(**sample_session_config)
+
+        # Ensure no legion system
+        coordinator.legion_system = None
+
+        result = await coordinator.delete_session(session_id)
+
+        assert result["success"] is True


### PR DESCRIPTION
## Summary
Resolves #671

When deleting a session that has active schedules, the schedules were not being cancelled, leaving orphaned schedule entries. This mirrors the existing pattern in `dispose_minion()` which already cancels schedules.

## Changes Made
- Add `cancel_schedules_for_minion()` call in `SessionCoordinator.delete_session()` (Step 1.55, between parent cleanup and capability registry cleanup)
- Guard with `if self.legion_system` since non-legion projects have no scheduler
- Use try/except to prevent scheduler errors from blocking session deletion
- Add 4 tests: cancellation, no-op, error resilience, no legion system

## Testing
- All 410 unit tests passing
- New tests cover: schedule cancellation on delete, no schedules (no-op), scheduler error (non-blocking), no legion system
- Backend health endpoint verified
- Ruff linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)