### PR TITLE
feat: add development Docker image with UV, Node.js, and Chromium

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ A development Docker image is available at `docker/Dockerfile.dev` for working o
 
 ```bash
 # Build the dev image
-docker build -f docker/Dockerfile.dev -t claude-code-dev:local docker/
+docker build -f docker/Dockerfile.dev -t claudecode-webui-dev:local docker/
 
 # Use it with claude-docker by setting the image
-CLAUDE_DOCKER_IMAGE=claude-code-dev:local claude-docker ...
+CLAUDE_DOCKER_IMAGE=claudecode-webui-dev:local claude-docker ...
 
 # Or configure it in your session's Docker image setting within the WebUI
 ```

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -4,11 +4,11 @@
 # UV (Python package manager), Node.js 22 LTS, and Chromium for headless testing.
 #
 # Build:
-#   docker build -f docker/Dockerfile.dev -t claude-code-dev:local docker/
+#   docker build -f docker/Dockerfile.dev -t claudecode-webui-dev:local docker/
 #
 # Usage with claude-docker:
-#   Set session Docker image to "claude-code-dev:local" or:
-#   CLAUDE_DOCKER_IMAGE=claude-code-dev:local claude-docker ...
+#   Set session Docker image to "claudecode-webui-dev:local" or:
+#   CLAUDE_DOCKER_IMAGE=claudecode-webui-dev:local claude-docker ...
 #
 # Running dev servers inside the container:
 #   Backend:  uv run python main.py --host 0.0.0.0 --port 8001


### PR DESCRIPTION
## Summary
- Adds `docker/Dockerfile.dev` — a development environment Docker image with UV, Node.js 22 LTS, and Chromium for headless testing
- Drop-in compatible with existing `claude-docker` infrastructure via `CLAUDE_DOCKER_IMAGE` env var
- No app code changes required; standalone artifact

## Test plan
- [ ] Build image: `docker build -f docker/Dockerfile.dev -t claude-code-dev:local docker/`
- [ ] Verify tools inside container: `claude --version`, `uv --version`, `node --version`, `chromium --version`
- [ ] Mount project and run `uv sync` + `cd frontend && npm install`
- [ ] Start backend/frontend dev servers with port forwarding
- [ ] Test Chromium headless: `chromium --headless --no-sandbox --dump-dom https://example.com`

Resolves #768

🤖 Generated with [Claude Code](https://claude.com/claude-code)