### PR TITLE
fix: register missing debug loggers and convert error logging to exception logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -37,6 +37,10 @@ Debug Flags:
   --debug-session-manager   Enable session manager debugging
   --debug-template-manager  Enable template manager debugging
   --debug-skill-manager     Enable skill manager debugging
+  --debug-queue-manager     Enable queue manager debugging
+  --debug-queue-processor   Enable queue processor debugging
+  --debug-archive           Enable archive manager debugging
+  --debug-project-manager   Enable project manager debugging
   --debug-all               Enable all debug logging (excludes ping/pong)
         """
     )
@@ -64,6 +68,10 @@ Debug Flags:
     parser.add_argument('--debug-session-manager', action='store_true', help='Enable session manager debugging')
     parser.add_argument('--debug-template-manager', action='store_true', help='Enable template manager debugging')
     parser.add_argument('--debug-skill-manager', action='store_true', help='Enable skill manager debugging')
+    parser.add_argument('--debug-queue-manager', action='store_true', help='Enable queue manager debugging')
+    parser.add_argument('--debug-queue-processor', action='store_true', help='Enable queue processor debugging')
+    parser.add_argument('--debug-archive', action='store_true', help='Enable archive manager debugging')
+    parser.add_argument('--debug-project-manager', action='store_true', help='Enable project manager debugging')
     parser.add_argument('--debug-all', action='store_true', help='Enable all debug logging (excludes ping/pong)')
 
     # Experimental features
@@ -111,6 +119,10 @@ Debug Flags:
         debug_session_manager=args.debug_session_manager,
         debug_template_manager=args.debug_template_manager,
         debug_skill_manager=args.debug_skill_manager,
+        debug_queue_manager=args.debug_queue_manager,
+        debug_queue_processor=args.debug_queue_processor,
+        debug_archive=args.debug_archive,
+        debug_project_manager=args.debug_project_manager,
         debug_all=args.debug_all,
         log_dir=str(data_dir_path / "logs")
     )

--- a/src/claude_sdk.py
+++ b/src/claude_sdk.py
@@ -103,8 +103,8 @@ class SDKErrorDetectionHandler(logging.Handler):
                     await self.error_callback("immediate_cli_failure", Exception(error_message))
                 else:
                     self.error_callback("immediate_cli_failure", Exception(error_message))
-        except Exception as e:
-            self.logger.error(f"Error in SDK error callback: {e}")
+        except Exception:
+            self.logger.exception("Error in SDK error callback")
 
 
 @dataclass
@@ -272,8 +272,8 @@ class ClaudeSDK:
             sdk_logger.addHandler(self._sdk_error_handler)
 
             sdk_logger.debug(f"SDK error detection handler set up for session {self.session_id}")
-        except Exception as e:
-            logger.error(f"Failed to set up SDK error detection: {e}")
+        except Exception:
+            logger.exception("Failed to set up SDK error detection")
 
     def _cleanup_sdk_error_detection(self):
         """Clean up SDK error detection handler."""
@@ -283,8 +283,8 @@ class ClaudeSDK:
                 sdk_logger.removeHandler(self._sdk_error_handler)
                 self._sdk_error_handler = None
                 sdk_logger.debug(f"SDK error detection handler cleaned up for session {self.session_id}")
-        except Exception as e:
-            logger.error(f"Failed to clean up SDK error detection: {e}")
+        except Exception:
+            logger.exception("Failed to clean up SDK error detection")
 
     async def start(self) -> bool:
         """
@@ -338,7 +338,7 @@ class ClaudeSDK:
             return True
 
         except Exception as e:
-            logger.error(f"Failed to start Claude Code SDK session: {e}")
+            logger.exception("Failed to start Claude Code SDK session")
             self.info.state = SessionState.FAILED
             self.info.error_message = str(e)
             if self.error_callback:
@@ -377,7 +377,7 @@ class ClaudeSDK:
             return True
 
         except Exception as e:
-            logger.error(f"Failed to queue message: {e}")
+            logger.exception("Failed to queue message")
             if self.error_callback:
                 await self._safe_callback(self.error_callback, "message_queue_failed", e)
             return False
@@ -419,7 +419,7 @@ class ClaudeSDK:
             return True
 
         except Exception as e:
-            logger.error(f"Failed to interrupt session {self.session_id}: {e}")
+            logger.exception(f"Failed to interrupt session {self.session_id}")
             if self.error_callback:
                 await self._safe_callback(self.error_callback, "interrupt_failed", e)
             return False
@@ -463,7 +463,7 @@ class ClaudeSDK:
             return True
 
         except Exception as e:
-            logger.error(f"Failed to set permission mode for session {self.session_id}: {e}")
+            logger.exception(f"Failed to set permission mode for session {self.session_id}")
             if self.error_callback:
                 await self._safe_callback(self.error_callback, "set_permission_mode_failed", e)
             return False
@@ -481,8 +481,8 @@ class ClaudeSDK:
 
             result = await self._sdk_client.get_mcp_status()
             return result
-        except Exception as e:
-            logger.error(f"Failed to get MCP status for session {self.session_id}: {e}")
+        except Exception:
+            logger.exception(f"Failed to get MCP status for session {self.session_id}")
             return {"servers": []}
 
     async def toggle_mcp_server(self, name: str, enabled: bool) -> None:
@@ -534,8 +534,8 @@ class ClaudeSDK:
             sdk_logger.info(f"SDK session {self.session_id} disconnected successfully")
             return True
 
-        except Exception as e:
-            logger.error(f"Failed to disconnect SDK session {self.session_id}: {e}")
+        except Exception:
+            logger.exception(f"Failed to disconnect SDK session {self.session_id}")
             return False
 
     async def _message_processing_loop(self):
@@ -588,9 +588,9 @@ class ClaudeSDK:
                             await self._process_sdk_message(response_message)
                             self._session_health_checks["total_responses_received"] += 1
                             self._session_health_checks["last_successful_response"] = time.time()
-                    except Exception as e:
+                    except Exception:
                         if not self._shutdown_event.is_set():
-                            logger.error(f"Error in global response consumer: {e}")
+                            logger.exception("Error in global response consumer")
 
                 # Start response consumer as background task
                 response_consumer_task = asyncio.create_task(consume_all_responses())
@@ -655,8 +655,8 @@ class ClaudeSDK:
                                         "session_id": self.session_id,
                                         "timestamp": time.time()
                                     })
-                            except Exception as e:
-                                logger.error(f"Failed to send interrupt: {e}")
+                            except Exception:
+                                logger.exception("Failed to send interrupt")
 
 
                         self._message_queue.task_done()
@@ -668,7 +668,7 @@ class ClaudeSDK:
                         sdk_logger.info("Message processing loop cancelled")
                         break
                     except Exception as e:
-                        logger.error(f"Error processing message: {e}")
+                        logger.exception("Error processing message")
                         if self.error_callback:
                             await self._safe_callback(self.error_callback, "message_processing_error", e)
 
@@ -679,8 +679,8 @@ class ClaudeSDK:
                     with contextlib.suppress(asyncio.CancelledError):
                         await response_consumer_task
                     sdk_logger.info("Global response consumer cleaned up successfully")
-                except Exception as e:
-                    logger.error(f"Error during response consumer cleanup: {e}")
+                except Exception:
+                    logger.exception("Error during response consumer cleanup")
                     sdk_logger.info("Global response consumer cleanup completed with errors")
 
             # Update health monitoring state
@@ -689,28 +689,16 @@ class ClaudeSDK:
 
         except Exception as e:
             fatal_error_time = time.time()
-            logger.error(f"FATAL ERROR in message processing loop at {fatal_error_time}: {e}")
-            logger.error(f"Exception type: {type(e)}")
-            logger.error(f"Exception details: {e}")
-            logger.error(f"Session state before error: {self.info.state}")
-
-
-            # Comprehensive fatal error tracking
-            import traceback
-            logger.error("FATAL ERROR - Full exception traceback:")
-            for line in traceback.format_exception(type(e), e, e.__traceback__):
-                logger.error(f"{line.rstrip()}")
-
-            logger.error("Fatal error context:")
-            logger.error(f"- Session ID: {self.session_id}")
-            logger.error(f"- Working directory: {self.working_directory}")
-            logger.error(f"- Session state: {self.info.state}")
-            logger.error(f"- Message count: {self.info.message_count}")
-            logger.error(f"- Queue size: {self._message_queue.qsize()}")
-            logger.error(f"- Shutdown event: {self._shutdown_event.is_set()}")
-            logger.error(f"- Context manager was active: {self._session_health_checks.get('context_manager_active', False)}")
-            logger.error(f"- Total queries sent: {self._session_health_checks.get('total_queries_sent', 0)}")
-            logger.error(f"- Total responses received: {self._session_health_checks.get('total_responses_received', 0)}")
+            logger.exception(
+                f"FATAL ERROR in message processing loop at {fatal_error_time}. "
+                f"Context: session={self.session_id}, cwd={self.working_directory}, "
+                f"state={self.info.state}, msg_count={self.info.message_count}, "
+                f"queue_size={self._message_queue.qsize()}, "
+                f"shutdown={self._shutdown_event.is_set()}, "
+                f"ctx_mgr_active={self._session_health_checks.get('context_manager_active', False)}, "
+                f"queries_sent={self._session_health_checks.get('total_queries_sent', 0)}, "
+                f"responses_received={self._session_health_checks.get('total_responses_received', 0)}"
+            )
 
             # Update health monitoring
             self._session_health_checks["context_manager_active"] = False
@@ -719,8 +707,8 @@ class ClaudeSDK:
             # Final health check for fatal error
             try:
                 self._log_session_health(None, "fatal_error")
-            except Exception as health_check_error:
-                logger.error(f"Health check failed during fatal error handling: {health_check_error}")
+            except Exception:
+                logger.exception("Health check failed during fatal error handling")
 
             self.info.state = SessionState.FAILED
             # Include buffered stderr in error message (issue #517)
@@ -976,7 +964,7 @@ class ClaudeSDK:
             sdk_logger.debug(f"Processed SDK message: {converted_message.get('type', 'unknown')}")
 
         except Exception as e:
-            logger.error(f"Failed to process SDK message: {e}")
+            logger.exception("Failed to process SDK message")
             if self.error_callback:
                 await self._safe_callback(self.error_callback, "sdk_message_processing_failed", e)
 
@@ -1017,7 +1005,7 @@ class ClaudeSDK:
             await self.storage_manager.append_message(storage_data)
 
         except Exception as e:
-            logger.error(f"Failed to store SDK message: {e}")
+            logger.exception("Failed to store SDK message")
             # Ultimate fallback - minimal storage format
             storage_message = {
                 "type": converted_message.get("type", "unknown"),
@@ -1124,7 +1112,7 @@ class ClaudeSDK:
                     return PermissionResultDeny(message="Invalid callback response")
 
             except Exception as e:
-                logger.error(f"Error in external permission_callback: {e}")
+                logger.exception("Error in external permission_callback")
                 return PermissionResultDeny(message=f"Permission callback error: {str(e)}")
 
         perm_logger.debug(f"No permission_callback provided. Denying tool use: '{tool_name}'")
@@ -1139,8 +1127,8 @@ class ClaudeSDK:
                 await callback(*args, **kwargs)
             else:
                 callback(*args, **kwargs)
-        except Exception as e:
-            logger.error(f"Error in callback execution: {e}")
+        except Exception:
+            logger.exception("Error in callback execution")
 
     def _convert_sdk_message(self, sdk_message: Any) -> dict[str, Any]:
         """Convert SDK message to a serializable format while preserving type information."""
@@ -1281,8 +1269,8 @@ class ClaudeSDK:
             sdk_logger.info("Claude Code SDK session terminated successfully")
             return True
 
-        except Exception as e:
-            logger.error(f"Error terminating SDK session: {e}")
+        except Exception:
+            logger.exception("Error terminating SDK session")
             # Cleanup SDK error detection handler even on error
             self._cleanup_sdk_error_detection()
             return False
@@ -1404,8 +1392,8 @@ class ClaudeSDK:
             os.close(fd)
             sdk_logger.debug(f"Created system prompt temp file: {path} ({len(content)} chars)")
             return path
-        except Exception as e:
-            logger.error(f"Failed to create system prompt temp file: {e}")
+        except Exception:
+            logger.exception("Failed to create system prompt temp file")
             raise
 
     def _cleanup_system_prompt_temp_file(self):

--- a/src/data_storage.py
+++ b/src/data_storage.py
@@ -51,8 +51,8 @@ class DataStorageManager:
                 storage_logger.info(f"Deleted legacy history.json for session {self.session_dir.name}")
 
             storage_logger.debug(f"Initialized storage for session {self.session_dir.name}")
-        except Exception as e:
-            logger.error(f"Failed to initialize storage: {e}")
+        except Exception:
+            logger.exception("Failed to initialize storage")
             raise
 
     async def append_message(self, message_data: dict[str, Any]):
@@ -69,8 +69,8 @@ class DataStorageManager:
 
 
             storage_logger.debug(f"Appended message to {self.session_dir.name}")
-        except Exception as e:
-            logger.error(f"Failed to append message: {e}")
+        except Exception:
+            logger.exception("Failed to append message")
             raise
 
     async def read_messages(self, limit: int | None = None, offset: int = 0) -> list[dict[str, Any]]:
@@ -99,8 +99,8 @@ class DataStorageManager:
                         logger.warning(f"Failed to parse message line: {line[:100]}... Error: {e}")
 
             return messages
-        except Exception as e:
-            logger.error(f"Failed to read messages: {e}")
+        except Exception:
+            logger.exception("Failed to read messages")
             return []
 
     async def get_message_count(self) -> int:
@@ -116,8 +116,8 @@ class DataStorageManager:
                         count += 1
 
             return count
-        except Exception as e:
-            logger.error(f"Failed to count messages: {e}")
+        except Exception:
+            logger.exception("Failed to count messages")
             return 0
 
     async def clear_messages(self) -> bool:
@@ -136,8 +136,8 @@ class DataStorageManager:
 
             return True
 
-        except Exception as e:
-            logger.error(f"Failed to clear messages: {e}")
+        except Exception:
+            logger.exception("Failed to clear messages")
             return False
 
     async def cleanup(self):
@@ -168,8 +168,8 @@ class DataStorageManager:
                 gc.collect()
 
             storage_logger.debug(f"Cleaned up storage for {session_name}")
-        except Exception as e:
-            logger.error(f"Failed to cleanup storage: {e}")
+        except Exception:
+            logger.exception("Failed to cleanup storage")
             # Still force GC even on error
             gc.collect()
 
@@ -203,8 +203,8 @@ class DataStorageManager:
             )
             return True
 
-        except Exception as e:
-            logger.error(f"Failed to save image file {image_id}: {e}")
+        except Exception:
+            logger.exception(f"Failed to save image file {image_id}")
             return False
 
     async def append_image(self, image_metadata: dict[str, Any]) -> bool:
@@ -236,8 +236,8 @@ class DataStorageManager:
             )
             return True
 
-        except Exception as e:
-            logger.error(f"Failed to append image metadata: {e}")
+        except Exception:
+            logger.exception("Failed to append image metadata")
             return False
 
     async def read_images(self) -> list[dict[str, Any]]:
@@ -268,8 +268,8 @@ class DataStorageManager:
 
             return images
 
-        except Exception as e:
-            logger.error(f"Failed to read images: {e}")
+        except Exception:
+            logger.exception("Failed to read images")
             return []
 
     async def get_image_file(self, image_id: str) -> bytes | None:
@@ -291,8 +291,8 @@ class DataStorageManager:
             with open(image_path, 'rb') as f:
                 return f.read()
 
-        except Exception as e:
-            logger.error(f"Failed to read image file {image_id}: {e}")
+        except Exception:
+            logger.exception(f"Failed to read image file {image_id}")
             return None
 
     async def delete_image(self, image_id: str) -> bool:
@@ -313,8 +313,8 @@ class DataStorageManager:
                 return True
             return False
 
-        except Exception as e:
-            logger.error(f"Failed to delete image {image_id}: {e}")
+        except Exception:
+            logger.exception(f"Failed to delete image {image_id}")
             return False
 
     async def clear_images(self) -> bool:
@@ -333,8 +333,8 @@ class DataStorageManager:
 
             return True
 
-        except Exception as e:
-            logger.error(f"Failed to clear images: {e}")
+        except Exception:
+            logger.exception("Failed to clear images")
             return False
 
     async def get_image_count(self) -> int:
@@ -356,8 +356,8 @@ class DataStorageManager:
 
             return count
 
-        except Exception as e:
-            logger.error(f"Failed to count images: {e}")
+        except Exception:
+            logger.exception("Failed to count images")
             return 0
 
     # =========================================================================
@@ -390,8 +390,8 @@ class DataStorageManager:
             )
             return True
 
-        except Exception as e:
-            logger.error(f"Failed to save resource file {resource_id}: {e}")
+        except Exception:
+            logger.exception(f"Failed to save resource file {resource_id}")
             return False
 
     async def append_resource(self, resource_metadata: dict[str, Any]) -> bool:
@@ -423,8 +423,8 @@ class DataStorageManager:
             )
             return True
 
-        except Exception as e:
-            logger.error(f"Failed to append resource metadata: {e}")
+        except Exception:
+            logger.exception("Failed to append resource metadata")
             return False
 
     async def read_resources(self) -> list[dict[str, Any]]:
@@ -465,8 +465,8 @@ class DataStorageManager:
 
             return resources
 
-        except Exception as e:
-            logger.error(f"Failed to read resources: {e}")
+        except Exception:
+            logger.exception("Failed to read resources")
             return []
 
     async def remove_resource_from_display(self, resource_id: str) -> bool:
@@ -501,8 +501,8 @@ class DataStorageManager:
             )
             return True
 
-        except Exception as e:
-            logger.error(f"Failed to remove resource from display {resource_id}: {e}")
+        except Exception:
+            logger.exception(f"Failed to remove resource from display {resource_id}")
             return False
 
     async def get_resource_file(self, resource_id: str) -> bytes | None:
@@ -524,8 +524,8 @@ class DataStorageManager:
             with open(resource_path, 'rb') as f:
                 return f.read()
 
-        except Exception as e:
-            logger.error(f"Failed to read resource file {resource_id}: {e}")
+        except Exception:
+            logger.exception(f"Failed to read resource file {resource_id}")
             return None
 
     async def delete_resource(self, resource_id: str) -> bool:
@@ -546,8 +546,8 @@ class DataStorageManager:
                 return True
             return False
 
-        except Exception as e:
-            logger.error(f"Failed to delete resource {resource_id}: {e}")
+        except Exception:
+            logger.exception(f"Failed to delete resource {resource_id}")
             return False
 
     async def clear_resources(self) -> bool:
@@ -566,8 +566,8 @@ class DataStorageManager:
 
             return True
 
-        except Exception as e:
-            logger.error(f"Failed to clear resources: {e}")
+        except Exception:
+            logger.exception("Failed to clear resources")
             return False
 
     async def get_resource_count(self) -> int:
@@ -589,6 +589,6 @@ class DataStorageManager:
 
             return count
 
-        except Exception as e:
-            logger.error(f"Failed to count resources: {e}")
+        except Exception:
+            logger.exception("Failed to count resources")
             return 0

--- a/src/logging_config.py
+++ b/src/logging_config.py
@@ -110,6 +110,10 @@ def configure_logging(
     debug_session_manager: bool = False,
     debug_template_manager: bool = False,
     debug_skill_manager: bool = False,
+    debug_queue_manager: bool = False,
+    debug_queue_processor: bool = False,
+    debug_archive: bool = False,
+    debug_project_manager: bool = False,
     debug_all: bool = False,
     log_dir: str = "data/logs"
 ) -> None:
@@ -127,6 +131,10 @@ def configure_logging(
         debug_session_manager: Enable session manager debugging
         debug_template_manager: Enable template manager debugging
         debug_skill_manager: Enable skill manager debugging
+        debug_queue_manager: Enable queue manager debugging
+        debug_queue_processor: Enable queue processor debugging
+        debug_archive: Enable archive manager debugging
+        debug_project_manager: Enable project manager debugging
         debug_all: Enable all debug logging (excludes ping/pong due to excessive noise)
         log_dir: Directory for log files
 
@@ -161,6 +169,10 @@ def configure_logging(
         'debug_session_manager': debug_session_manager or debug_all,
         'debug_template_manager': debug_template_manager or debug_all,
         'debug_skill_manager': debug_skill_manager or debug_all,
+        'debug_queue_manager': debug_queue_manager or debug_all,
+        'debug_queue_processor': debug_queue_processor or debug_all,
+        'debug_archive': debug_archive or debug_all,
+        'debug_project_manager': debug_project_manager or debug_all,
         'log_dir': log_dir
     }
 
@@ -250,6 +262,30 @@ def configure_logging(
             'file': f"{log_dir}/skill_manager.log",
             'enabled': _log_config['debug_skill_manager'],
             'console': _log_config['debug_skill_manager'],
+            'level': logging.DEBUG
+        },
+        'queue_manager': {
+            'file': f"{log_dir}/queue_manager.log",
+            'enabled': _log_config['debug_queue_manager'],
+            'console': _log_config['debug_queue_manager'],
+            'level': logging.DEBUG
+        },
+        'queue_processor': {
+            'file': f"{log_dir}/queue_processor.log",
+            'enabled': _log_config['debug_queue_processor'],
+            'console': _log_config['debug_queue_processor'],
+            'level': logging.DEBUG
+        },
+        'archive': {
+            'file': f"{log_dir}/archive.log",
+            'enabled': _log_config['debug_archive'],
+            'console': _log_config['debug_archive'],
+            'level': logging.DEBUG
+        },
+        'project_manager': {
+            'file': f"{log_dir}/project_manager.log",
+            'enabled': _log_config['debug_project_manager'],
+            'console': _log_config['debug_project_manager'],
             'level': logging.DEBUG
         }
     }

--- a/src/project_manager.py
+++ b/src/project_manager.py
@@ -19,7 +19,10 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from src.logging_config import get_logger
+
 logger = logging.getLogger(__name__)
+project_logger = get_logger('project_manager', category='PROJECT_MANAGER')
 
 
 @dataclass
@@ -95,7 +98,7 @@ class ProjectManager:
             self.data_dir.mkdir(exist_ok=True)
             self.projects_dir.mkdir(exist_ok=True)
             await self._load_existing_projects()
-            logger.info(f"ProjectManager initialized with {len(self._active_projects)} existing projects")
+            project_logger.info(f"ProjectManager initialized with {len(self._active_projects)} existing projects")
         except Exception as e:
             logger.error(f"Failed to initialize ProjectManager: {e}")
             raise
@@ -113,7 +116,7 @@ class ProjectManager:
                             project_info = ProjectInfo.from_dict(data)
                             self._active_projects[project_info.project_id] = project_info
                             self._project_locks[project_info.project_id] = asyncio.Lock()
-                            logger.debug(f"Loaded project {project_info.project_id} ({project_info.name})")
+                            project_logger.debug(f"Loaded project {project_info.project_id} ({project_info.name})")
                         except Exception as e:
                             logger.error(f"Failed to load project from {project_dir}: {e}")
         except Exception as e:
@@ -161,7 +164,7 @@ class ProjectManager:
 
             await self._persist_project_state(project_id)
 
-            logger.info(f"Created project {project_id} ({name}) at {working_directory}")
+            project_logger.info(f"Created project {project_id} ({name}) at {working_directory}")
             return project_info
 
         except Exception as e:
@@ -213,7 +216,7 @@ class ProjectManager:
 
                 project.updated_at = datetime.now(UTC)
                 await self._persist_project_state(project_id)
-                logger.info(f"Updated project {project_id}")
+                project_logger.info(f"Updated project {project_id}")
                 return True
 
             except Exception as e:
@@ -234,14 +237,14 @@ class ProjectManager:
                 if project_dir.exists():
                     try:
                         shutil.rmtree(project_dir)
-                        logger.info(f"Deleted project directory: {project_dir}")
+                        project_logger.info(f"Deleted project directory: {project_dir}")
                     except Exception as e:
                         logger.warning(f"Standard deletion failed for {project_dir}: {e}")
 
                         # Try Windows-specific fallback deletion
                         if os.name == 'nt':  # Windows
                             try:
-                                logger.info(f"Attempting Windows-specific deletion for {project_dir}")
+                                project_logger.info(f"Attempting Windows-specific deletion for {project_dir}")
                                 gc.collect()
                                 time.sleep(0.5)
 
@@ -253,13 +256,13 @@ class ProjectManager:
                                 )
 
                                 if result.returncode == 0:
-                                    logger.info(f"Successfully deleted directory using Windows rmdir: {project_dir}")
+                                    project_logger.info(f"Successfully deleted directory using Windows rmdir: {project_dir}")
                                 else:
                                     logger.error(f"Windows rmdir failed: {result.stderr}")
                                     return False
 
-                            except Exception as fallback_e:
-                                logger.error(f"Windows fallback deletion also failed for {project_dir}: {fallback_e}")
+                            except Exception:
+                                logger.exception(f"Windows fallback deletion also failed for {project_dir}")
                                 return False
                         else:
                             logger.error(f"Failed to delete project directory {project_dir}: {e}")
@@ -272,11 +275,11 @@ class ProjectManager:
                 if project_id in self._project_locks:
                     del self._project_locks[project_id]
 
-                logger.info(f"Successfully deleted project {project_id}")
+                project_logger.info(f"Successfully deleted project {project_id}")
                 return True
 
-            except Exception as e:
-                logger.error(f"Failed to delete project {project_id}: {e}")
+            except Exception:
+                logger.exception(f"Failed to delete project {project_id}")
                 return False
 
     async def _delete_project_internal(self, project_id: str) -> bool:
@@ -303,14 +306,14 @@ class ProjectManager:
             if project_dir.exists():
                 try:
                     shutil.rmtree(project_dir)
-                    logger.info(f"Deleted project directory: {project_dir}")
+                    project_logger.info(f"Deleted project directory: {project_dir}")
                 except Exception as e:
                     logger.warning(f"Standard deletion failed for {project_dir}: {e}")
 
                     # Try Windows-specific fallback deletion
                     if os.name == 'nt':  # Windows
                         try:
-                            logger.info(f"Attempting Windows-specific deletion for {project_dir}")
+                            project_logger.info(f"Attempting Windows-specific deletion for {project_dir}")
                             gc.collect()
                             time.sleep(0.5)
 
@@ -322,13 +325,13 @@ class ProjectManager:
                             )
 
                             if result.returncode == 0:
-                                logger.info(f"Successfully deleted directory using Windows rmdir: {project_dir}")
+                                project_logger.info(f"Successfully deleted directory using Windows rmdir: {project_dir}")
                             else:
                                 logger.error(f"Windows rmdir failed: {result.stderr}")
                                 return False
 
-                        except Exception as fallback_e:
-                            logger.error(f"Windows fallback deletion also failed for {project_dir}: {fallback_e}")
+                        except Exception:
+                            logger.exception(f"Windows fallback deletion also failed for {project_dir}")
                             return False
                     else:
                         logger.error(f"Failed to delete project directory {project_dir}: {e}")
@@ -341,11 +344,11 @@ class ProjectManager:
             # The lock will be released when remove_session_from_project() exits
             # and can be garbage collected later
 
-            logger.info(f"Successfully deleted project {project_id} (internal deletion)")
+            project_logger.info(f"Successfully deleted project {project_id} (internal deletion)")
             return True
 
-        except Exception as e:
-            logger.error(f"Failed to delete project {project_id} internally: {e}")
+        except Exception:
+            logger.exception(f"Failed to delete project {project_id} internally")
             return False
 
     async def add_session_to_project(self, project_id: str, session_id: str) -> bool:
@@ -361,7 +364,7 @@ class ProjectManager:
                     project.session_ids.insert(0, session_id)  # Insert at beginning (new sessions at top)
                     project.updated_at = datetime.now(UTC)
                     await self._persist_project_state(project_id)
-                    logger.info(f"Added session {session_id} to project {project_id}")
+                    project_logger.info(f"Added session {session_id} to project {project_id}")
                     return True
                 else:
                     logger.warning(f"Session {session_id} already in project {project_id}")
@@ -392,7 +395,7 @@ class ProjectManager:
                     project.session_ids.remove(session_id)
                     project.updated_at = datetime.now(UTC)
                     await self._persist_project_state(project_id)
-                    logger.info(f"Removed session {session_id} from project {project_id} ({len(project.session_ids)} session(s) remaining)")
+                    project_logger.info(f"Removed session {session_id} from project {project_id} ({len(project.session_ids)} session(s) remaining)")
                     return (True, False)
                 else:
                     logger.warning(f"Session {session_id} not found in project {project_id}")
@@ -423,7 +426,7 @@ class ProjectManager:
                 project.session_ids = session_ids
                 project.updated_at = datetime.now(UTC)
                 await self._persist_project_state(project_id)
-                logger.info(f"Reordered sessions in project {project_id}")
+                project_logger.info(f"Reordered sessions in project {project_id}")
                 return True
 
             except Exception as e:
@@ -433,8 +436,8 @@ class ProjectManager:
     async def reorder_projects(self, project_ids: list[str]) -> bool:
         """Reorder projects by assigning sequential order values"""
         try:
-            logger.debug(f"Reorder request for projects: {project_ids}")
-            logger.debug(f"Active projects: {list(self._active_projects.keys())}")
+            project_logger.debug(f"Reorder request for projects: {project_ids}")
+            project_logger.debug(f"Active projects: {list(self._active_projects.keys())}")
 
             # Validate that all project_ids exist
             valid_project_ids = []
@@ -458,7 +461,7 @@ class ProjectManager:
             # Check if all updates succeeded
             success_count = sum(1 for result in results if result is True)
             if success_count == len(valid_project_ids):
-                logger.info(f"Successfully reordered {success_count} projects")
+                project_logger.info(f"Successfully reordered {success_count} projects")
                 return True
             else:
                 logger.error(f"Reorder partially failed: {success_count}/{len(valid_project_ids)} projects updated")
@@ -480,7 +483,7 @@ class ProjectManager:
                 project.is_expanded = not project.is_expanded
                 project.updated_at = datetime.now(UTC)
                 await self._persist_project_state(project_id)
-                logger.info(f"Toggled expansion for project {project_id} to {project.is_expanded}")
+                project_logger.info(f"Toggled expansion for project {project_id} to {project.is_expanded}")
                 return True
 
             except Exception as e:
@@ -519,7 +522,7 @@ class ProjectManager:
             if tasks:
                 results = await asyncio.gather(*tasks, return_exceptions=True)
                 success_count = sum(1 for result in results if result is True)
-                logger.info(f"Shifted {success_count}/{len(tasks)} existing projects down for new project")
+                project_logger.info(f"Shifted {success_count}/{len(tasks)} existing projects down for new project")
 
         except Exception as e:
             logger.error(f"Failed to shift existing projects down: {e}")

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -180,8 +180,8 @@ class SessionCoordinator:
                 await self.legion_system.scheduler_service.start()
 
             coord_logger.info("Session coordinator initialized successfully")
-        except Exception as e:
-            logger.error(f"Failed to initialize session coordinator: {e}")
+        except Exception:
+            logger.exception("Failed to initialize session coordinator")
             raise
 
     async def _initialize_existing_session_storage(self):
@@ -201,8 +201,8 @@ class SessionCoordinator:
                     self._storage_managers[session_id] = storage_manager
                     # logger.info(f"Initialized storage manager for session {session_id}")
 
-        except Exception as e:
-            logger.error(f"Failed to initialize storage managers for existing sessions: {e}")
+        except Exception:
+            logger.exception("Failed to initialize storage managers for existing sessions")
             # Don't raise - this shouldn't block coordinator initialization
 
     async def _initialize_queues(self):
@@ -219,8 +219,8 @@ class SessionCoordinator:
                         queue_paused = getattr(session, 'queue_paused', False)
                         if not queue_paused:
                             self.queue_processor.ensure_running(session_id)
-        except Exception as e:
-            logger.error(f"Failed to initialize queues: {e}")
+        except Exception:
+            logger.exception("Failed to initialize queues")
 
     # =========================================================================
     # Message Queue Operations (Issue #500)
@@ -501,8 +501,8 @@ class SessionCoordinator:
 
             return session_id
 
-        except Exception as e:
-            logger.error(f"Failed to create integrated session: {e}")
+        except Exception:
+            logger.exception("Failed to create integrated session")
             raise
 
     async def get_session_storage(self, session_id: str):
@@ -704,8 +704,8 @@ class SessionCoordinator:
                     await self._resource_broadcast_callback(session_id, resource_metadata)
                 else:
                     self._resource_broadcast_callback(session_id, resource_metadata)
-            except Exception as e:
-                logger.error(f"Failed to broadcast resource_registered for {session_id}: {e}")
+            except Exception:
+                logger.exception(f"Failed to broadcast resource_registered for {session_id}")
 
     async def start_session(self, session_id: str, permission_callback: Callable[[str, dict[str, Any]], bool | dict[str, Any]] | None = None) -> bool:
         """Start a session with SDK integration"""
@@ -891,8 +891,8 @@ class SessionCoordinator:
                     await self.session_manager.update_processing_state(session_id, False)
                     await self._notify_state_change(session_id, SessionState.ERROR)
                     # logger.info(f"Updated session {session_id} state to ERROR and reset processing state")
-                except Exception as state_error:
-                    logger.error(f"Failed to update session state to ERROR: {state_error}")
+                except Exception:
+                    logger.exception("Failed to update session state to ERROR")
 
                 # Send system message explaining the failure (with raw details)
                 await self._send_session_failure_message(session_id, error_message, raw_error_message)
@@ -917,7 +917,7 @@ class SessionCoordinator:
             return True
 
         except Exception as e:
-            logger.error(f"Failed to start integrated session {session_id}: {e}")
+            logger.exception(f"Failed to start integrated session {session_id}")
 
             # Extract user-friendly error message, preserve raw for details
             raw_error_str = str(e)
@@ -929,8 +929,8 @@ class SessionCoordinator:
                 await self.session_manager.update_processing_state(session_id, False)
                 await self._notify_state_change(session_id, SessionState.ERROR)
                 coord_logger.info(f"Updated session {session_id} state to ERROR after exception")
-            except Exception as state_error:
-                logger.error(f"Failed to update session state to ERROR: {state_error}")
+            except Exception:
+                logger.exception("Failed to update session state to ERROR")
 
             # Send system message explaining the failure (with raw details)
             await self._send_session_failure_message(session_id, error_message, raw_error_str)
@@ -955,8 +955,8 @@ class SessionCoordinator:
             if success:
                 await self._notify_state_change(session_id, SessionState.PAUSED)
             return success
-        except Exception as e:
-            logger.error(f"Failed to pause session {session_id}: {e}")
+        except Exception:
+            logger.exception(f"Failed to pause session {session_id}")
             return False
 
     async def terminate_session(self, session_id: str) -> bool:
@@ -1000,8 +1000,8 @@ class SessionCoordinator:
             coord_logger.info(f"Session {session_id} stopped")
             return success
 
-        except Exception as e:
-            logger.error(f"Failed to terminate integrated session {session_id}: {e}")
+        except Exception:
+            logger.exception(f"Failed to terminate integrated session {session_id}")
             return False
 
     # =========================================================================
@@ -1114,8 +1114,8 @@ class SessionCoordinator:
             coord_logger.info(f"Archive-and-clear complete for session {session_id}")
             return True
 
-        except Exception as e:
-            logger.error(f"Failed to archive-and-clear session {session_id}: {e}")
+        except Exception:
+            logger.exception(f"Failed to archive-and-clear session {session_id}")
             return False
 
     async def update_session_name(self, session_id: str, name: str) -> bool:
@@ -1129,8 +1129,8 @@ class SessionCoordinator:
                     await self._notify_state_change(session_id, session_info.state)
             coord_logger.info(f"Updated session {session_id} name to '{name}'")
             return success
-        except Exception as e:
-            logger.error(f"Failed to update session {session_id} name: {e}")
+        except Exception:
+            logger.exception(f"Failed to update session {session_id} name")
             return False
 
     async def delete_session(self, session_id: str, archive_reason: str = "user_deleted") -> dict:
@@ -1256,8 +1256,8 @@ class SessionCoordinator:
                         coord_logger.info(f"Archived session {session_id} to {archive_result.archive_path} before deletion")
                     else:
                         coord_logger.warning(f"Failed to archive session {session_id}: {archive_result.error_message}")
-                except Exception as e:
-                    coord_logger.error(f"Error archiving session {session_id} before deletion: {e}")
+                except Exception:
+                    coord_logger.exception(f"Error archiving session {session_id} before deletion")
 
             # Step 1.8: Legion-specific cleanup (issue #349: all sessions are minions)
             if session_info and project and self.legion_system:
@@ -1271,8 +1271,8 @@ class SessionCoordinator:
                         import shutil
                         shutil.rmtree(minion_dir)
                         coord_logger.info(f"Deleted Legion minion directory: {minion_dir}")
-                    except Exception as e:
-                        coord_logger.error(f"Failed to delete Legion minion directory {minion_dir}: {e}")
+                    except Exception:
+                        coord_logger.exception(f"Failed to delete Legion minion directory {minion_dir}")
                 else:
                     coord_logger.debug(f"Legion minion directory does not exist (already cleaned): {minion_dir}")
 
@@ -1317,8 +1317,8 @@ class SessionCoordinator:
 
             return {"success": success, "deleted_session_ids": deleted_ids}
 
-        except Exception as e:
-            logger.error(f"Failed to delete integrated session {session_id}: {e}")
+        except Exception:
+            logger.exception(f"Failed to delete integrated session {session_id}")
             return {"success": False, "deleted_session_ids": deleted_ids}
 
     async def _find_project_for_session(self, session_id: str) -> ProjectInfo | None:
@@ -1394,8 +1394,8 @@ class SessionCoordinator:
 
             return result
 
-        except Exception as e:
-            logger.error(f"Failed to send message to session {session_id}: {e}")
+        except Exception:
+            logger.exception(f"Failed to send message to session {session_id}")
             # Reset processing state on error
             try:
                 await self.session_manager.update_processing_state(session_id, False)
@@ -1452,8 +1452,8 @@ class SessionCoordinator:
 
             return result
 
-        except Exception as e:
-            logger.error(f"Failed to interrupt session {session_id}: {e}")
+        except Exception:
+            logger.exception(f"Failed to interrupt session {session_id}")
             return False
 
     async def set_permission_mode(self, session_id: str, mode: str) -> bool:
@@ -1496,8 +1496,8 @@ class SessionCoordinator:
 
             return sdk_result
 
-        except Exception as e:
-            logger.error(f"Failed to set permission mode for session {session_id}: {e}")
+        except Exception:
+            logger.exception(f"Failed to set permission mode for session {session_id}")
             return False
 
     async def get_mcp_status(self, session_id: str) -> dict:
@@ -1509,8 +1509,8 @@ class SessionCoordinator:
                 return {"servers": []}
 
             return await sdk.get_mcp_status()
-        except Exception as e:
-            logger.error(f"Failed to get MCP status for session {session_id}: {e}")
+        except Exception:
+            logger.exception(f"Failed to get MCP status for session {session_id}")
             return {"servers": []}
 
     async def toggle_mcp_server(self, session_id: str, name: str, enabled: bool) -> None:
@@ -1571,8 +1571,8 @@ class SessionCoordinator:
 
             return success
 
-        except Exception as e:
-            logger.error(f"Failed to restart session {session_id}: {e}")
+        except Exception:
+            logger.exception(f"Failed to restart session {session_id}")
             return False
 
     async def reset_session(self, session_id: str, permission_callback: Callable | None = None, _from_queue_processor: bool = False) -> bool:
@@ -1644,8 +1644,8 @@ class SessionCoordinator:
 
             return success
 
-        except Exception as e:
-            logger.error(f"Failed to reset session {session_id}: {e}")
+        except Exception:
+            logger.exception(f"Failed to reset session {session_id}")
             return False
 
     async def _archive_session_for_reset(self, session_id: str) -> bool:
@@ -1760,8 +1760,8 @@ class SessionCoordinator:
                 "storage": storage_info
             }
 
-        except Exception as e:
-            logger.error(f"Failed to get session info for {session_id}: {e}")
+        except Exception:
+            logger.exception(f"Failed to get session info for {session_id}")
             return None
 
     async def list_sessions(self) -> list[dict[str, Any]]:
@@ -1769,8 +1769,8 @@ class SessionCoordinator:
         try:
             sessions = await self.session_manager.list_sessions()
             return [session.to_dict() for session in sessions]
-        except Exception as e:
-            logger.error(f"Failed to list sessions: {e}")
+        except Exception:
+            logger.exception("Failed to list sessions")
             return []
 
     @staticmethod
@@ -2385,8 +2385,8 @@ class SessionCoordinator:
                 "has_more": has_more
             }
 
-        except Exception as e:
-            logger.error(f"Failed to get messages for session {session_id}: {e}")
+        except Exception:
+            logger.exception(f"Failed to get messages for session {session_id}")
             return {
                 "messages": [],
                 "total_count": 0,
@@ -2428,8 +2428,8 @@ class SessionCoordinator:
                     await cb(session_id)
                 else:
                     cb(session_id)
-            except Exception as e:
-                logger.error(f"Error in session reset callback: {e}")
+            except Exception:
+                logger.exception("Error in session reset callback")
 
     def _get_display_projection(self, session_id: str) -> DisplayProjection:
         """
@@ -2491,9 +2491,9 @@ class SessionCoordinator:
             stored_dict = StoredMessage.from_tool_call_update(
                 tool_call, triggering_message
             ).to_dict()
-        except Exception as e:
-            coord_logger.error(
-                f"Failed to build ToolCallUpdate for {tool_call.tool_use_id}: {e}"
+        except Exception:
+            coord_logger.exception(
+                f"Failed to build ToolCallUpdate for {tool_call.tool_use_id}"
             )
             return
         asyncio.ensure_future(self._write_tool_call_update(storage, stored_dict, tool_call.tool_use_id))
@@ -2507,9 +2507,9 @@ class SessionCoordinator:
         """Write a pre-built ToolCallUpdate dict to storage (Issue #494)."""
         try:
             await storage.append_message(stored_dict)
-        except Exception as e:
-            coord_logger.error(
-                f"Failed to store ToolCallUpdate for {tool_use_id}: {e}"
+        except Exception:
+            coord_logger.exception(
+                f"Failed to store ToolCallUpdate for {tool_use_id}"
             )
 
     # ============================================================
@@ -2777,8 +2777,8 @@ class SessionCoordinator:
                 for cb in self._tool_call_broadcast_callbacks:
                     try:
                         cb(session_id, tool_call_data)
-                    except Exception as e:
-                        logger.error(f"Error in tool_call broadcast callback: {e}")
+                    except Exception:
+                        logger.exception("Error in tool_call broadcast callback")
 
         return interrupted
 
@@ -2881,8 +2881,8 @@ class SessionCoordinator:
             else:
                 logger.warning(f"No storage manager found for session {session_id}")
 
-        except Exception as e:
-            logger.error(f"Failed to store processed message for session {session_id}: {e}")
+        except Exception:
+            logger.exception(f"Failed to store processed message for session {session_id}")
             # Fallback to direct storage
             storage = self._storage_managers.get(session_id)
             if storage:
@@ -3029,16 +3029,16 @@ class SessionCoordinator:
                     try:
                         await self.session_manager.update_processing_state(session_id, False)
                         # logger.info(f"Reset processing state for session {session_id} after result message")
-                    except Exception as e:
-                        logger.error(f"Failed to reset processing state for session {session_id}: {e}")
+                    except Exception:
+                        logger.exception(f"Failed to reset processing state for session {session_id}")
 
                 # Also reset processing state on interrupt_success
                 if parsed_message.type.value == 'system' and parsed_message.metadata.get('subtype') == 'interrupt_success':
                     try:
                         await self.session_manager.update_processing_state(session_id, False)
                         coord_logger.info(f"Reset processing state for session {session_id} after interrupt")
-                    except Exception as e:
-                        logger.error(f"Failed to reset processing state after interrupt for session {session_id}: {e}")
+                    except Exception:
+                        logger.exception(f"Failed to reset processing state after interrupt for session {session_id}")
 
                 # Call registered callbacks with processed message (maintain backward compatibility)
                 callbacks = self._message_callbacks.get(session_id, [])
@@ -3056,11 +3056,11 @@ class SessionCoordinator:
                             await cb(session_id, parsed_message)
                         else:
                             cb(session_id, parsed_message)
-                    except Exception as e:
-                        logger.error(f"Error in message callback: {e}")
+                    except Exception:
+                        logger.exception("Error in message callback")
 
-            except Exception as e:
-                logger.error(f"Error processing message callback for {session_id}: {e}")
+            except Exception:
+                logger.exception(f"Error processing message callback for {session_id}")
 
         return callback
 
@@ -3081,8 +3081,8 @@ class SessionCoordinator:
                 try:
                     await self.session_manager.update_processing_state(session_id, False)
                     # logger.info(f"Reset processing state for session {session_id} after error: {error_type}")
-                except Exception as e:
-                    logger.error(f"Failed to reset processing state for session {session_id}: {e}")
+                except Exception:
+                    logger.exception(f"Failed to reset processing state for session {session_id}")
 
                 # Handle critical errors that require session state updates
                 if error_type in ["startup_failed", "message_processing_loop_error", "immediate_cli_failure"]:
@@ -3099,8 +3099,8 @@ class SessionCoordinator:
                         await self.session_manager.update_processing_state(session_id, False)
                         await self._notify_state_change(session_id, SessionState.ERROR)
                         # logger.info(f"Updated session {session_id} state to ERROR and reset processing state due to SDK error")
-                    except Exception as state_error:
-                        logger.error(f"Failed to update session state to ERROR: {state_error}")
+                    except Exception:
+                        logger.exception("Failed to update session state to ERROR")
 
                     # Send system message explaining the runtime failure (with raw details)
                     await self._send_session_failure_message(session_id, user_error_message, raw_error_str)
@@ -3118,11 +3118,11 @@ class SessionCoordinator:
                             await cb(session_id, error_data)
                         else:
                             cb(session_id, error_data)
-                    except Exception as e:
-                        logger.error(f"Error in error callback: {e}")
+                    except Exception:
+                        logger.exception("Error in error callback")
 
-            except Exception as e:
-                logger.error(f"Error processing error callback for {session_id}: {e}")
+            except Exception:
+                logger.exception(f"Error processing error callback for {session_id}")
 
         return callback
 
@@ -3145,8 +3145,8 @@ class SessionCoordinator:
                     "timestamp": get_unix_timestamp()
                 }
                 await message_callback(stderr_message)
-            except Exception as e:
-                logger.error(f"Error in stderr callback for session {session_id}: {e}")
+            except Exception:
+                logger.exception(f"Error in stderr callback for session {session_id}")
 
         return callback
 
@@ -3178,10 +3178,8 @@ class SessionCoordinator:
 
             # logger.info(f"SUCCESS: Sent client launched message for session {session_id}")
 
-        except Exception as e:
-            logger.error(f"ERROR: Failed to send client launched message for {session_id}: {e}")
-            import traceback
-            logger.error(f"ERROR: Traceback: {traceback.format_exc()}")
+        except Exception:
+            logger.exception(f"Failed to send client launched message for {session_id}")
 
     async def _send_session_failure_message(self, session_id: str, error_message: str,
                                                raw_error: str | None = None):
@@ -3211,8 +3209,8 @@ class SessionCoordinator:
             await callback(message_data)
 
             coord_logger.info(f"Session failure message sent for session {session_id}")
-        except Exception as e:
-            logger.error(f"Failed to send session failure message for {session_id}: {e}")
+        except Exception:
+            logger.exception(f"Failed to send session failure message for {session_id}")
 
     async def _send_interrupt_message(self, session_id: str):
         """Send interrupt system message via callback system (following client_launched pattern)"""
@@ -3236,8 +3234,8 @@ class SessionCoordinator:
 
             coord_logger.info(f"Interrupt message sent for session {session_id}")
 
-        except Exception as e:
-            logger.error(f"Failed to send interrupt message for {session_id}: {e}")
+        except Exception:
+            logger.exception(f"Failed to send interrupt message for {session_id}")
 
     def _format_failure_content(self, friendly_error: str, raw_error: str | None) -> str:
         """Format failure message content, extracting stderr when available.
@@ -3332,11 +3330,11 @@ class SessionCoordinator:
                         await callback(state_data)
                     else:
                         callback(state_data)
-                except Exception as e:
-                    logger.error(f"Error in state change callback: {e}")
+                except Exception:
+                    logger.exception("Error in state change callback")
 
-        except Exception as e:
-            logger.error(f"Error notifying state change for {session_id}: {e}")
+        except Exception:
+            logger.exception(f"Error notifying state change for {session_id}")
 
     async def _on_session_manager_state_change(self, session_id: str, new_state: SessionState):
         """Handle state changes from session manager"""
@@ -3415,8 +3413,8 @@ class SessionCoordinator:
             else:
                 coord_logger.info("Startup validation complete: no orphaned data found")
 
-        except Exception as e:
-            logger.error(f"Error during startup project validation: {e}")
+        except Exception:
+            logger.exception("Error during startup project validation")
             # Don't raise - this shouldn't block startup
 
     # ==================== FILE UPLOAD TRACKING (Issue #403) ====================
@@ -3558,5 +3556,5 @@ class SessionCoordinator:
 
             coord_logger.info("Session coordinator cleanup completed")
 
-        except Exception as e:
-            logger.error(f"Error during session coordinator cleanup: {e}")
+        except Exception:
+            logger.exception("Error during session coordinator cleanup")

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -330,8 +330,8 @@ class UIWebSocketManager:
                 await connection.send_json(message)
                 logger.debug(f"Broadcasted message to UI WebSocket: {message.get('type', 'unknown')}")
 
-            except Exception as e:
-                logger.error(f"Error sending to UI WebSocket connection: {e}")
+            except Exception:
+                logger.exception("Error sending to UI WebSocket connection")
                 dead_connections.append(connection)
 
         # Clean up dead connections
@@ -390,8 +390,8 @@ class WebSocketManager:
                     logger.info(f"WebSocketManager: Sending message to WebSocket connection for session {session_id}")
                     await connection.send_text(json.dumps(message))
                     logger.info(f"WebSocketManager: Message sent successfully to WebSocket connection for session {session_id}")
-                except Exception as e:
-                    logger.error(f"Error sending WebSocket message: {e}")
+                except Exception:
+                    logger.exception("Error sending WebSocket message")
                     dead_connections.append(connection)
 
             # Remove dead connections
@@ -436,8 +436,8 @@ class LegionWebSocketManager:
 
                 await connection.send_text(json.dumps(message))
                 logger.debug(f"Broadcast message to legion {legion_id} WebSocket")
-            except Exception as e:
-                logger.error(f"Error broadcasting to legion {legion_id} WebSocket: {e}")
+            except Exception:
+                logger.exception(f"Error broadcasting to legion {legion_id} WebSocket")
                 dead_connections.append(connection)
 
         # Clean up dead connections
@@ -592,16 +592,16 @@ class ClaudeWebUI:
                 "timestamp": datetime.now(UTC).isoformat()
             })
             logger.debug(f"Broadcast comm {comm.comm_id} to legion {legion_id} WebSocket clients")
-        except Exception as e:
-            logger.error(f"Error broadcasting comm to legion WebSocket: {e}")
+        except Exception:
+            logger.exception("Error broadcasting comm to legion WebSocket")
 
     async def _broadcast_schedule_to_legion_websocket(self, legion_id: str, event: dict):
         """Broadcast schedule event to WebSocket clients watching this legion."""
         try:
             await self.legion_websocket_manager.broadcast_to_legion(legion_id, event)
             logger.debug(f"Broadcast schedule event to legion {legion_id} WebSocket clients")
-        except Exception as e:
-            logger.error(f"Error broadcasting schedule event to legion WebSocket: {e}")
+        except Exception:
+            logger.exception("Error broadcasting schedule event to legion WebSocket")
 
     async def _broadcast_resource_registered(self, session_id: str, resource_metadata: dict):
         """
@@ -620,8 +620,8 @@ class ClaudeWebUI:
                 "timestamp": datetime.now(UTC).isoformat()
             })
             logger.debug(f"Broadcast resource_registered for {resource_metadata.get('resource_id')} to session {session_id}")
-        except Exception as e:
-            logger.error(f"Error broadcasting resource_registered: {e}")
+        except Exception:
+            logger.exception("Error broadcasting resource_registered")
 
     async def _broadcast_queue_update(self, session_id: str, action: str, item: dict):
         """
@@ -642,8 +642,8 @@ class ClaudeWebUI:
                 "pending_count": self.coordinator.queue_manager.get_pending_count(session_id),
                 "timestamp": datetime.now(UTC).isoformat()
             })
-        except Exception as e:
-            logger.error(f"Error broadcasting queue_update: {e}")
+        except Exception:
+            logger.exception("Error broadcasting queue_update")
 
     def _cleanup_pending_permissions_for_session(self, session_id: str):
         """Clean up pending permissions for a specific session by auto-denying them"""
@@ -672,8 +672,8 @@ class ClaudeWebUI:
             if permissions_to_cleanup:
                 logger.info(f"Cleaned up {len(permissions_to_cleanup)} pending permissions for session {session_id}")
 
-        except Exception as e:
-            logger.error(f"Error cleaning up pending permissions for session {session_id}: {e}")
+        except Exception:
+            logger.exception(f"Error cleaning up pending permissions for session {session_id}")
 
     async def initialize(self):
         """Initialize the WebUI application"""
@@ -726,7 +726,7 @@ class ClaudeWebUI:
                 )
                 return {"project": project.to_dict()}
             except Exception as e:
-                logger.error(f"Failed to create project: {e}")
+                logger.exception("Failed to create project")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.get("/api/projects")
@@ -736,7 +736,7 @@ class ClaudeWebUI:
                 projects = await self.coordinator.project_manager.list_projects()
                 return {"projects": [p.to_dict() for p in projects]}
             except Exception as e:
-                logger.error(f"Failed to list projects: {e}")
+                logger.exception("Failed to list projects")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.get("/api/projects/{project_id}")
@@ -757,7 +757,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to get project: {e}")
+                logger.exception("Failed to get project")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.put("/api/projects/reorder")
@@ -771,7 +771,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to reorder projects: {e}")
+                logger.exception("Failed to reorder projects")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.put("/api/projects/{project_id}")
@@ -797,7 +797,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to update project: {e}")
+                logger.exception("Failed to update project")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.delete("/api/projects/{project_id}")
@@ -827,7 +827,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to delete project: {e}")
+                logger.exception("Failed to delete project")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.put("/api/projects/{project_id}/toggle-expansion")
@@ -849,7 +849,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to toggle expansion: {e}")
+                logger.exception("Failed to toggle expansion")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.put("/api/projects/{project_id}/sessions/reorder")
@@ -878,7 +878,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to reorder project sessions: {e}")
+                logger.exception("Failed to reorder project sessions")
                 raise HTTPException(status_code=500, detail=str(e))
 
         # ==================== ARCHIVE ENDPOINTS ====================
@@ -895,7 +895,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to list archives: {e}")
+                logger.exception("Failed to list archives")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.get("/api/projects/{project_id}/archives/{session_id}/{archive_id}/messages")
@@ -915,7 +915,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to get archive messages: {e}")
+                logger.exception("Failed to get archive messages")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.get("/api/projects/{project_id}/archives/{session_id}/{archive_id}/state")
@@ -932,7 +932,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to get archive state: {e}")
+                logger.exception("Failed to get archive state")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.get(
@@ -953,7 +953,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to get archive resources: {e}")
+                logger.exception("Failed to get archive resources")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.get(
@@ -1005,7 +1005,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to get archive resource: {e}")
+                logger.exception("Failed to get archive resource")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.get("/api/projects/{project_id}/deleted-agents")
@@ -1020,7 +1020,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to list deleted agents: {e}")
+                logger.exception("Failed to list deleted agents")
                 raise HTTPException(status_code=500, detail=str(e))
 
         # ==================== SESSION ENDPOINTS ====================
@@ -1082,7 +1082,7 @@ class ClaudeWebUI:
                 return {"session_id": session_id}
 
             except Exception as e:
-                logger.error(f"Failed to create session: {e}")
+                logger.exception("Failed to create session")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.get("/api/sessions")
@@ -1092,7 +1092,7 @@ class ClaudeWebUI:
                 sessions = await self.coordinator.list_sessions()
                 return {"sessions": sessions}
             except Exception as e:
-                logger.error(f"Failed to list sessions: {e}")
+                logger.exception("Failed to list sessions")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.get("/api/sessions/{session_id}")
@@ -1111,7 +1111,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to get session info: {e}")
+                logger.exception("Failed to get session info")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.get("/api/sessions/{session_id}/descendants")
@@ -1125,7 +1125,7 @@ class ClaudeWebUI:
                     "count": len(descendants)
                 }
             except Exception as e:
-                logger.error(f"Failed to get descendants for session {session_id}: {e}")
+                logger.exception(f"Failed to get descendants for session {session_id}")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.post("/api/sessions/{session_id}/start")
@@ -1145,7 +1145,7 @@ class ClaudeWebUI:
                 success = await self.coordinator.start_session(session_id, permission_callback=self._create_permission_callback(session_id))
                 return {"success": success}
             except Exception as e:
-                logger.error(f"Failed to start session: {e}")
+                logger.exception("Failed to start session")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.post("/api/sessions/{session_id}/pause")
@@ -1155,7 +1155,7 @@ class ClaudeWebUI:
                 success = await self.coordinator.pause_session(session_id)
                 return {"success": success}
             except Exception as e:
-                logger.error(f"Failed to pause session: {e}")
+                logger.exception("Failed to pause session")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.post("/api/sessions/{session_id}/terminate")
@@ -1168,7 +1168,7 @@ class ClaudeWebUI:
                 success = await self.coordinator.terminate_session(session_id)
                 return {"success": success}
             except Exception as e:
-                logger.error(f"Failed to terminate session: {e}")
+                logger.exception("Failed to terminate session")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.put("/api/sessions/{session_id}/name")
@@ -1182,7 +1182,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to update session name: {e}")
+                logger.exception("Failed to update session name")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.patch("/api/sessions/{session_id}")
@@ -1279,7 +1279,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to update session: {e}")
+                logger.exception("Failed to update session")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.delete("/api/sessions/{session_id}")
@@ -1335,7 +1335,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to delete session: {e}")
+                logger.exception("Failed to delete session")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.post("/api/sessions/{session_id}/messages")
@@ -1345,7 +1345,7 @@ class ClaudeWebUI:
                 success = await self.coordinator.send_message(session_id, request.message)
                 return {"success": success}
             except Exception as e:
-                logger.error(f"Failed to send message: {e}")
+                logger.exception("Failed to send message")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.get("/api/sessions/{session_id}/messages")
@@ -1357,7 +1357,7 @@ class ClaudeWebUI:
                 )
                 return result
             except Exception as e:
-                logger.error(f"Failed to get messages: {e}")
+                logger.exception("Failed to get messages")
                 raise HTTPException(status_code=500, detail=str(e))
 
         # ==================== FILE UPLOAD ENDPOINTS ====================
@@ -1422,7 +1422,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to upload file: {e}")
+                logger.exception("Failed to upload file")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.get("/api/sessions/{session_id}/files")
@@ -1444,7 +1444,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to list files: {e}")
+                logger.exception("Failed to list files")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.delete("/api/sessions/{session_id}/files/{file_id}")
@@ -1473,7 +1473,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to delete file: {e}")
+                logger.exception("Failed to delete file")
                 raise HTTPException(status_code=500, detail=str(e))
 
         # Issue #404: Resource gallery endpoints
@@ -1484,7 +1484,7 @@ class ClaudeWebUI:
                 resources = await self.coordinator.get_session_resources(session_id)
                 return {"resources": resources, "count": len(resources)}
             except Exception as e:
-                logger.error(f"Failed to get resources: {e}")
+                logger.exception("Failed to get resources")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.get("/api/sessions/{session_id}/resources/{resource_id}")
@@ -1519,7 +1519,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to get resource: {e}")
+                logger.exception("Failed to get resource")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.get("/api/sessions/{session_id}/resources/{resource_id}/download")
@@ -1553,7 +1553,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to download resource: {e}")
+                logger.exception("Failed to download resource")
                 raise HTTPException(status_code=500, detail=str(e))
 
         # Issue #423: Remove resource from session display (soft-remove)
@@ -1575,7 +1575,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to remove resource: {e}")
+                logger.exception("Failed to remove resource")
                 raise HTTPException(status_code=500, detail=str(e))
 
         # Issue #404: Legacy image endpoints (backward compatibility)
@@ -1586,7 +1586,7 @@ class ClaudeWebUI:
                 images = await self.coordinator.get_session_images(session_id)
                 return {"images": images, "count": len(images)}
             except Exception as e:
-                logger.error(f"Failed to get images: {e}")
+                logger.exception("Failed to get images")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.get("/api/sessions/{session_id}/images/{image_id}")
@@ -1627,7 +1627,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to get image: {e}")
+                logger.exception("Failed to get image")
                 raise HTTPException(status_code=500, detail=str(e))
 
         # ==================== PERMISSION MODE ENDPOINT ====================
@@ -1648,7 +1648,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to set permission mode: {e}")
+                logger.exception("Failed to set permission mode")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.get("/api/sessions/{session_id}/mcp-status")
@@ -1658,7 +1658,7 @@ class ClaudeWebUI:
                 result = await self.coordinator.get_mcp_status(session_id)
                 return result
             except Exception as e:
-                logger.error(f"Failed to get MCP status: {e}")
+                logger.exception("Failed to get MCP status")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.post("/api/sessions/{session_id}/mcp-toggle")
@@ -1670,7 +1670,7 @@ class ClaudeWebUI:
                 )
                 return {"success": True, "name": request.name, "enabled": request.enabled}
             except Exception as e:
-                logger.error(f"Failed to toggle MCP server: {e}")
+                logger.exception("Failed to toggle MCP server")
                 raise HTTPException(status_code=400, detail=str(e))
 
         @self.app.post("/api/sessions/{session_id}/mcp-reconnect")
@@ -1680,7 +1680,7 @@ class ClaudeWebUI:
                 await self.coordinator.reconnect_mcp_server(session_id, request.name)
                 return {"success": True, "name": request.name}
             except Exception as e:
-                logger.error(f"Failed to reconnect MCP server: {e}")
+                logger.exception("Failed to reconnect MCP server")
                 raise HTTPException(status_code=400, detail=str(e))
 
         @self.app.post("/api/sessions/{session_id}/restart")
@@ -1696,7 +1696,7 @@ class ClaudeWebUI:
                 )
                 return {"success": success}
             except Exception as e:
-                logger.error(f"Failed to restart session: {e}")
+                logger.exception("Failed to restart session")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.post("/api/sessions/{session_id}/reset")
@@ -1712,7 +1712,7 @@ class ClaudeWebUI:
                 )
                 return {"success": success}
             except Exception as e:
-                logger.error(f"Failed to reset session: {e}")
+                logger.exception("Failed to reset session")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.delete("/api/sessions/{session_id}/history")
@@ -1756,7 +1756,7 @@ class ClaudeWebUI:
                     return {"success": success}
                 return {"success": True}  # Already disconnected
             except Exception as e:
-                logger.error(f"Failed to disconnect session: {e}")
+                logger.exception("Failed to disconnect session")
                 raise HTTPException(status_code=500, detail=str(e))
 
         # ==================== DIFF ENDPOINTS (Issue #435) ====================
@@ -2040,7 +2040,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to get diff for session {session_id}: {e}")
+                logger.exception(f"Failed to get diff for session {session_id}")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.get("/api/sessions/{session_id}/diff/file")
@@ -2160,7 +2160,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to get file diff for {path}: {e}")
+                logger.exception(f"Failed to get file diff for {path}")
                 raise HTTPException(status_code=500, detail=str(e))
 
         # ==================== QUEUE ENDPOINTS (Issue #500) ====================
@@ -2194,7 +2194,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to enqueue message: {e}")
+                logger.exception("Failed to enqueue message")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.get("/api/sessions/{session_id}/queue")
@@ -2208,7 +2208,7 @@ class ClaudeWebUI:
                     "pending_count": pending_count,
                 }
             except Exception as e:
-                logger.error(f"Failed to get queue: {e}")
+                logger.exception("Failed to get queue")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.delete("/api/sessions/{session_id}/queue/{queue_id}")
@@ -2224,7 +2224,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to cancel queue item: {e}")
+                logger.exception("Failed to cancel queue item")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.post("/api/sessions/{session_id}/queue/{queue_id}/requeue")
@@ -2240,7 +2240,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to requeue item: {e}")
+                logger.exception("Failed to requeue item")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.delete("/api/sessions/{session_id}/queue")
@@ -2251,7 +2251,7 @@ class ClaudeWebUI:
                 await self._broadcast_queue_update(session_id, "cleared", {"count": count})
                 return {"cancelled_count": count}
             except Exception as e:
-                logger.error(f"Failed to clear queue: {e}")
+                logger.exception("Failed to clear queue")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.put("/api/sessions/{session_id}/queue/pause")
@@ -2270,7 +2270,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to pause/resume queue: {e}")
+                logger.exception("Failed to pause/resume queue")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.put("/api/sessions/{session_id}/queue/config")
@@ -2285,7 +2285,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to update queue config: {e}")
+                logger.exception("Failed to update queue config")
                 raise HTTPException(status_code=500, detail=str(e))
 
         # ==================== LEGION ENDPOINTS ====================
@@ -2354,7 +2354,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to get timeline: {e}")
+                logger.exception("Failed to get timeline")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.get("/api/legions/{legion_id}/hierarchy")
@@ -2379,7 +2379,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to get minion hierarchy: {e}")
+                logger.exception("Failed to get minion hierarchy")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.post("/api/legions/{legion_id}/comms")
@@ -2423,7 +2423,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to send comm: {e}")
+                logger.exception("Failed to send comm")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.post("/api/legions/{legion_id}/minions")
@@ -2483,12 +2483,12 @@ class ClaudeWebUI:
 
             except ValueError as e:
                 # OverseerController raises ValueError for validation errors
-                logger.error(f"Validation error creating minion: {e}")
+                logger.exception("Validation error creating minion")
                 raise HTTPException(status_code=400, detail=str(e))
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to create minion: {e}")
+                logger.exception("Failed to create minion")
                 raise HTTPException(status_code=500, detail=str(e))
 
         # ==================== FLEET CONTROL ENDPOINTS ====================
@@ -2515,7 +2515,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to halt all minions: {e}")
+                logger.exception("Failed to halt all minions")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.post("/api/legions/{legion_id}/resume-all")
@@ -2540,7 +2540,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to resume all minions: {e}")
+                logger.exception("Failed to resume all minions")
                 raise HTTPException(status_code=500, detail=str(e))
 
         # ==================== SCHEDULE ENDPOINTS (Issue #495) ====================
@@ -2573,7 +2573,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to list schedules: {e}")
+                logger.exception("Failed to list schedules")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.post("/api/legions/{legion_id}/schedules")
@@ -2632,7 +2632,7 @@ class ClaudeWebUI:
             except ValueError as e:
                 raise HTTPException(status_code=400, detail=str(e))
             except Exception as e:
-                logger.error(f"Failed to create schedule: {e}")
+                logger.exception("Failed to create schedule")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.get("/api/legions/{legion_id}/schedules/{schedule_id}")
@@ -2648,7 +2648,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to get schedule: {e}")
+                logger.exception("Failed to get schedule")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.put("/api/legions/{legion_id}/schedules/{schedule_id}")
@@ -2673,7 +2673,7 @@ class ClaudeWebUI:
             except ValueError as e:
                 raise HTTPException(status_code=400, detail=str(e))
             except Exception as e:
-                logger.error(f"Failed to update schedule: {e}")
+                logger.exception("Failed to update schedule")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.post("/api/legions/{legion_id}/schedules/{schedule_id}/pause")
@@ -2695,7 +2695,7 @@ class ClaudeWebUI:
             except ValueError as e:
                 raise HTTPException(status_code=400, detail=str(e))
             except Exception as e:
-                logger.error(f"Failed to pause schedule: {e}")
+                logger.exception("Failed to pause schedule")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.post("/api/legions/{legion_id}/schedules/{schedule_id}/resume")
@@ -2717,7 +2717,7 @@ class ClaudeWebUI:
             except ValueError as e:
                 raise HTTPException(status_code=400, detail=str(e))
             except Exception as e:
-                logger.error(f"Failed to resume schedule: {e}")
+                logger.exception("Failed to resume schedule")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.post("/api/legions/{legion_id}/schedules/{schedule_id}/cancel")
@@ -2739,7 +2739,7 @@ class ClaudeWebUI:
             except ValueError as e:
                 raise HTTPException(status_code=400, detail=str(e))
             except Exception as e:
-                logger.error(f"Failed to cancel schedule: {e}")
+                logger.exception("Failed to cancel schedule")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.post("/api/legions/{legion_id}/schedules/{schedule_id}/run-now")
@@ -2763,7 +2763,7 @@ class ClaudeWebUI:
             except RuntimeError as e:
                 raise HTTPException(status_code=409, detail=str(e))
             except Exception as e:
-                logger.error(f"Failed to run schedule now: {e}")
+                logger.exception("Failed to run schedule now")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.delete("/api/legions/{legion_id}/schedules/{schedule_id}")
@@ -2800,7 +2800,7 @@ class ClaudeWebUI:
             except ValueError as e:
                 raise HTTPException(status_code=400, detail=str(e))
             except Exception as e:
-                logger.error(f"Failed to delete schedule: {e}")
+                logger.exception("Failed to delete schedule")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.get("/api/legions/{legion_id}/schedules/{schedule_id}/history")
@@ -2823,7 +2823,7 @@ class ClaudeWebUI:
                     "offset": offset,
                 }
             except Exception as e:
-                logger.error(f"Failed to get schedule history: {e}")
+                logger.exception("Failed to get schedule history")
                 raise HTTPException(status_code=500, detail=str(e))
 
         # ==================== PERMISSION PREVIEW ENDPOINT (Issue #36) ====================
@@ -2843,7 +2843,7 @@ class ClaudeWebUI:
                 )
                 return {"permissions": permissions}
             except Exception as e:
-                logger.error(f"Failed to preview permissions: {e}")
+                logger.exception("Failed to preview permissions")
                 raise HTTPException(status_code=500, detail=str(e))
 
         # ==================== CONFIG ENDPOINTS ====================
@@ -2920,7 +2920,7 @@ class ClaudeWebUI:
                 status = await check_docker_available()
                 return status
             except Exception as e:
-                logger.error(f"Failed to check Docker status: {e}")
+                logger.exception("Failed to check Docker status")
                 raise HTTPException(status_code=500, detail=str(e)) from e
 
         @self.app.get("/api/system/git-status")
@@ -3022,7 +3022,7 @@ class ClaudeWebUI:
                     "remote_fetch_failed": remote_fetch_failed,
                 }
             except Exception as e:
-                logger.error(f"Failed to get git status: {e}")
+                logger.exception("Failed to get git status")
                 raise HTTPException(status_code=500, detail=str(e)) from e
 
         @self.app.post("/api/system/restart", status_code=202)
@@ -3057,7 +3057,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"git pull failed: {e}")
+                logger.exception("git pull failed")
                 raise HTTPException(status_code=500, detail=str(e)) from e
 
             # Sync Python dependencies (after git pull, before restart)
@@ -3077,7 +3077,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"uv sync failed: {e}")
+                logger.exception("uv sync failed")
                 raise HTTPException(status_code=500, detail=str(e)) from e
 
             # Broadcast restart notice to all WebSocket connections
@@ -3158,7 +3158,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to browse filesystem: {e}")
+                logger.exception("Failed to browse filesystem")
                 raise HTTPException(status_code=500, detail=str(e))
 
         # ========== Template Endpoints ==========
@@ -3170,7 +3170,7 @@ class ClaudeWebUI:
                 templates = await self.coordinator.template_manager.list_templates()
                 return [t.to_dict() for t in templates]
             except Exception as e:
-                logger.error(f"Failed to list templates: {e}")
+                logger.exception("Failed to list templates")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.get("/api/templates/{template_id}")
@@ -3184,7 +3184,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to get template: {e}")
+                logger.exception("Failed to get template")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.post("/api/templates")
@@ -3219,7 +3219,7 @@ class ClaudeWebUI:
             except ValueError as e:
                 raise HTTPException(status_code=400, detail=str(e))
             except Exception as e:
-                logger.error(f"Failed to create template: {e}")
+                logger.exception("Failed to create template")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.put("/api/templates/{template_id}")
@@ -3255,7 +3255,7 @@ class ClaudeWebUI:
             except ValueError as e:
                 raise HTTPException(status_code=400, detail=str(e))
             except Exception as e:
-                logger.error(f"Failed to update template: {e}")
+                logger.exception("Failed to update template")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.delete("/api/templates/{template_id}")
@@ -3269,7 +3269,7 @@ class ClaudeWebUI:
             except HTTPException:
                 raise
             except Exception as e:
-                logger.error(f"Failed to delete template: {e}")
+                logger.exception("Failed to delete template")
                 raise HTTPException(status_code=500, detail=str(e))
 
         @self.app.websocket("/ws/ui")
@@ -3317,8 +3317,8 @@ class ClaudeWebUI:
 
             except WebSocketDisconnect:
                 logger.info("UI WebSocket disconnected")
-            except Exception as e:
-                logger.error(f"Error in UI WebSocket: {e}")
+            except Exception:
+                logger.exception("Error in UI WebSocket")
             finally:
                 self.ui_websocket_manager.disconnect(websocket)
 
@@ -3334,8 +3334,8 @@ class ClaudeWebUI:
                     logger.warning(f"Legion WebSocket connection rejected - project not found: {legion_id}")
                     await websocket.close(code=4404)
                     return
-            except Exception as e:
-                logger.error(f"Error validating project {legion_id}: {e}")
+            except Exception:
+                logger.exception(f"Error validating project {legion_id}")
                 await websocket.close(code=4500)
                 return
 
@@ -3348,8 +3348,8 @@ class ClaudeWebUI:
                     "legion_id": legion_id,
                     "timestamp": datetime.now(UTC).isoformat()
                 })
-            except Exception as e:
-                logger.error(f"Failed to send initial message to legion WebSocket {legion_id}: {e}")
+            except Exception:
+                logger.exception(f"Failed to send initial message to legion WebSocket {legion_id}")
                 self.legion_websocket_manager.disconnect(websocket, legion_id)
                 return
 
@@ -3372,8 +3372,8 @@ class ClaudeWebUI:
                         })
             except WebSocketDisconnect:
                 logger.info(f"Legion WebSocket disconnected for legion {legion_id}")
-            except Exception as e:
-                logger.error(f"Error in legion WebSocket for {legion_id}: {e}")
+            except Exception:
+                logger.exception(f"Error in legion WebSocket for {legion_id}")
             finally:
                 self.legion_websocket_manager.disconnect(websocket, legion_id)
 
@@ -3409,9 +3409,9 @@ class ClaudeWebUI:
                 validation_success_time = time.time()
                 ws_logger.debug(f"Session validation successful for {session_id} at {validation_success_time}")
 
-            except Exception as e:
+            except Exception:
                 validation_error_time = time.time()
-                logger.error(f"Error validating session {session_id} for WebSocket at {validation_error_time}: {e}")
+                logger.exception(f"Error validating session {session_id} for WebSocket at {validation_error_time}")
                 await websocket.close(code=4500)
                 return
 
@@ -3440,9 +3440,9 @@ class ClaudeWebUI:
                 initial_message_sent_time = time.time()
                 ws_logger.debug(f"Initial message sent successfully at {initial_message_sent_time}")
 
-            except Exception as e:
+            except Exception:
                 initial_message_error_time = time.time()
-                logger.error(f"Failed to send initial message to WebSocket {session_id} at {initial_message_error_time}: {e}")
+                logger.exception(f"Failed to send initial message to WebSocket {session_id} at {initial_message_error_time}")
                 # Clean up the connection that was already registered
                 self.websocket_manager.disconnect(websocket, session_id)
                 ws_logger.debug(f"WebSocket disconnected due to initial message failure for session {session_id}")
@@ -3550,7 +3550,7 @@ class ClaudeWebUI:
                                     }))
 
                             except Exception as interrupt_error:
-                                logger.error(f"Interrupt error for session {session_id}: {interrupt_error}")
+                                logger.exception(f"Interrupt error for session {session_id}")
 
                                 # Send error response back to client
                                 try:
@@ -3561,8 +3561,8 @@ class ClaudeWebUI:
                                         "session_id": session_id,
                                         "timestamp": datetime.now(UTC).isoformat()
                                     }))
-                                except Exception as response_error:
-                                    logger.error(f"Failed to send interrupt error response: {response_error}")
+                                except Exception:
+                                    logger.exception("Failed to send interrupt error response")
 
                         elif message_data.get("type") == "permission_response":
                             # Handle permission response from user
@@ -3657,7 +3657,7 @@ class ClaudeWebUI:
 
             except Exception as ws_error:
                 error_time = time.time()
-                logger.error(f"WebSocket ERROR for session {session_id} at {error_time}: {ws_error}")
+                logger.exception(f"WebSocket ERROR for session {session_id} at {error_time}")
                 logger.error(f"Error type: {type(ws_error)}")
                 logger.error(f"Total message loop iterations before error: {message_loop_iteration}")
                 self.websocket_manager.disconnect(websocket, session_id)
@@ -3700,8 +3700,8 @@ class ClaudeWebUI:
                 await self.websocket_manager.send_message(session_id, serialized)
                 logger.info(f"WebSocket message sent successfully for session {session_id}")
 
-            except Exception as e:
-                logger.error(f"Error in message callback: {e}")
+            except Exception:
+                logger.exception("Error in message callback")
 
         return callback
 
@@ -3789,8 +3789,8 @@ class ClaudeWebUI:
                                 f"for {tool_use_id} in session {session_id}"
                             )
 
-        except Exception as e:
-            logger.error(f"Error emitting tool_call updates: {e}")
+        except Exception:
+            logger.exception("Error emitting tool_call updates")
 
     async def _on_state_change(self, state_data: dict):
         """Handle session state changes"""
@@ -3816,8 +3816,8 @@ class ClaudeWebUI:
                     # Broadcast to all UI WebSocket connections instead of session-specific
                     await self.ui_websocket_manager.broadcast_to_all(message)
                     logger.info(f"Broadcasted state change for session {session_id} to all UI clients")
-        except Exception as e:
-            logger.error(f"Error handling state change: {e}")
+        except Exception:
+            logger.exception("Error handling state change")
 
     def _on_tool_call_broadcast(self, session_id: str, tool_call_data: dict):
         """Issue #520: Broadcast tool_call message via WebSocket.
@@ -3843,8 +3843,8 @@ class ClaudeWebUI:
             }
             await self.ui_websocket_manager.broadcast_to_all(message)
             logger.info(f"Broadcasted session_reset for {session_id}")
-        except Exception as e:
-            logger.error(f"Error broadcasting session_reset: {e}")
+        except Exception:
+            logger.exception("Error broadcasting session_reset")
 
     def _create_permission_callback(self, session_id: str):
         """Create permission callback for tool usage"""
@@ -3889,8 +3889,8 @@ class ClaudeWebUI:
                         # Prepend so it appears first in UI
                         suggestions.insert(0, setmode_suggestion)
                         logger.info(f"Injected setMode suggestion for ExitPlanMode in session {session_id}")
-                except Exception as inject_error:
-                    logger.error(f"Failed to inject setMode suggestion for ExitPlanMode: {inject_error}")
+                except Exception:
+                    logger.exception("Failed to inject setMode suggestion for ExitPlanMode")
 
             # Store permission request message using dataclass (Phase 0, Issue #310)
             try:
@@ -3984,13 +3984,13 @@ class ClaudeWebUI:
 
                     # Issue #491: Legacy permission_request broadcast removed.
                     # Only unified tool_call messages are emitted for permission lifecycle.
-                except Exception as ws_error:
-                    logger.error(f"Failed to broadcast permission request to WebSocket: {ws_error}")
+                except Exception:
+                    logger.exception("Failed to broadcast permission request to WebSocket")
                     # Issue #616: If broadcast failed, auto-deny rather than deadlock
                     return {"behavior": "deny"}
 
-            except Exception as e:
-                logger.error(f"Failed to store permission request message: {e}")
+            except Exception:
+                logger.exception("Failed to store permission request message")
                 return {"behavior": "deny"}
 
             # Issue #616: Session pause, Future creation, and await are now INSIDE the
@@ -4002,8 +4002,8 @@ class ClaudeWebUI:
             try:
                 await self.coordinator.session_manager.pause_session(session_id)
                 logger.info(f"Set session {session_id} to PAUSED state while waiting for permission")
-            except Exception as pause_error:
-                logger.error(f"Failed to pause session {session_id} for permission wait: {pause_error}")
+            except Exception:
+                logger.exception(f"Failed to pause session {session_id} for permission wait")
 
             # Wait for user permission decision via WebSocket
             logger.info(f"PERMISSION CALLBACK: Creating Future for request_id {request_id}")
@@ -4026,8 +4026,8 @@ class ClaudeWebUI:
                         # Use update_session_state instead of start_session to avoid re-initializing SDK
                         await self.coordinator.session_manager.update_session_state(session_id, SessionState.ACTIVE)
                         logger.info(f"Restored session {session_id} to ACTIVE state after permission decision")
-                except Exception as restore_error:
-                    logger.error(f"Failed to restore session {session_id} to ACTIVE after permission: {restore_error}")
+                except Exception:
+                    logger.exception(f"Failed to restore session {session_id} to ACTIVE after permission")
 
                 decision = response.get("behavior")
                 reasoning = f"User {decision}ed permission"
@@ -4075,8 +4075,8 @@ class ClaudeWebUI:
                             try:
                                 await self.coordinator.session_manager.update_permission_mode(session_id, new_mode)
                                 logger.info(f"Updated session {session_id} permission mode to {new_mode}")
-                            except Exception as mode_error:
-                                logger.error(f"Failed to update session mode: {mode_error}")
+                            except Exception:
+                                logger.exception("Failed to update session mode")
 
                         # Issue #630: Persist addDirectories to session configuration
                         if suggestion_dict['type'] == 'addDirectories' and suggestion_dict.get('directories'):
@@ -4088,8 +4088,8 @@ class ClaudeWebUI:
                                     f"Updated session {session_id} additional_directories "
                                     f"with {len(suggestion_dict['directories'])} dirs"
                                 )
-                            except Exception as dirs_error:
-                                logger.error(f"Failed to update session directories: {dirs_error}")
+                            except Exception:
+                                logger.exception("Failed to update session directories")
 
                     response['updated_permissions'] = updated_permissions
                     response['applied_updates_for_storage'] = applied_updates_for_storage
@@ -4153,12 +4153,12 @@ class ClaudeWebUI:
                                 f"Persisted {len(tools_to_persist)} approved tools to session "
                                 f"{session_id} allowed_tools: {tools_to_persist}"
                             )
-                        except Exception as persist_error:
-                            logger.error(f"Failed to persist approved tools: {persist_error}")
+                        except Exception:
+                            logger.exception("Failed to persist approved tools")
 
             except Exception as e:
                 # Handle any errors (e.g., session termination)
-                logger.error(f"PERMISSION CALLBACK: Error waiting for permission decision: {e}")
+                logger.exception("PERMISSION CALLBACK: Error waiting for permission decision")
                 decision = "deny"
                 reasoning = f"Permission request failed: {str(e)}"
                 response = {
@@ -4246,14 +4246,14 @@ class ClaudeWebUI:
                                 f"Broadcasted tool_call {'running' if granted else 'denied'} "
                                 f"for {tool_name} in session {session_id}"
                             )
-                except Exception as tc_error:
-                    logger.error(f"Failed to update ToolCall for permission response: {tc_error}")
+                except Exception:
+                    logger.exception("Failed to update ToolCall for permission response")
 
                 # Issue #491: Legacy permission_response broadcast removed.
                 # Only unified tool_call messages are emitted for permission lifecycle.
 
-            except Exception as e:
-                logger.error(f"Failed to store permission response message: {e}")
+            except Exception:
+                logger.exception("Failed to store permission response message")
 
             logger.info(f"Permission {decision} for tool: {tool_name} (request_id: {request_id})")
             return response


### PR DESCRIPTION
## Summary
- Register 4 new logger categories (`queue_manager`, `queue_processor`, `archive`, `project_manager`) in `logging_config.py` with file handlers and rotating log files
- Add 4 new CLI flags (`--debug-queue-manager`, `--debug-queue-processor`, `--debug-archive`, `--debug-project-manager`) in `main.py`, all included in `--debug-all`
- Add category-specific `project_logger` to `project_manager.py` for project hierarchy debug output
- Convert `logger.error(f"...{e}")` to `logger.exception("...")` in exception handlers across `data_storage.py`, `session_coordinator.py`, `web_server.py`, and `claude_sdk.py` to capture full tracebacks

Resolves #618

## Test plan
- [ ] Start with `--debug-all`, confirm `queue_manager.log`, `queue_processor.log`, `archive.log`, `project_manager.log` created in `data/logs/`
- [ ] Create/delete a project, verify `project_manager.log` has entries
- [ ] Verify existing loggers (coordinator.log, sdk_debug.log) still function
- [ ] Run `uv run pytest src/tests/ -v` — all 419 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)