### PR TITLE
feat: add restart_session MCP tool for agent self-restart

### DIFF
--- a/src/legion/mcp/legion_mcp_tools.py
+++ b/src/legion/mcp/legion_mcp_tools.py
@@ -13,6 +13,10 @@ Implementation uses Claude Agent SDK's @tool decorator and create_sdk_mcp_server
 Tools are exposed to minions with names like: mcp__legion__send_comm
 """
 
+import asyncio
+import logging
+import uuid
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 try:
@@ -21,6 +25,8 @@ except ImportError:
     # For testing environments without SDK
     tool = None
     create_sdk_mcp_server = None
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from src.legion_system import LegionSystem
@@ -40,6 +46,7 @@ class LegionMCPTools:
             system: LegionSystem instance for accessing other components
         """
         self.system = system
+        self._pending_restarts: set[str] = set()
 
         # Note: No longer creating a shared MCP server here
         # Each minion session gets its own session-specific server
@@ -344,6 +351,26 @@ class LegionMCPTools:
             args["_from_minion_id"] = session_id
             return await self._handle_cancel_schedule(args)
 
+        # ── Session lifecycle tools (Issue #680) ──
+
+        @tool(
+            "restart_session",
+            "Request a restart of your own session. This is useful when you are stuck, "
+            "have accumulated too much context, or need a fresh start to continue work."
+            "\n\n**IMPORTANT:** After calling this tool, you MUST stop all work immediately. "
+            "Do not execute any more tools or produce further output. The system will "
+            "restart your session and send a continuation message so you can resume."
+            "\n\nParameters:"
+            "\n- reason (optional): Why you need to restart (logged for audit)",
+            {
+                "reason": str,
+            }
+        )
+        async def restart_session_tool(args: dict[str, Any]) -> dict[str, Any]:
+            """Request a session restart."""
+            args["_from_minion_id"] = session_id
+            return await self._handle_restart_session(args)
+
         # Create and return MCP server with all tools
         return create_sdk_mcp_server(
             name="legion",
@@ -363,6 +390,7 @@ class LegionMCPTools:
                 pause_schedule_tool,
                 resume_schedule_tool,
                 cancel_schedule_tool,
+                restart_session_tool,
             ]
         )
 
@@ -2063,3 +2091,143 @@ class LegionMCPTools:
                 "content": [{"type": "text", "text": f"Unexpected error cancelling schedule: {e}"}],
                 "is_error": True,
             }
+
+    # ── Session Lifecycle Handlers (Issue #680) ──
+
+    async def _handle_restart_session(self, args: dict[str, Any]) -> dict[str, Any]:
+        """Handle restart_session tool call."""
+        from src.session_manager import SessionState
+
+        session_id = args.get("_from_minion_id")
+        reason = args.get("reason", "").strip()
+
+        if not session_id:
+            return {
+                "content": [{"type": "text", "text": "Error: Unable to determine session ID"}],
+                "is_error": True,
+            }
+
+        # Check session exists and is active
+        session_info = await self.system.session_coordinator.session_manager.get_session_info(
+            session_id
+        )
+        if not session_info:
+            return {
+                "content": [{"type": "text", "text": "Error: Session not found"}],
+                "is_error": True,
+            }
+        if session_info.state != SessionState.ACTIVE:
+            return {
+                "content": [{
+                    "type": "text",
+                    "text": f"Error: Session is not active (state: {session_info.state.value})"
+                }],
+                "is_error": True,
+            }
+
+        # Prevent duplicate restarts
+        if session_id in self._pending_restarts:
+            return {
+                "content": [{"type": "text", "text": "Error: Restart already in progress"}],
+                "is_error": True,
+            }
+
+        restart_id = str(uuid.uuid4())
+        self._pending_restarts.add(session_id)
+
+        logger.info(
+            f"Session {session_id} restart initiated (restart_id={restart_id}, reason={reason})"
+        )
+
+        # Spawn background monitor task
+        asyncio.create_task(self._restart_monitor(session_id, restart_id, reason))
+
+        return {
+            "content": [{
+                "type": "text",
+                "text": (
+                    "Restart initiated. STOP all work immediately and wait for session restart. "
+                    "Do not execute any more tools or produce further output. "
+                    f"Restart ID: {restart_id}"
+                ),
+            }],
+            "is_error": False,
+        }
+
+    async def _restart_monitor(self, session_id: str, restart_id: str, reason: str) -> None:
+        """Background task that waits for session idle then triggers restart."""
+        timestamp = datetime.now(UTC).isoformat()
+        coordinator = self.system.session_coordinator
+
+        try:
+            # Poll is_processing every 2 seconds for up to 30 seconds
+            for _ in range(15):
+                await asyncio.sleep(2)
+
+                session_info = await coordinator.session_manager.get_session_info(session_id)
+                if not session_info:
+                    logger.warning(f"Session {session_id} disappeared during restart monitor")
+                    return
+
+                if not session_info.is_processing:
+                    # Session is idle — proceed with restart
+                    permission_callback = None
+                    if self.system.permission_callback_factory:
+                        permission_callback = self.system.permission_callback_factory(session_id)
+
+                    success = await coordinator.restart_session(
+                        session_id, permission_callback
+                    )
+
+                    if success:
+                        logger.info(
+                            f"Session {session_id} self-restarted successfully "
+                            f"(restart_id={restart_id}, reason={reason})"
+                        )
+
+                        # Broadcast WebSocket event
+                        if self.system.ui_websocket_manager:
+                            await self.system.ui_websocket_manager.broadcast_to_all({
+                                "type": "session_self_restart",
+                                "data": {
+                                    "session_id": session_id,
+                                    "restart_id": restart_id,
+                                    "reason": reason,
+                                    "timestamp": timestamp,
+                                },
+                            })
+
+                        # Queue continuation message
+                        continuation = (
+                            "Your session has been restarted successfully. "
+                            "Continue with your previous work."
+                        )
+                        if reason:
+                            continuation += f" Restart reason: {reason}"
+
+                        await coordinator.enqueue_message(
+                            session_id=session_id,
+                            content=continuation,
+                            reset_session=False,
+                        )
+                    else:
+                        logger.error(
+                            f"Session {session_id} restart failed (restart_id={restart_id})"
+                        )
+
+                    return
+
+            # Timeout — session still processing after 30 seconds
+            logger.warning(
+                f"Session {session_id} restart timed out (restart_id={restart_id})"
+            )
+            await coordinator.send_message(
+                session_id,
+                "Session restart timed out after 30 seconds — the session was still processing. "
+                "If you still need to restart, call restart_session() again.",
+            )
+
+        except Exception as e:
+            logger.error(f"Restart monitor error for session {session_id}: {e}")
+        finally:
+            self._pending_restarts.discard(session_id)

--- a/src/tests/test_restart_session.py
+++ b/src/tests/test_restart_session.py
@@ -1,0 +1,228 @@
+"""
+Tests for the restart_session MCP tool (Issue #680).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+from src.legion_system import LegionSystem
+from src.session_manager import SessionState
+
+
+@pytest.fixture
+def legion_system():
+    """Create mock LegionSystem for testing."""
+    system = LegionSystem(
+        session_coordinator=Mock(),
+        data_storage_manager=Mock(),
+        template_manager=Mock(),
+    )
+    # Set up session_coordinator mocks
+    system.session_coordinator.session_manager = AsyncMock()
+    system.session_coordinator.restart_session = AsyncMock(return_value=True)
+    system.session_coordinator.enqueue_message = AsyncMock()
+    system.session_coordinator.send_message = AsyncMock(return_value=True)
+    return system
+
+
+@pytest.fixture
+def mcp_tools(legion_system):
+    """Create LegionMCPTools instance."""
+    return legion_system.mcp_tools
+
+
+def _make_session_info(state=SessionState.ACTIVE, is_processing=True):
+    """Create a mock SessionInfo."""
+    info = MagicMock()
+    info.state = state
+    info.is_processing = is_processing
+    return info
+
+
+@pytest.mark.asyncio
+async def test_issue_680_restart_returns_correct_format(mcp_tools):
+    """Tool returns success with restart instructions."""
+    session_info = _make_session_info(state=SessionState.ACTIVE)
+    mcp_tools.system.session_coordinator.session_manager.get_session_info = AsyncMock(
+        return_value=session_info
+    )
+
+    result = await mcp_tools._handle_restart_session({
+        "_from_minion_id": "session-1",
+        "reason": "context overflow",
+    })
+
+    assert result["is_error"] is False
+    text = result["content"][0]["text"]
+    assert "STOP all work immediately" in text
+    assert "Restart ID:" in text
+
+
+@pytest.mark.asyncio
+async def test_issue_680_restart_missing_session_id(mcp_tools):
+    """Tool returns error when session ID is missing."""
+    result = await mcp_tools._handle_restart_session({"reason": "test"})
+
+    assert result["is_error"] is True
+    assert "session id" in result["content"][0]["text"].lower()
+
+
+@pytest.mark.asyncio
+async def test_issue_680_restart_session_not_found(mcp_tools):
+    """Tool returns error when session doesn't exist."""
+    mcp_tools.system.session_coordinator.session_manager.get_session_info = AsyncMock(
+        return_value=None
+    )
+
+    result = await mcp_tools._handle_restart_session({
+        "_from_minion_id": "nonexistent",
+        "reason": "",
+    })
+
+    assert result["is_error"] is True
+    assert "not found" in result["content"][0]["text"].lower()
+
+
+@pytest.mark.asyncio
+async def test_issue_680_restart_session_not_active(mcp_tools):
+    """Tool returns error when session is not active."""
+    session_info = _make_session_info(state=SessionState.TERMINATED)
+    mcp_tools.system.session_coordinator.session_manager.get_session_info = AsyncMock(
+        return_value=session_info
+    )
+
+    result = await mcp_tools._handle_restart_session({
+        "_from_minion_id": "session-1",
+        "reason": "",
+    })
+
+    assert result["is_error"] is True
+    assert "not active" in result["content"][0]["text"].lower()
+
+
+@pytest.mark.asyncio
+async def test_issue_680_duplicate_restart_prevention(mcp_tools):
+    """Second restart call returns error while first is pending."""
+    session_info = _make_session_info(state=SessionState.ACTIVE)
+    mcp_tools.system.session_coordinator.session_manager.get_session_info = AsyncMock(
+        return_value=session_info
+    )
+
+    # First call succeeds
+    result1 = await mcp_tools._handle_restart_session({
+        "_from_minion_id": "session-1",
+        "reason": "first",
+    })
+    assert result1["is_error"] is False
+
+    # Second call should fail (restart already pending)
+    result2 = await mcp_tools._handle_restart_session({
+        "_from_minion_id": "session-1",
+        "reason": "second",
+    })
+    assert result2["is_error"] is True
+    assert "already in progress" in result2["content"][0]["text"].lower()
+
+    # Clean up pending restarts for other tests
+    mcp_tools._pending_restarts.discard("session-1")
+
+
+@pytest.mark.asyncio
+async def test_issue_680_monitor_detects_idle_and_restarts(mcp_tools):
+    """Monitor detects idle session and triggers restart."""
+    coordinator = mcp_tools.system.session_coordinator
+
+    # Session becomes idle on first check
+    idle_info = _make_session_info(state=SessionState.ACTIVE, is_processing=False)
+    coordinator.session_manager.get_session_info = AsyncMock(return_value=idle_info)
+
+    # Set up permission callback factory
+    mock_callback = Mock()
+    mcp_tools.system.permission_callback_factory = Mock(return_value=mock_callback)
+
+    # Set up websocket manager
+    mcp_tools.system.ui_websocket_manager = AsyncMock()
+    mcp_tools.system.ui_websocket_manager.broadcast_to_all = AsyncMock()
+
+    with patch("src.legion.mcp.legion_mcp_tools.asyncio.sleep", new_callable=AsyncMock):
+        await mcp_tools._restart_monitor("session-1", "restart-123", "test reason")
+
+    coordinator.restart_session.assert_awaited_once_with("session-1", mock_callback)
+    coordinator.enqueue_message.assert_awaited_once()
+    enqueue_kwargs = coordinator.enqueue_message.call_args
+    assert "test reason" in enqueue_kwargs.kwargs.get("content", enqueue_kwargs[1].get("content", ""))
+
+    mcp_tools.system.ui_websocket_manager.broadcast_to_all.assert_awaited_once()
+    broadcast_msg = mcp_tools.system.ui_websocket_manager.broadcast_to_all.call_args[0][0]
+    assert broadcast_msg["type"] == "session_self_restart"
+    assert broadcast_msg["data"]["session_id"] == "session-1"
+    assert broadcast_msg["data"]["restart_id"] == "restart-123"
+    assert broadcast_msg["data"]["reason"] == "test reason"
+
+    # Pending restart should be cleaned up
+    assert "session-1" not in mcp_tools._pending_restarts
+
+
+@pytest.mark.asyncio
+async def test_issue_680_monitor_timeout_sends_failure(mcp_tools):
+    """Monitor sends failure message after 30s timeout."""
+    coordinator = mcp_tools.system.session_coordinator
+
+    # Session stays processing for all checks
+    busy_info = _make_session_info(state=SessionState.ACTIVE, is_processing=True)
+    coordinator.session_manager.get_session_info = AsyncMock(return_value=busy_info)
+
+    mcp_tools._pending_restarts.add("session-1")
+
+    with patch("src.legion.mcp.legion_mcp_tools.asyncio.sleep", new_callable=AsyncMock):
+        await mcp_tools._restart_monitor("session-1", "restart-456", "stuck")
+
+    # restart_session should NOT have been called
+    coordinator.restart_session.assert_not_awaited()
+
+    # Timeout message should be sent
+    coordinator.send_message.assert_awaited_once()
+    msg_args = coordinator.send_message.call_args[0]
+    assert msg_args[0] == "session-1"
+    assert "timed out" in msg_args[1].lower()
+
+    # Pending restart should be cleaned up
+    assert "session-1" not in mcp_tools._pending_restarts
+
+
+@pytest.mark.asyncio
+async def test_issue_680_monitor_session_disappears(mcp_tools):
+    """Monitor exits gracefully if session disappears."""
+    coordinator = mcp_tools.system.session_coordinator
+    coordinator.session_manager.get_session_info = AsyncMock(return_value=None)
+
+    mcp_tools._pending_restarts.add("session-1")
+
+    with patch("src.legion.mcp.legion_mcp_tools.asyncio.sleep", new_callable=AsyncMock):
+        await mcp_tools._restart_monitor("session-1", "restart-789", "")
+
+    coordinator.restart_session.assert_not_awaited()
+    coordinator.send_message.assert_not_awaited()
+
+    # Pending restart should be cleaned up
+    assert "session-1" not in mcp_tools._pending_restarts
+
+
+@pytest.mark.asyncio
+async def test_issue_680_continuation_message_no_reason(mcp_tools):
+    """Continuation message omits reason when empty."""
+    coordinator = mcp_tools.system.session_coordinator
+
+    idle_info = _make_session_info(state=SessionState.ACTIVE, is_processing=False)
+    coordinator.session_manager.get_session_info = AsyncMock(return_value=idle_info)
+    mcp_tools.system.permission_callback_factory = None
+    mcp_tools.system.ui_websocket_manager = None
+
+    with patch("src.legion.mcp.legion_mcp_tools.asyncio.sleep", new_callable=AsyncMock):
+        await mcp_tools._restart_monitor("session-2", "restart-abc", "")
+
+    coordinator.restart_session.assert_awaited_once_with("session-2", None)
+    enqueue_call = coordinator.enqueue_message.call_args
+    content = enqueue_call.kwargs.get("content", enqueue_call[1].get("content", ""))
+    assert "Restart reason:" not in content


### PR DESCRIPTION
## Summary
Resolves #680

Add `restart_session` MCP tool to `LegionMCPTools` enabling agents to request their own session restart when stuck or needing a fresh context.

## Changes Made
- Added `restart_session` tool definition with `reason` parameter to `LegionMCPTools.create_mcp_server_for_session()`
- Implemented `_handle_restart_session()` handler with session validation and duplicate restart prevention
- Implemented `_restart_monitor()` background task that polls `is_processing` every 2s for up to 30s, then triggers restart or sends timeout message
- On successful restart: broadcasts `session_self_restart` WebSocket event and queues continuation message
- Added `_pending_restarts` set to prevent concurrent restart attempts on the same session
- Added 9 unit tests covering: tool return format, missing session ID, session not found, session not active, duplicate prevention, monitor idle detection, monitor timeout, session disappearance, and continuation message formatting

## Testing
- 9 new unit tests in `src/tests/test_restart_session.py` — all passing
- Full test suite (419 tests) — all passing
- Backend health endpoint verified
- Ruff linting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)