### PR TITLE
fix: isolate integration tests from global config file

### DIFF
--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -178,7 +178,8 @@ async def api_integration_env(request, tmp_path):
 
     fixtures_dir = Path(__file__).parent.parent / "fixtures"
 
-    webui = ClaudeWebUI(data_dir=data_dir)
+    config_file = tmp_path / "config.json"
+    webui = ClaudeWebUI(data_dir=data_dir, config_file=config_file)
     await webui.initialize()
 
     # Inject a lenient mock SDK factory: resolves fixture names when available,
@@ -295,7 +296,8 @@ def ws_integration_env(tmp_path):
 
     import asyncio
 
-    webui = ClaudeWebUI(data_dir=data_dir)
+    config_file = tmp_path / "config.json"
+    webui = ClaudeWebUI(data_dir=data_dir, config_file=config_file)
 
     # Initialize app (creates data directories, loads templates, etc.)
     # Must happen before TestClient starts, since there's no lifespan event.

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -437,9 +437,11 @@ class ClaudeWebUI:
 
     def __init__(self, data_dir: Path = None, experimental: bool = False,
                  mock_sdk: bool = False, fixtures_dir: Path | None = None,
-                 available_fixtures: list[str] | None = None):
+                 available_fixtures: list[str] | None = None,
+                 config_file: Path | None = None):
         self.app = FastAPI(title="Claude Code WebUI", version="1.0.0")
         self.coordinator = SessionCoordinator(data_dir, experimental=experimental)
+        self.config_file = config_file
 
         # Wire mock SDK factory if mock mode active (issue #561)
         if mock_sdk and fixtures_dir:
@@ -664,7 +666,7 @@ class ClaudeWebUI:
         """Initialize the WebUI application"""
         from .config_manager import load_config
         await self.coordinator.initialize()
-        config = load_config()
+        config = load_config(self.config_file) if self.config_file else load_config()
         if config.features.skill_sync_enabled:
             await self.skill_manager.sync()
         else:
@@ -2805,7 +2807,7 @@ class ClaudeWebUI:
         async def get_config():
             """Return full application config."""
             from .config_manager import load_config
-            config = load_config()
+            config = load_config(self.config_file) if self.config_file else load_config()
             return {"config": config.to_dict()}
 
         @self.app.put("/api/config")
@@ -2813,7 +2815,7 @@ class ClaudeWebUI:
             """Update application config with side effects."""
             from .config_manager import load_config, save_config
             body = await request.json()
-            config = load_config()
+            config = load_config(self.config_file) if self.config_file else load_config()
             old_sync = config.features.skill_sync_enabled
 
             # Merge features section
@@ -2830,7 +2832,10 @@ class ClaudeWebUI:
                 if "acknowledged_risk" in net:
                     config.networking.acknowledged_risk = net["acknowledged_risk"]
 
-            save_config(config)
+            if self.config_file:
+                save_config(config, self.config_file)
+            else:
+                save_config(config)
 
             # Side effects for skill sync toggle
             new_sync = config.features.skill_sync_enabled
@@ -2847,7 +2852,7 @@ class ClaudeWebUI:
         async def sync_skills():
             """Manually trigger skill sync."""
             from .config_manager import load_config
-            config = load_config()
+            config = load_config(self.config_file) if self.config_file else load_config()
             if not config.features.skill_sync_enabled:
                 raise HTTPException(status_code=409, detail="Skill syncing is disabled")
             result = await self.skill_manager.sync()
@@ -2857,7 +2862,7 @@ class ClaudeWebUI:
         async def get_skills_status():
             """Get skill sync status."""
             from .config_manager import load_config
-            config = load_config()
+            config = load_config(self.config_file) if self.config_file else load_config()
             return {
                 "sync_enabled": config.features.skill_sync_enabled,
                 "last_sync_time": self.skill_manager.last_sync_time,


### PR DESCRIPTION
## Summary
- Thread `config_file: Path | None` parameter through `ClaudeWebUI.__init__` into `initialize()` and the 4 config/skills endpoints (`get_config`, `update_config`, `sync_skills`, `get_skills_status`)
- Both integration test fixtures (`api_integration_env`, sync variant) now pass an isolated `tmp_path/config.json`, preventing test runs from reading/mutating `~/.config/cc_webui/config.json`
- No changes to `config_manager.py` — its functions already accept an optional `config_file` argument

Resolves #724

## Test plan
- [x] All 621 tests pass (`uv run pytest src/tests/ -v`)
- [x] Backend health endpoint verified on port 8724
- [x] Ruff linting clean on modified files (no new violations)
- [ ] Manual: confirm `~/.config/cc_webui/config.json` mtime unchanged after running integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)