### PR TITLE
fix: add color-scheme: light to prevent Chrome Auto Dark Mode inversion

### DIFF
--- a/frontend/src/assets/styles.css
+++ b/frontend/src/assets/styles.css
@@ -15,6 +15,7 @@
 
 /* Reduce default font size */
 :root {
+    color-scheme: light;
     --bs-body-font-size: 0.875rem; /* 14px if base is 16px */
 }
 


### PR DESCRIPTION
## Summary
- Adds `color-scheme: light;` to the `:root` CSS block in `frontend/src/assets/styles.css`
- This is the W3C-standard declaration telling browsers not to apply automatic dark mode inversion
- Prevents Chrome Auto Dark Mode from inverting light backgrounds on non-native elements (divs, buttons) while leaving native controls (inputs, selects) unchanged

## What Changed
One line added to `:root` in `styles.css`. No color values changed — the existing Bootstrap 5.3 light theme colors are correct.

## Test Plan
- [ ] Open on Android Chrome with Auto Dark Mode enabled — config modal should render with light backgrounds
- [ ] Open on desktop browser — no visual change expected
- [ ] Verify Quick Settings panel buttons and working directory display have light backgrounds
- [ ] Verify Advanced Settings priority cards have white backgrounds with dark text
- [ ] Verify no visual regression in other modals or UI elements

Resolves #718

🤖 Generated with [Claude Code](https://claude.com/claude-code)