### PR TITLE
fix: handle StoredMessage format in history distillation

### DIFF
--- a/src/history_distiller.py
+++ b/src/history_distiller.py
@@ -49,6 +49,41 @@ def _extract_content(msg: dict) -> str:
     return str(content) if content else ""
 
 
+def _extract_stored_message_content(data: dict) -> str:
+    """Extract text content from StoredMessage data dict.
+
+    StoredMessage data.content is a list of content blocks like
+    [{"text": "..."}, {"thinking": "..."}, {"signature": "..."}].
+    Only text fields are extracted; thinking and other block types are skipped.
+    """
+    content = data.get("content", [])
+    if not isinstance(content, list):
+        return str(content) if content else ""
+    parts = []
+    for block in content:
+        if isinstance(block, dict):
+            text = block.get("text")
+            if text:
+                parts.append(text)
+        elif isinstance(block, str):
+            parts.append(block)
+    return "\n".join(parts)
+
+
+def _is_tool_result_user_message(data: dict) -> bool:
+    """Check if a StoredMessage UserMessage is a tool result (not human speech).
+
+    Tool result UserMessages have content blocks containing tool_use_id fields.
+    """
+    content = data.get("content", [])
+    if not isinstance(content, list):
+        return False
+    return any(
+        isinstance(block, dict) and "tool_use_id" in block
+        for block in content
+    )
+
+
 async def distill_session_history(
     messages_jsonl_path: Path,
     output_path: Path,
@@ -94,8 +129,6 @@ async def distill_session_history(
                 except json.JSONDecodeError:
                     continue
 
-                msg_type = msg.get("type", "")
-                metadata = msg.get("metadata", {}) or {}
                 timestamp = msg.get("timestamp")
 
                 # Track first/last timestamps for duration
@@ -107,54 +140,133 @@ async def distill_session_history(
                         last_ts = ts_val
 
                 formatted_ts = _format_timestamp(timestamp)
-                content = _extract_content(msg)
 
-                if msg_type == "user":
-                    if metadata.get("comm"):
-                        # Inbound comm
-                        comm_data = metadata["comm"]
-                        sender = comm_data.get("from_display_name", "unknown")
-                        entries.append(
-                            f"## {formatted_ts} - Comm (Inbound from {sender})\n{content}\n"
-                        )
-                        stats["comm_inbound"] += 1
-                        stats["total"] += 1
-                    else:
-                        entries.append(f"## {formatted_ts} - User\n{content}\n")
-                        stats["user"] += 1
+                # Detect StoredMessage format (has _type field) vs legacy format
+                stored_type = msg.get("_type")
+
+                if stored_type:
+                    # --- StoredMessage format ---
+                    data = msg.get("data", {}) or {}
+
+                    if stored_type == "AssistantMessage":
+                        content = _extract_stored_message_content(data)
+                        if content:
+                            entries.append(f"## {formatted_ts} - Agent\n{content}\n")
+                            stats["agent"] += 1
+                            stats["total"] += 1
+
+                    elif stored_type == "UserMessage":
+                        if _is_tool_result_user_message(data):
+                            continue  # Skip tool result UserMessages
+                        content = _extract_stored_message_content(data)
+                        if not content:
+                            continue
+                        # Check for comm metadata
+                        metadata = msg.get("metadata", {}) or {}
+                        if metadata.get("comm"):
+                            comm_data = metadata["comm"]
+                            sender = comm_data.get("from_display_name", "unknown")
+                            entries.append(
+                                f"## {formatted_ts} - Comm (Inbound from {sender})\n"
+                                f"{content}\n"
+                            )
+                            stats["comm_inbound"] += 1
+                            stats["total"] += 1
+                        else:
+                            entries.append(f"## {formatted_ts} - User\n{content}\n")
+                            stats["user"] += 1
+                            stats["total"] += 1
+
+                    elif stored_type == "SystemMessage":
+                        subtype = data.get("subtype", "")
+                        if subtype not in _EXCLUDED_SYSTEM_SUBTYPES:
+                            content = _extract_stored_message_content(data)
+                            if content:
+                                entries.append(
+                                    f"## {formatted_ts} - System\n{content}\n"
+                                )
+                                stats["system"] += 1
+                                stats["total"] += 1
+
+                    elif stored_type == "ToolCallUpdate":
+                        tool_name = data.get("name", "")
+                        if tool_name == "mcp__legion__send_comm":
+                            tool_input = data.get("input", {}) or {}
+                            recipient = tool_input.get("to_minion_name", "unknown")
+                            summary = tool_input.get("summary", "")
+                            comm_content = tool_input.get("content", "")
+                            body = ""
+                            if summary:
+                                body += f"**Summary:** {summary}\n"
+                            if comm_content:
+                                body += f"{comm_content}\n"
+                            if not body:
+                                body = "(no content)\n"
+                            entries.append(
+                                f"## {formatted_ts} - Comm (Outbound to {recipient})\n"
+                                f"{body}"
+                            )
+                            stats["comm_outbound"] += 1
+                            stats["total"] += 1
+
+                    # All other StoredMessage _types (ResultMessage, TaskStartedMessage,
+                    # PermissionRequestMessage, etc.) are silently skipped.
+
+                else:
+                    # --- Legacy flat-dict format ---
+                    msg_type = msg.get("type", "")
+                    metadata = msg.get("metadata", {}) or {}
+                    content = _extract_content(msg)
+
+                    if msg_type == "user":
+                        if metadata.get("comm"):
+                            comm_data = metadata["comm"]
+                            sender = comm_data.get("from_display_name", "unknown")
+                            entries.append(
+                                f"## {formatted_ts} - Comm (Inbound from {sender})\n"
+                                f"{content}\n"
+                            )
+                            stats["comm_inbound"] += 1
+                            stats["total"] += 1
+                        else:
+                            entries.append(f"## {formatted_ts} - User\n{content}\n")
+                            stats["user"] += 1
+                            stats["total"] += 1
+
+                    elif msg_type == "assistant":
+                        entries.append(f"## {formatted_ts} - Agent\n{content}\n")
+                        stats["agent"] += 1
                         stats["total"] += 1
 
-                elif msg_type == "assistant":
-                    entries.append(f"## {formatted_ts} - Agent\n{content}\n")
-                    stats["agent"] += 1
-                    stats["total"] += 1
+                    elif msg_type == "system":
+                        subtype = metadata.get("subtype", "")
+                        if subtype not in _EXCLUDED_SYSTEM_SUBTYPES:
+                            entries.append(
+                                f"## {formatted_ts} - System\n{content}\n"
+                            )
+                            stats["system"] += 1
+                            stats["total"] += 1
 
-                elif msg_type == "system":
-                    subtype = metadata.get("subtype", "")
-                    if subtype not in _EXCLUDED_SYSTEM_SUBTYPES:
-                        entries.append(f"## {formatted_ts} - System\n{content}\n")
-                        stats["system"] += 1
-                        stats["total"] += 1
-
-                elif msg_type == "tool_use":
-                    tool_name = metadata.get("tool_name", "")
-                    if tool_name == "mcp__legion__send_comm":
-                        tool_input = metadata.get("tool_input", {}) or {}
-                        recipient = tool_input.get("to_minion_name", "unknown")
-                        summary = tool_input.get("summary", "")
-                        comm_content = tool_input.get("content", "")
-                        body = ""
-                        if summary:
-                            body += f"**Summary:** {summary}\n"
-                        if comm_content:
-                            body += f"{comm_content}\n"
-                        if not body:
-                            body = content + "\n"
-                        entries.append(
-                            f"## {formatted_ts} - Comm (Outbound to {recipient})\n{body}"
-                        )
-                        stats["comm_outbound"] += 1
-                        stats["total"] += 1
+                    elif msg_type == "tool_use":
+                        tool_name = metadata.get("tool_name", "")
+                        if tool_name == "mcp__legion__send_comm":
+                            tool_input = metadata.get("tool_input", {}) or {}
+                            recipient = tool_input.get("to_minion_name", "unknown")
+                            summary = tool_input.get("summary", "")
+                            comm_content = tool_input.get("content", "")
+                            body = ""
+                            if summary:
+                                body += f"**Summary:** {summary}\n"
+                            if comm_content:
+                                body += f"{comm_content}\n"
+                            if not body:
+                                body = content + "\n"
+                            entries.append(
+                                f"## {formatted_ts} - Comm (Outbound to {recipient})\n"
+                                f"{body}"
+                            )
+                            stats["comm_outbound"] += 1
+                            stats["total"] += 1
 
         # Calculate duration
         duration_str = "unknown"

--- a/src/tests/test_history_distiller.py
+++ b/src/tests/test_history_distiller.py
@@ -232,3 +232,250 @@ async def test_issue_691_structured_content(temp_dir):
     await distill_session_history(jsonl, output, "s1", "2024-01-01T00:00:00+00:00")
     content = output.read_text()
     assert "Hello\nWorld" in content
+
+
+# --- StoredMessage format tests (issue #722) ---
+
+
+@pytest.mark.asyncio
+async def test_issue_722_stored_assistant_message(temp_dir):
+    """StoredMessage AssistantMessage extracts text blocks, skips thinking."""
+    messages = [
+        {
+            "_type": "AssistantMessage",
+            "timestamp": 1700000000.0,
+            "data": {
+                "content": [
+                    {"thinking": "Let me think about this..."},
+                    {"text": "Here is my response."},
+                    {"signature": "abc123"},
+                    {"text": "And a follow-up."},
+                ]
+            },
+        },
+    ]
+    jsonl = temp_dir / "messages.jsonl"
+    output = temp_dir / "out.md"
+    _write_jsonl(jsonl, messages)
+
+    await distill_session_history(jsonl, output, "s1", "2024-01-01T00:00:00+00:00")
+    content = output.read_text()
+    assert "Agent" in content
+    assert "Here is my response." in content
+    assert "And a follow-up." in content
+    assert "thinking" not in content.split("---")[0]  # No thinking in entries
+    assert "Agent messages: 1" in content
+
+
+@pytest.mark.asyncio
+async def test_issue_722_stored_assistant_empty_skipped(temp_dir):
+    """StoredMessage AssistantMessage with only thinking blocks produces no entry."""
+    messages = [
+        {
+            "_type": "AssistantMessage",
+            "timestamp": 1700000000.0,
+            "data": {
+                "content": [
+                    {"thinking": "Just thinking, no text output."},
+                ]
+            },
+        },
+    ]
+    jsonl = temp_dir / "messages.jsonl"
+    output = temp_dir / "out.md"
+    _write_jsonl(jsonl, messages)
+
+    await distill_session_history(jsonl, output, "s1", "2024-01-01T00:00:00+00:00")
+    content = output.read_text()
+    assert "Total messages: 0" in content
+
+
+@pytest.mark.asyncio
+async def test_issue_722_stored_user_message(temp_dir):
+    """StoredMessage UserMessage extracts text content."""
+    messages = [
+        {
+            "_type": "UserMessage",
+            "timestamp": 1700000000.0,
+            "data": {
+                "content": [
+                    {"text": "Please fix the bug."},
+                ]
+            },
+        },
+    ]
+    jsonl = temp_dir / "messages.jsonl"
+    output = temp_dir / "out.md"
+    _write_jsonl(jsonl, messages)
+
+    await distill_session_history(jsonl, output, "s1", "2024-01-01T00:00:00+00:00")
+    content = output.read_text()
+    assert "User" in content
+    assert "Please fix the bug." in content
+    assert "User messages: 1" in content
+
+
+@pytest.mark.asyncio
+async def test_issue_722_stored_user_tool_result_skipped(temp_dir):
+    """StoredMessage UserMessage with tool_use_id is a tool result, skipped."""
+    messages = [
+        {
+            "_type": "UserMessage",
+            "timestamp": 1700000000.0,
+            "data": {
+                "content": [
+                    {"tool_use_id": "tool-123", "type": "tool_result", "content": "file contents"},
+                ]
+            },
+        },
+    ]
+    jsonl = temp_dir / "messages.jsonl"
+    output = temp_dir / "out.md"
+    _write_jsonl(jsonl, messages)
+
+    await distill_session_history(jsonl, output, "s1", "2024-01-01T00:00:00+00:00")
+    content = output.read_text()
+    assert "Total messages: 0" in content
+
+
+@pytest.mark.asyncio
+async def test_issue_722_stored_tool_call_send_comm(temp_dir):
+    """StoredMessage ToolCallUpdate for send_comm extracts outbound comm."""
+    messages = [
+        {
+            "_type": "ToolCallUpdate",
+            "timestamp": 1700000000.0,
+            "data": {
+                "name": "mcp__legion__send_comm",
+                "input": {
+                    "to_minion_name": "Reviewer",
+                    "summary": "Build complete",
+                    "content": "All tests passing.",
+                },
+            },
+        },
+    ]
+    jsonl = temp_dir / "messages.jsonl"
+    output = temp_dir / "out.md"
+    _write_jsonl(jsonl, messages)
+
+    await distill_session_history(jsonl, output, "s1", "2024-01-01T00:00:00+00:00")
+    content = output.read_text()
+    assert "Comm (Outbound to Reviewer)" in content
+    assert "**Summary:** Build complete" in content
+    assert "All tests passing." in content
+    assert "Outbound: 1" in content
+
+
+@pytest.mark.asyncio
+async def test_issue_722_stored_tool_call_non_comm_skipped(temp_dir):
+    """StoredMessage ToolCallUpdate for non-comm tools is skipped."""
+    messages = [
+        {
+            "_type": "ToolCallUpdate",
+            "timestamp": 1700000000.0,
+            "data": {
+                "name": "Read",
+                "input": {"file_path": "/some/file.py"},
+            },
+        },
+    ]
+    jsonl = temp_dir / "messages.jsonl"
+    output = temp_dir / "out.md"
+    _write_jsonl(jsonl, messages)
+
+    await distill_session_history(jsonl, output, "s1", "2024-01-01T00:00:00+00:00")
+    content = output.read_text()
+    assert "Total messages: 0" in content
+
+
+@pytest.mark.asyncio
+async def test_issue_722_stored_system_message(temp_dir):
+    """StoredMessage SystemMessage applies exclusion filter."""
+    messages = [
+        {
+            "_type": "SystemMessage",
+            "timestamp": 1700000000.0,
+            "data": {
+                "subtype": "task_started",
+                "content": [{"text": "should be excluded"}],
+            },
+        },
+        {
+            "_type": "SystemMessage",
+            "timestamp": 1700000001.0,
+            "data": {
+                "subtype": "init",
+                "content": [{"text": "Session initialized"}],
+            },
+        },
+    ]
+    jsonl = temp_dir / "messages.jsonl"
+    output = temp_dir / "out.md"
+    _write_jsonl(jsonl, messages)
+
+    await distill_session_history(jsonl, output, "s1", "2024-01-01T00:00:00+00:00")
+    content = output.read_text()
+    assert "System messages: 1" in content
+    assert "Session initialized" in content
+    assert "should be excluded" not in content
+
+
+@pytest.mark.asyncio
+async def test_issue_722_stored_skipped_types(temp_dir):
+    """StoredMessage ResultMessage, TaskStartedMessage, PermissionRequestMessage are skipped."""
+    messages = [
+        {"_type": "ResultMessage", "timestamp": 1700000000.0, "data": {"content": "ok"}},
+        {"_type": "TaskStartedMessage", "timestamp": 1700000001.0, "data": {}},
+        {"_type": "TaskNotificationMessage", "timestamp": 1700000002.0, "data": {}},
+        {"_type": "TaskProgressMessage", "timestamp": 1700000003.0, "data": {}},
+        {"_type": "PermissionRequestMessage", "timestamp": 1700000004.0, "data": {}},
+        {"_type": "PermissionResponseMessage", "timestamp": 1700000005.0, "data": {}},
+        {
+            "_type": "AssistantMessage",
+            "timestamp": 1700000006.0,
+            "data": {"content": [{"text": "real message"}]},
+        },
+    ]
+    jsonl = temp_dir / "messages.jsonl"
+    output = temp_dir / "out.md"
+    _write_jsonl(jsonl, messages)
+
+    await distill_session_history(jsonl, output, "s1", "2024-01-01T00:00:00+00:00")
+    content = output.read_text()
+    assert "Total messages: 1" in content
+    assert "real message" in content
+
+
+@pytest.mark.asyncio
+async def test_issue_722_mixed_legacy_and_stored(temp_dir):
+    """Mixed legacy and StoredMessage formats are both handled correctly."""
+    messages = [
+        # Legacy format
+        {"type": "user", "content": "Hello legacy", "timestamp": 1700000000.0, "metadata": {}},
+        {"type": "assistant", "content": "Legacy reply", "timestamp": 1700000001.0, "metadata": {}},
+        # StoredMessage format
+        {
+            "_type": "UserMessage",
+            "timestamp": 1700000002.0,
+            "data": {"content": [{"text": "Hello stored"}]},
+        },
+        {
+            "_type": "AssistantMessage",
+            "timestamp": 1700000003.0,
+            "data": {"content": [{"text": "Stored reply"}]},
+        },
+    ]
+    jsonl = temp_dir / "messages.jsonl"
+    output = temp_dir / "out.md"
+    _write_jsonl(jsonl, messages)
+
+    await distill_session_history(jsonl, output, "s1", "2024-01-01T00:00:00+00:00")
+    content = output.read_text()
+    assert "Hello legacy" in content
+    assert "Legacy reply" in content
+    assert "Hello stored" in content
+    assert "Stored reply" in content
+    assert "User messages: 2" in content
+    assert "Agent messages: 2" in content
+    assert "Total messages: 4" in content


### PR DESCRIPTION
## Summary
- Adds StoredMessage format (`_type` field) detection alongside existing legacy format in `src/history_distiller.py`
- Extracts AssistantMessage (text blocks only), UserMessage (skips tool results), SystemMessage (with exclusion filter), and ToolCallUpdate (send_comm outbound comms)
- Silently skips ResultMessage, TaskStartedMessage, PermissionRequestMessage, and other non-content types
- Legacy format handling unchanged — fully backward compatible

## Test plan
- [x] 9 new unit tests covering all StoredMessage types (assistant, user, tool result skip, send_comm, non-comm skip, system exclusion, skipped types, mixed formats, empty assistant)
- [x] All 19 tests pass (10 existing + 9 new)
- [x] Ruff linting passes on both changed files
- [ ] Manual verification: re-distill Builder-713 archive to confirm assistant messages now appear

Resolves #722

🤖 Generated with [Claude Code](https://claude.com/claude-code)