### PR TITLE
fix: persist MCP server toggles in template configuration

### DIFF
--- a/src/models/minion_template.py
+++ b/src/models/minion_template.py
@@ -49,6 +49,9 @@ class MinionTemplate:
     skill_creating_enabled: bool = False
     # MCP server configuration (issue #676)
     mcp_server_ids: list[str] | None = None
+    # MCP toggle configuration (issue #786)
+    enable_claudeai_mcp_servers: bool = True
+    strict_mcp_config: bool = False
     created_at: datetime | None = None
     updated_at: datetime | None = None
 
@@ -110,6 +113,9 @@ class MinionTemplate:
             data.setdefault('auto_memory_mode', 'claude')
         data.setdefault('skill_creating_enabled', False)
         data.setdefault('mcp_server_ids', None)
+        # MCP toggle configuration (issue #786)
+        data.setdefault('enable_claudeai_mcp_servers', True)
+        data.setdefault('strict_mcp_config', False)
         # Backward-compat renames (issue #731)
         if 'default_role' in data:
             data.setdefault('role', data.pop('default_role'))

--- a/src/template_manager.py
+++ b/src/template_manager.py
@@ -201,6 +201,8 @@ class TemplateManager:
             auto_memory_mode=config.auto_memory_mode,
             skill_creating_enabled=config.skill_creating_enabled,
             mcp_server_ids=config.mcp_server_ids if config.mcp_server_ids is not None else [],
+            enable_claudeai_mcp_servers=config.enable_claudeai_mcp_servers,
+            strict_mcp_config=config.strict_mcp_config,
         )
 
         await self._save_template(template)
@@ -253,6 +255,9 @@ class TemplateManager:
         auto_memory_mode: str | None = None,
         skill_creating_enabled: bool | None = None,
         mcp_server_ids: list[str] | None = None,
+        # MCP toggle configuration (issue #786)
+        enable_claudeai_mcp_servers: bool | None = None,
+        strict_mcp_config: bool | None = None,
     ) -> MinionTemplate:
         """Update existing template."""
         template = self.templates.get(template_id)
@@ -336,6 +341,12 @@ class TemplateManager:
 
         if mcp_server_ids is not None:
             template.mcp_server_ids = mcp_server_ids
+
+        if enable_claudeai_mcp_servers is not None:
+            template.enable_claudeai_mcp_servers = enable_claudeai_mcp_servers
+
+        if strict_mcp_config is not None:
+            template.strict_mcp_config = strict_mcp_config
 
         template.updated_at = datetime.now(UTC)
 

--- a/src/tests/test_template_manager.py
+++ b/src/tests/test_template_manager.py
@@ -326,6 +326,55 @@ class TestCreateDefaultTemplates:
             tm._get_default_templates_dir = original_fn
 
 
+# --- MCP toggle regression tests (issue #786) ---
+
+
+class TestMcpToggleRoundTrip:
+    """Regression: enable_claudeai_mcp_servers and strict_mcp_config must persist."""
+
+    def test_mcp_toggles_round_trip(self):
+        """to_dict()/from_dict() must preserve non-default MCP toggle values."""
+        template = MinionTemplate(
+            template_id="mcp-test",
+            name="MCP Toggle Test",
+            permission_mode="default",
+            enable_claudeai_mcp_servers=False,
+            strict_mcp_config=True,
+        )
+
+        data = template.to_dict()
+        restored = MinionTemplate.from_dict(data)
+
+        assert restored.enable_claudeai_mcp_servers is False
+        assert restored.strict_mcp_config is True
+
+    @pytest.mark.asyncio
+    async def test_update_mcp_toggles_persist(self, manager):
+        """update_template() must persist MCP toggle changes to disk."""
+        template = await manager.create_template(
+            name="MCP Update Test",
+            config=SessionConfig(permission_mode="default"),
+        )
+        # Defaults should be True/False
+        assert template.enable_claudeai_mcp_servers is True
+        assert template.strict_mcp_config is False
+
+        updated = await manager.update_template(
+            template.template_id,
+            enable_claudeai_mcp_servers=False,
+            strict_mcp_config=True,
+        )
+        assert updated.enable_claudeai_mcp_servers is False
+        assert updated.strict_mcp_config is True
+
+        # Reload from disk and verify persistence
+        manager2 = TemplateManager(manager.templates_dir.parent)
+        await manager2.load_templates()
+        reloaded = await manager2.get_template(template.template_id)
+        assert reloaded.enable_claudeai_mcp_servers is False
+        assert reloaded.strict_mcp_config is True
+
+
 class TestSignatureParity:
     """Ensure create_template and update_template accept all MinionTemplate fields.
 

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -309,6 +309,9 @@ class TemplateUpdateRequest(BaseModel):
     skill_creating_enabled: bool | None = None
     # MCP server configuration (issue #676)
     mcp_server_ids: list[str] | None = None
+    # MCP toggle configuration (issue #786)
+    enable_claudeai_mcp_servers: bool | None = None
+    strict_mcp_config: bool | None = None
 
 
 # MCP config request models (issue #676)
@@ -3416,6 +3419,8 @@ class ClaudeWebUI:
                     auto_memory_mode=request.auto_memory_mode,
                     skill_creating_enabled=request.skill_creating_enabled,
                     mcp_server_ids=request.mcp_server_ids,
+                    enable_claudeai_mcp_servers=request.enable_claudeai_mcp_servers,
+                    strict_mcp_config=request.strict_mcp_config,
                 )
                 return template.to_dict()
             except ValueError as e:


### PR DESCRIPTION
## Summary
Resolves #786

Three coordinated defects prevented `enable_claudeai_mcp_servers` and `strict_mcp_config` from persisting when saving minion templates. The frontend fix (adding `'template'` to the `enable_claudeai_mcp_servers` contexts array) was already merged via a prior commit; this PR fixes the remaining three backend layers.

## Changes Made
- **`src/models/minion_template.py`**: Added `enable_claudeai_mcp_servers: bool = True` and `strict_mcp_config: bool = False` fields to `MinionTemplate` dataclass; added backward-compatible `setdefault` entries in `from_dict()` so existing templates load with correct defaults
- **`src/web_server.py`**: Added both fields to `TemplateUpdateRequest`; passed them through in the `update_template` endpoint
- **`src/template_manager.py`**: `create_template()` now reads both fields from `SessionConfig`; `update_template()` accepts and applies both fields
- **`src/tests/test_template_manager.py`**: Added `TestMcpToggleRoundTrip` class with two regression tests — `to_dict()/from_dict()` round-trip and update persistence through disk reload

## Testing
- 678 unit tests pass, 0 failures (`uv run pytest src/tests/ -v`)
- Manual test steps:
  1. Open template editor → toggle "Claude AI server" OFF → Save
  2. Reopen template editor → verify toggle is still OFF
  3. Repeat with "local MCP servers" toggle
  4. Spawn a minion from the template → verify session respects the toggle values

## Dev Servers
- Backend: http://localhost:8786/?token=test
- Frontend (Vite): http://localhost:5786/?token=test

🤖 Generated with [Claude Code](https://claude.com/claude-code)