### PR TITLE
fix: agent is_processing stuck true when agent is idle

### DIFF
--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -742,6 +742,9 @@ class SessionCoordinator:
 
             # Defensively reset processing state on session start
             await self.session_manager.update_processing_state(session_id, False)
+            # Reset pending results counter — stale count from a previous run would cause
+            # is_processing to get stuck true after the next send_message completes.
+            self._pending_results[session_id] = 0
 
             # Check if SDK exists and is running
             sdk = self._active_sdks.get(session_id)
@@ -1519,6 +1522,9 @@ class SessionCoordinator:
             # Reset processing state on error
             try:
                 await self.session_manager.update_processing_state(session_id, False)
+                # Decrement the counter that was incremented before the exception so
+                # it doesn't leave is_processing permanently stuck true.
+                self._pending_results[session_id] = max(0, self._pending_results.get(session_id, 0) - 1)
             except Exception:
                 pass  # Don't fail on state update error
             return False

--- a/src/tests/test_session_coordinator.py
+++ b/src/tests/test_session_coordinator.py
@@ -622,3 +622,56 @@ class TestDeleteSessionScheduleCancellation:
         result = await coordinator.delete_session(session_id)
 
         assert result["success"] is True
+
+
+class TestIssue811IsProcessingStuck:
+    """Regression tests for issue #811 — is_processing stuck true when agent is idle."""
+
+    @pytest.mark.asyncio
+    async def test_issue_811_start_session_resets_pending_results_counter(
+        self, temp_coordinator, sample_session_config
+    ):
+        """start_session() must zero _pending_results so a stale counter from a
+        previous run cannot leave is_processing permanently stuck true."""
+        coordinator = temp_coordinator
+        session_id = await coordinator.create_session(**sample_session_config)
+
+        # Simulate a stale counter left over from a previous session run.
+        coordinator._pending_results[session_id] = 3
+
+        mock_sdk = AsyncMock()
+        mock_sdk.start.return_value = True
+        mock_sdk.is_running.return_value = False
+        coordinator.set_sdk_factory(Mock(return_value=mock_sdk))
+
+        await coordinator.start_session(session_id)
+
+        assert coordinator._pending_results.get(session_id) == 0, (
+            "start_session() must reset _pending_results to 0 to prevent is_processing getting stuck"
+        )
+
+    @pytest.mark.asyncio
+    async def test_issue_811_send_message_exception_decrements_pending_results(
+        self, temp_coordinator, sample_session_config
+    ):
+        """When send_message() raises an exception after incrementing the counter,
+        the except block must decrement it so is_processing can clear on next result."""
+        coordinator = temp_coordinator
+        session_id = await coordinator.create_session(**sample_session_config)
+
+        await coordinator.session_manager.update_session_state(session_id, SessionState.ACTIVE)
+
+        mock_sdk = AsyncMock()
+        mock_sdk.send_message.side_effect = RuntimeError("SDK blew up")
+        coordinator._active_sdks[session_id] = mock_sdk
+
+        # Counter starts at 0.
+        assert coordinator._pending_results.get(session_id, 0) == 0
+
+        result = await coordinator.send_message(session_id, "Hello!")
+
+        assert result is False
+        # Counter must be back to 0 — not left at 1.
+        assert coordinator._pending_results.get(session_id, 0) == 0, (
+            "Exception in send_message() must decrement _pending_results so is_processing can clear"
+        )


### PR DESCRIPTION
## Summary
Resolves #811

Fixes two bugs in the `_pending_results` counter (introduced in #748) that caused `is_processing` to remain permanently `true` after an agent became idle.

## Changes Made

**`src/session_coordinator.py`**
- `start_session()`: Reset `_pending_results[session_id] = 0` after resetting `is_processing`. Without this, a stale counter from a previous run left over after restart/reset caused the next `ResultMessage` to fail to clear `is_processing`.
- `send_message()` exception handler: Decrement the counter alongside the existing `update_processing_state(False)` call. Previously an exception thrown by `sdk.send_message()` left the counter at 1, so the next `ResultMessage` skipped the `is_processing` reset.

**`src/tests/test_session_coordinator.py`**
- Added `TestIssue811IsProcessingStuck` with two regression tests covering both code paths.

## Testing
- 690 existing unit tests pass with no regressions
- 2 new regression tests added and passing (`TestIssue811IsProcessingStuck`)
- Backend running at http://localhost:8811/?token=test
- Frontend running at http://localhost:5811/?token=test

🤖 Generated with [Claude Code](https://claude.com/claude-code)