### PR TITLE
fix: add emoji font to dev container for headless Chromium rendering

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -50,6 +50,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
 RUN apt-get update && apt-get install -y --no-install-recommends \
     chromium \
     chromium-driver \
+    fonts-noto-color-emoji \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # ---------- Layer 4: gh CLI (GitHub CLI) ----------


### PR DESCRIPTION
## Summary
Resolves #805

Install `fonts-noto-color-emoji` in the dev container so headless Chromium renders emoji correctly in automated UI screenshots.

## Changes Made
- Added `fonts-noto-color-emoji` to the Chromium apt-get layer in `docker/Dockerfile.dev`

## Testing
- No container build required in CI — user will rebuild and verify emoji rendering in headless Chromium screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)