### PR TITLE
fix: end IME composition before filling slash command on mobile

### DIFF
--- a/frontend/src/components/messages/InputArea.vue
+++ b/frontend/src/components/messages/InputArea.vue
@@ -124,7 +124,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, onUnmounted, watch, inject } from 'vue'
+import { ref, computed, onMounted, onUnmounted, watch, inject, nextTick } from 'vue'
 import { useSessionStore } from '@/stores/session'
 import { useWebSocketStore } from '@/stores/websocket'
 import { useResourceStore } from '@/stores/resource'
@@ -316,10 +316,24 @@ watch(inputText, (text) => {
  * Insert selected slash command into input
  */
 function selectSlashCommand(command) {
-  inputText.value = `/${command} `
+  const textarea = messageTextarea.value
+  // End any active IME composition by blurring (mobile virtual keyboards
+  // use composition mode for Latin text, which blocks v-model updates)
+  textarea?.blur()
+  const fullCommand = `/${command} `
+  // Set DOM value directly to bypass Vue's composition guard
+  if (textarea) {
+    textarea.value = fullCommand
+  }
+  inputText.value = fullCommand
   showSlashDropdown.value = false
-  messageTextarea.value?.focus()
-  autoResizeTextarea()
+  nextTick(() => {
+    textarea?.focus()
+    if (textarea) {
+      textarea.selectionStart = textarea.selectionEnd = fullCommand.length
+    }
+    autoResizeTextarea()
+  })
 }
 
 /**


### PR DESCRIPTION
## Summary
Resolves #770

Mobile virtual keyboards use IME composition mode for Latin text input, causing Vue's `v-model` composition guard to block reactive updates when a user taps a slash command suggestion. The textarea retains the partial text (e.g., `/appr`) instead of filling the full command (`/approve_plan `).

## Changes Made
- Modified `selectSlashCommand()` in `InputArea.vue` to blur the textarea (ending IME composition), set the DOM value directly to bypass Vue's composition guard, then re-focus with cursor placement via `nextTick`
- Added `nextTick` to Vue imports

## Testing
- Frontend build passes
- 676 unit tests pass, 0 failures
- Backend and Vite dev servers running for manual verification:
  - Backend: http://localhost:8770/?token=test
  - Frontend: http://localhost:5770/?token=test
- Manual test: type `/appr` on mobile, tap `/approve_plan` → input correctly fills

🤖 Generated with [Claude Code](https://claude.com/claude-code)