### PR TITLE
chore: upgrade claude-agent-sdk to v0.1.48

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "uvicorn>=0.24.0",
     "websockets>=12.0",
     "pydantic>=2.5.0",
-    "claude-agent-sdk>=0.1.47",
+    "claude-agent-sdk==0.1.48",
     "croniter>=6.0.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -124,18 +124,18 @@ wheels = [
 
 [[package]]
 name = "claude-agent-sdk"
-version = "0.1.47"
+version = "0.1.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "mcp" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/68/07/db12af4b4decb423040a652016f250562fcda22959215f418546a2332a34/claude_agent_sdk-0.1.47.tar.gz", hash = "sha256:b154a49602f0bc10087bd85668aedf2bd731426fed51f9ea2b7780926ea1933d", size = 86670, upload-time = "2026-03-06T01:29:42.076Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/dd/2818538efd18ed4ef72d4775efa75bb36cbea0fa418eda51df85ee9c2424/claude_agent_sdk-0.1.48.tar.gz", hash = "sha256:ee294d3f02936c0b826119ffbefcf88c67731cf8c2d2cb7111ccc97f76344272", size = 87375, upload-time = "2026-03-07T00:21:37.087Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/72/ecce35d9967fffe5623abef11b51dd5934519f6afafa8369d4e0f12f3b6f/claude_agent_sdk-0.1.47-py3-none-macosx_11_0_arm64.whl", hash = "sha256:8c738a025b27201ba96a0c70e058a4de9420ead6123bf70e55dffa98c5dae089", size = 59606979, upload-time = "2026-03-06T01:29:28.598Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/6b/55a38abd9d5cc1d6b6583f5de4881aa9f978ad01d4bc65db7c1670570bea/claude_agent_sdk-0.1.47-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:25c38d13f378f06079c6c8bb09d60c751215b9c70a7509eaf6b0915410ee2abb", size = 75412913, upload-time = "2026-03-06T01:29:32.055Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/8b/d91975df575f196fe62d2abf4161696f34c20703435eedee5e54d022b503/claude_agent_sdk-0.1.47-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:d2dc2c0b5b4a2266a69ace5ada21fcf90e3f284a1e0968f94218d041cfc72ea9", size = 76109307, upload-time = "2026-03-06T01:29:35.119Z" },
-    { url = "https://files.pythonhosted.org/packages/43/c6/9300d5f5f834145028b5fa8d372c226a8b590b56a488ab417a9cbece19cd/claude_agent_sdk-0.1.47-py3-none-win_amd64.whl", hash = "sha256:75a85c9e566cb89e7ecd17b430246f47f225f91a52a7f44cfdb301231d5eba4e", size = 77287865, upload-time = "2026-03-06T01:29:39.402Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/cf/bbbdee52ee0c63c8709b0ac03ce3c1da5bdc37def5da0eca63363448744f/claude_agent_sdk-0.1.48-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5761ff1d362e0f17c2b1bfd890d1c897f0aa81091e37bbd15b7d06f05ced552d", size = 57559306, upload-time = "2026-03-07T00:21:20.011Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d1/2179154b88d4cf6ba1cf6a15066ee8e96257aaeb1330e625e809ba2f28eb/claude_agent_sdk-0.1.48-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:39c1307daa17e42fa8a71180bb20af8a789d72d3891fc93519ff15540badcb83", size = 73980309, upload-time = "2026-03-07T00:21:24.592Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/99/55b0cd3bf54a7449e744d23cf50be104e9445cf623e1ed75722112aa6264/claude_agent_sdk-0.1.48-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:543d70acba468eccfff836965a14b8ac88cf90809aeeb88431dfcea3ee9a2fa9", size = 74583686, upload-time = "2026-03-07T00:21:28.969Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/f6/4851bd9a238b7aadba7639eb906aca7da32a51f01563fa4488469c608b3a/claude_agent_sdk-0.1.48-py3-none-win_amd64.whl", hash = "sha256:0d37e60bd2b17efc3f927dccef080f14897ab62cd1d0d67a4abc8a0e2d4f1006", size = 74956045, upload-time = "2026-03-07T00:21:33.475Z" },
 ]
 
 [[package]]
@@ -170,7 +170,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
-    { name = "claude-agent-sdk", specifier = ">=0.1.47" },
+    { name = "claude-agent-sdk", specifier = "==0.1.48" },
     { name = "croniter", specifier = ">=6.0.0" },
     { name = "fastapi", specifier = ">=0.104.0" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12.0" },


### PR DESCRIPTION
## Summary
Resolves #686

Upgrade claude-agent-sdk from v0.1.47 to v0.1.48, which auto-injects `CLAUDE_CODE_ENABLE_FINE_GRAINED_TOOL_STREAMING=1` when `include_partial_messages=True` and bundles CLI v2.1.71.

## Changes Made
- Updated `pyproject.toml` dependency pin from `>=0.1.47` to `==0.1.48`
- Updated `uv.lock` to resolve v0.1.48

## Testing
- All 419 unit tests pass
- Backend server starts and health endpoint returns healthy
- No code changes required — SDK internal fix only

🤖 Generated with [Claude Code](https://claude.com/claude-code)