### PR TITLE
chore: update skills and templates to reflect current dockerized multi-agent workflow

### DIFF
--- a/src/default_skills/approve_issue/SKILL.md
+++ b/src/default_skills/approve_issue/SKILL.md
@@ -1,25 +1,21 @@
 ---
 name: approve_issue
 description: Approve completed issue work, merge PR, and clean up resources
-disable-model-invocation: true
 argument-hint: <issue_number> [stage]
 allowed-tools:
   - Bash(git branch -d:*)
   - Bash(git checkout:*)
   - Bash(git pull:*)
   - Bash(gh pr:*)
-  - Bash(rm:*)
   - Bash(ls:*)
   - Skill(github-pr-manager)
   - Skill(custom-cleanup-process)
-  - Skill(custom-plan-manager)
-  - Skill(plan-manager)
   - Skill(worktree-manager)
 ---
 
 ## Approve Issue
 
-This skill is called when the user is satisfied with the completed work. It merges the PR, runs project-specific cleanup, disposes both the Planner and Builder, deletes the plan file, and removes the worktree.
+This skill is called when the User/Agent is satisfied with the completed work. It merges the PR, runs project-specific cleanup, disposes both the Planner and Builder, and removes the worktree.
 
 ### Arguments
 
@@ -106,18 +102,10 @@ The Builder's knowledge is archived before deletion.
 
 If Builder doesn't exist (manual workflow), warn but continue.
 
-#### 8. Delete Plan File
+#### 8. Note: No Plan File Cleanup Required
 
-Check if `custom-plan-manager` skill exists:
-```bash
-ls .claude/skills/custom-plan-manager/SKILL.md 2>/dev/null
-```
-
-If it exists, **invoke the `custom-plan-manager` skill** with operation=`delete-plan`, issue_number=$1, and stage=$2 (if provided).
-
-If it does not exist, **invoke the `plan-manager` skill** with operation=`delete-plan`, issue_number=$1, and stage=$2 (if provided).
-
-This removes the plan file from `~/.cc_webui/plans/` (or removes the `ready-to-build` label if using GitHub).
+Plans are transported via comm FILE ATTACHMENTS, not stored in `~/.cc_webui/plans/`.
+No plan file deletion is required during cleanup.
 
 #### 9. Remove Worktree
 
@@ -157,7 +145,6 @@ Completed Actions:
 - Project-specific cleanup completed (if configured)
 - Planner disposed: Planner-{suffix} (knowledge archived)
 - Builder disposed: Builder-{suffix} (knowledge archived)
-- Plan file deleted: ~/.cc_webui/plans/issue-{suffix}.md
 - Worktree removed: worktrees/issue-{suffix}/
 - Branch cleaned up with worktree
 - Main branch updated
@@ -169,8 +156,6 @@ Ready to start new issues with /plan_issue <number> [stage]
 
 - **mcp__legion__get_minion_info** - Verify Builder status
 - **mcp__legion__dispose_minion** - Dispose Planner and Builder
-- **custom-plan-manager** - Delete plan (if exists, overrides plan-manager)
-- **plan-manager** - Delete plan file (default)
 - **custom-cleanup-process** - Project-specific cleanup (if exists)
 - **github-pr-manager** - Check and merge PR
 - **worktree-manager** - Remove worktree
@@ -198,16 +183,12 @@ Ready to start new issues with /plan_issue <number> [stage]
 - Warn but continue with PR merge and cleanup
 - Manual work doesn't require minion disposal
 
-**Plan file not found:**
-- Warn but continue with cleanup
-- May have been deleted manually
-
 ### Important Notes
 
 - This is a destructive operation - resources are permanently removed
 - PR is squash-merged for clean history
 - Project-specific cleanup runs before merge (via custom-cleanup-process)
 - Both Planner and Builder are disposed (Planner was kept alive since /approve_plan)
-- Plan file is deleted from ~/.cc_webui/plans/
+- No plan file cleanup needed (comm attachments, not disk files)
 - Worktree is permanently deleted
 - Main branch is updated with merged changes

--- a/src/default_skills/approve_plan/SKILL.md
+++ b/src/default_skills/approve_plan/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: approve_plan
 description: Approve a plan and spawn a Builder to implement it
-disable-model-invocation: true
 argument-hint: <issue_number> [stage]
 allowed-tools:
   - Bash(git worktree:*)
@@ -44,31 +43,19 @@ Determine the naming suffix:
 
 If Planner doesn't exist, check if planning was done manually and proceed to spawn Builder.
 
-#### 3. Verify Plan Exists
+#### 3. Extract Plan FILE ATTACHMENT from /approve_plan Comm
 
-Check if `custom-plan-manager` skill exists:
-```bash
-ls .claude/skills/custom-plan-manager/SKILL.md 2>/dev/null
-```
+User/Agent sends /approve_plan with the plan FILE re-attached in the comm.
+- Extract the plan FILE ATTACHMENT from the incoming /approve_plan comm from User/Agent
+- If attachment is present: use this file for Builder kickoff (relay it)
+- If attachment is absent: warn User/Agent and ask if they want to proceed manually
 
-If it exists, **invoke the `custom-plan-manager` skill** with operation=`verify-plan`, issue_number=$1, and stage=$2 (if provided).
-The custom skill handles checking that the plan was posted and marked as approved.
+Note: Do NOT attempt to read plan-manager or look up `~/.cc_webui/plans/` paths.
+The plan file path is container-local to the Planner's container and is not accessible here.
+User/Agent re-attaches the file explicitly so Orchestrator never needs to reach into
+the Planner's container.
 
-If it does not exist, **invoke the `plan-manager` skill** with operation=`verify-plan`, issue_number=$1, and stage=$2 (if provided).
-The default skill checks that the plan file exists at `~/.cc_webui/plans/issue-{suffix}.md`.
-
-If plan is not found, warn user and ask if they want to proceed anyway.
-
-#### 4. Get Plan File Path
-
-The plan file path for the Builder is:
-- `$HOME/.cc_webui/plans/issue-{suffix}.md`
-
-This path will be passed to the Builder in its initialization context so it can read the plan directly.
-
-If using `custom-plan-manager`, the Builder will use the custom skill's `read-plan` operation instead.
-
-#### 5. Get Environment Configuration (if custom skill exists)
+#### 4. Get Environment Configuration (if custom skill exists)
 
 Check if `custom-environment-setup` skill exists:
 ```bash
@@ -83,7 +70,7 @@ Store the returned environment info for Builder initialization context.
 
 If it does not exist, proceed without project-specific environment configuration.
 
-#### 6. Get Worktree Path
+#### 5. Get Worktree Path
 
 Verify worktree exists:
 ```bash
@@ -92,7 +79,7 @@ git worktree list | grep "issue-{suffix}"
 
 Extract the absolute path for the Builder's working directory.
 
-#### 7. Spawn Builder Minion
+#### 6. Spawn Builder Minion
 
 **Invoke `mcp__legion__spawn_minion`** with:
 - **name**: `Builder-{suffix}`
@@ -107,12 +94,11 @@ Extract the absolute path for the Builder's working directory.
   Branch: feat/issue-{suffix}
   Issue: #$1
   Stage: {$2 if provided, else "default"}
-  Plan File: $HOME/.cc_webui/plans/issue-{suffix}.md
 
   [Include environment info from custom-environment-setup if available]
 
   Your mission:
-  1. Retrieve the approved plan (use custom-plan-manager read-plan if available, else plan-manager read-plan)
+  1. Extract the plan from your kickoff comm FILE ATTACHMENT
   2. Create task list from the plan using TaskCreate
   3. Implement changes systematically
   4. Run custom-build-process skill if it exists (project-specific build)
@@ -122,31 +108,32 @@ Extract the absolute path for the Builder's working directory.
   8. Push and create PR using github-pr-manager skill
   9. Send comm to Orchestrator with PR link
 
-  CRITICAL: If custom-test-process leaves servers running, leave them for user review.
-  The user will use /approve_issue $1 {$2 if provided} when satisfied.
+  CRITICAL: If custom-test-process leaves servers running, leave them for User/Agent review.
+  The User/Agent will use /approve_issue $1 {$2 if provided} when satisfied.
   ```
 
-#### 8. Start Builder Working
+#### 7. Start Builder Working
 
 **Invoke `mcp__legion__send_comm`** to the new Builder:
 - to_minion_name: `Builder-{suffix}`
 - summary: "Begin building issue #$1"
-- content: "Start the building workflow for issue #$1. Retrieve the approved plan and begin implementation."
+- content: "Start the building workflow for issue #$1. Extract the approved plan from this comm's FILE ATTACHMENT and begin implementation."
 - comm_type: "task"
 - interrupt_priority: "none"
+- attachments: [relay the plan FILE ATTACHMENT received from the Planner comm]
 
-#### 9. Confirm to User
+#### 8. Confirm to User/Agent
 
-Inform user:
+Inform User/Agent:
 ```
 Plan approved for issue #$1{" (stage: $2)" if stage provided}
 - Planner: Planner-{suffix} (remains alive for reference)
 - Builder spawned: Builder-{suffix}
 - Worktree: worktrees/issue-{suffix}/
-- Plan file: ~/.cc_webui/plans/issue-{suffix}.md
+- Plan: Relayed as FILE ATTACHMENT in Builder kickoff comm
 
 The Builder will:
-1. Retrieve the approved plan from file
+1. Extract the approved plan from its kickoff comm attachment
 2. Create task list and implement changes
 3. Run project-specific build, quality, and test steps (if configured)
 4. Create PR and report completion
@@ -170,9 +157,7 @@ When the Builder reports completion, you can:
 ### Important Notes
 
 - **Planner is NOT disposed** — it remains alive (idle) until `/approve_issue`
-- Builder receives plan file path in initialization context
-- Builder reads plan via custom-plan-manager read-plan or plan-manager read-plan
-- Plan verification uses custom-plan-manager if available, else plan-manager (file check)
+- Builder receives plan FILE ATTACHMENT in kickoff comm
 - Environment configuration is project-specific via custom-environment-setup
-- Test servers may be left running for user review (project-dependent)
-- User uses /approve_issue when satisfied (disposes both Planner and Builder)
+- Test servers may be left running for User/Agent review (project-dependent)
+- User/Agent uses /approve_issue when satisfied (disposes both Planner and Builder)

--- a/src/default_skills/plan-manager/SKILL.md
+++ b/src/default_skills/plan-manager/SKILL.md
@@ -17,6 +17,8 @@ allowed-tools:
 
 File-based plan storage at `~/.cc_webui/plans/`. This is the default plan manager used by the Planner/Builder workflow. Projects can override this by providing a `custom-plan-manager` skill in `.claude/skills/`.
 
+The plan file is for local Planner reference only. Do NOT share file paths across containers.
+
 ### Operations
 
 The first argument (`$1`) is the operation. The second argument (`$2`) is the issue number. The optional third argument (`$3`) is the stage name.
@@ -80,11 +82,17 @@ Writes the plan content to a file and registers it as a resource for the Resourc
 5. **Report path:**
    Output the file path so the caller knows where the plan was stored.
 
+**Note:** The reported path is container-local. Do NOT pass this path to other containers
+(Orchestrator, Builder). Instead, attach the file to your send_comm when reporting completion.
+
 ---
 
 ### Operation: read-plan
 
 **Usage:** `plan-manager read-plan <issue_number> [stage]`
+
+**Note:** This operation is for Planner local use only. The Builder no longer calls
+plan-manager read-plan — it extracts the plan from its kickoff comm FILE ATTACHMENT instead.
 
 Reads and returns the plan content from file.
 
@@ -112,6 +120,9 @@ Reads and returns the plan content from file.
 
 **Usage:** `plan-manager verify-plan <issue_number> [stage]`
 
+**Note:** Local use only. approve_plan no longer calls verify-plan — it extracts the plan
+from the Planner's completion comm attachment instead.
+
 Checks that the plan file exists and returns its absolute path.
 
 **Steps:**
@@ -138,7 +149,11 @@ Checks that the plan file exists and returns its absolute path.
 
 **Usage:** `plan-manager delete-plan <issue_number> [stage]`
 
-Deletes the plan file during cleanup (typically called by `/approve_issue`).
+**Note:** approve_issue no longer calls delete-plan. This operation is kept for manual
+cleanup only. Plans are transported via comm attachments, not retained in `~/.cc_webui/plans/`
+after the workflow completes.
+
+Deletes the plan file during cleanup.
 
 **Steps:**
 
@@ -169,3 +184,7 @@ Deletes the plan file during cleanup (typically called by `/approve_issue`).
 - The `fetch-issue` operation delegates to `github-issue-reader` by default
 - This skill is deployed automatically via the SkillManager symlink system
 - Projects can override by placing a `custom-plan-manager` in `.claude/skills/`
+- `write-plan`: local reference only — do NOT pass path to other containers
+- `read-plan`: for Planner local use only; Builder no longer calls this
+- `verify-plan`: local use only; approve_plan no longer calls this
+- `delete-plan`: no longer called by approve_issue

--- a/src/default_skills/plan_issue/SKILL.md
+++ b/src/default_skills/plan_issue/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: plan_issue
 description: Start planning phase for an issue by spawning a Planner minion
-disable-model-invocation: true
 argument-hint: <issue_number> [stage]
 allowed-tools:
   - Bash(ls:*)
@@ -32,7 +31,6 @@ This suffix is used consistently:
 - Worktree: `worktrees/issue-{suffix}/`
 - Branch: `feat/issue-{suffix}`
 - Minion: `Planner-{suffix}`
-- Plan file: `~/.cc_webui/plans/issue-{suffix}.md`
 
 ### Workflow
 
@@ -98,18 +96,19 @@ The skill will:
   Working Directory: [worktree path]
   Issue: #$1
   Stage: {$2 if provided, else "default"}
-  Plan File: $HOME/.cc_webui/plans/issue-{suffix}.md
 
   Your mission:
   1. Fetch issue details (use custom-plan-manager fetch-issue if available, else plan-manager fetch-issue)
   2. Explore current implementation using Task tool with Explore subagent
   3. Build user stories from requirements
   4. Create design artifacts (diagrams, flows) as appropriate
-  5. Present to user and iterate based on feedback
-  6. When user approves, write plan using custom-plan-manager write-plan (if available) or plan-manager write-plan
-  7. Send comm to Orchestrator: "Plan written for issue #$1, awaiting user approval"
+  5. Present to User/Agent and iterate based on feedback
+  6. When User/Agent approves, write plan using custom-plan-manager write-plan (if available) or plan-manager write-plan
+  7. Attach the plan FILE to your completion comm to Orchestrator
+     Note: The plan file path is container-local — do NOT pass paths across containers
+  8. Send comm to Orchestrator: "Plan written for issue #$1, awaiting User/Agent approval"
      IMPORTANT: Your comm is informational only. The Orchestrator will NOT
-     auto-transition to building. The user must explicitly invoke /approve_plan $1 {$2 if provided} when ready.
+     auto-transition to building. The User/Agent must explicitly invoke /approve_plan $1 {$2 if provided} when ready.
 
   CRITICAL - Codebase Exploration:
   When you need to understand the codebase structure, find relevant files, or
@@ -157,16 +156,16 @@ Planning started for issue #$1{" (stage: $2)" if stage provided}
 - Planner: Planner-{suffix}
 - Worktree: worktrees/issue-{suffix}/
 - Branch: feat/issue-{suffix}
-- Plan file: ~/.cc_webui/plans/issue-{suffix}.md
+- Plan: Will be attached as FILE to Planner comm for review
 
 The Planner will:
 1. Fetch and analyze the issue
 2. Build user stories from requirements
 3. Create design artifacts as needed
 4. Collaborate with you on requirements
-5. Write approved plan to file (viewable in Resource Gallery)
+5. Attach approved plan FILE to completion comm (viewable in Resource Gallery)
 
-Speak directly with the Planner to refine the plan.
+Speak directly with the Planner or Agent to refine the plan.
 When satisfied, use /approve_plan $1 {$2 if provided} to transition to the Building phase.
 ```
 
@@ -210,7 +209,7 @@ The Planner uses Task tool with Explore subagent for codebase investigation. Thi
 - Stage parameter enables parallel work on the same issue (e.g., backend + frontend)
 - Planner is READ-ONLY by default
 - User collaborates directly with Planner
-- Plan is written to file via plan-manager (or custom-plan-manager override)
+- Plan is written locally then attached as FILE to completion comm
 - Plan is registered as resource for Resource Gallery viewing
 - Worktree cleaned up after issue is merged
 - Environment configuration is project-specific via custom-environment-setup

--- a/src/default_skills/status_workers/SKILL.md
+++ b/src/default_skills/status_workers/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools:
 
 ## Status Workers
 
-This skill displays the status of all active Planners, Builders, and their worktrees, including stage information and plan file paths.
+This skill displays the status of all active Planners, Builders, and their worktrees, including stage information.
 
 ### Workflow
 
@@ -47,20 +47,9 @@ For each worker, **invoke `mcp__legion__get_minion_info`**:
 - Check for orphaned worktrees (no minion)
 - Check for branch status
 
-#### 5. Check Plan Files
+Plan status is tracked per-comm (file attachment), not by disk file. No plan file check needed.
 
-For each active worker, check for plan file:
-```bash
-ls "$HOME/.cc_webui/plans/" 2>/dev/null
-```
-
-Match plan files to workers:
-- `issue-42.md` → issue 42, no stage
-- `issue-501-backend.md` → issue 501, stage "backend"
-
-Identify orphaned plan files (plan exists but no active worker).
-
-#### 6. Check Running Servers (if custom skill exists)
+#### 5. Check Running Servers (if custom skill exists)
 
 Check if `custom-environment-setup` skill exists:
 ```bash
@@ -73,7 +62,7 @@ If it exists, **invoke the `custom-environment-setup` skill** to get environment
 
 If it does not exist, skip server/port status display.
 
-#### 7. Display Summary
+#### 6. Display Summary
 
 Show formatted status:
 ```
@@ -86,32 +75,25 @@ Issue #42 - Planner-42 (Planning Phase)
   Status: Collaborating with user
   Worktree: worktrees/issue-42/
   Branch: feat/issue-42
-  Plan: ~/.cc_webui/plans/issue-42.md (exists/pending)
 
 Issue #501 - Planner-501-backend (Planning Phase, stage: backend)
   Status: Idle (awaiting /approve_plan 501 backend)
   Worktree: worktrees/issue-501-backend/
   Branch: feat/issue-501-backend
-  Plan: ~/.cc_webui/plans/issue-501-backend.md (exists)
 
 Issue #501 - Builder-501-frontend (Building Phase, stage: frontend)
   Status: Implementing
   Worktree: worktrees/issue-501-frontend/
   Branch: feat/issue-501-frontend
-  Plan: ~/.cc_webui/plans/issue-501-frontend.md (exists)
   [Environment info from custom-environment-setup if available]
 
 Issue #123 - Builder-123 (Building Phase)
   Status: Testing
   Worktree: worktrees/issue-123/
   Branch: feat/issue-123
-  Plan: ~/.cc_webui/plans/issue-123.md (exists)
 
 Orphaned Worktrees: <count if any>
   - worktrees/issue-789/ (no minion found)
-
-Orphaned Plan Files: <count if any>
-  - ~/.cc_webui/plans/issue-800.md (no active worker)
 ```
 
 ### Skills Used
@@ -125,8 +107,8 @@ Orphaned Plan Files: <count if any>
 
 - Shows real-time status of all Planners and Builders
 - Parses stage suffix from minion names for multi-stage display
-- Shows plan file path and existence status per worker
 - Identifies which phase each issue is in (Planning vs Building)
 - Shows running servers and ports if custom-environment-setup is available
-- Identifies orphaned worktrees (no minion) and orphaned plan files (no worker)
+- Identifies orphaned worktrees (no minion)
+- Plan status tracked per-comm (attachment model), not by file
 - Helps coordinate multiple parallel issues and stages

--- a/src/default_templates/issue_builder.md
+++ b/src/default_templates/issue_builder.md
@@ -11,16 +11,12 @@ You are an Issue Builder minion responsible for implementing an approved plan fo
 
 ### Phase 1: Plan Retrieval
 
-1. **Fetch Implementation Plan**
-   Check if `custom-plan-manager` skill exists:
-   ```bash
-   ls .claude/skills/custom-plan-manager/SKILL.md 2>/dev/null
-   ```
-   If it exists, invoke `custom-plan-manager` with operation=`read-plan` and issue_number=${ISSUE_NUMBER} and stage=${STAGE} (if provided in init context).
-   The custom skill retrieves the approved plan from the configured issue tracker.
-
-   If it does not exist, invoke `plan-manager` with operation=`read-plan` and issue_number=${ISSUE_NUMBER} and stage=${STAGE} (if provided in init context).
-   The plan-manager reads the plan from `${PLAN_FILE}` (path provided in your initialization context).
+1. **Extract Implementation Plan from Kickoff Comm**
+   The plan was delivered as a FILE ATTACHMENT in your kickoff comm from the Orchestrator.
+   - Check your received comms for the plan file attachment
+   - Read the attached plan file directly using the Read tool
+   - Do NOT invoke plan-manager or custom-plan-manager read-plan
+   - Do NOT use any ${PLAN_FILE} path variable (no longer passed in init context)
 
    Extract all user stories, steps, and acceptance criteria from the plan.
 

--- a/src/default_templates/issue_planner.md
+++ b/src/default_templates/issue_planner.md
@@ -2,7 +2,7 @@ You are an Issue Planner minion responsible for the planning phase of issue impl
 
 ## Your Mission
 
-Transform an issue into a detailed, approved implementation plan through user collaboration.
+Transform an issue into a detailed, approved implementation plan through User/Agent collaboration.
 
 ## Planning Workflow
 
@@ -36,8 +36,8 @@ Transform an issue into a detailed, approved implementation plan through user co
    - API specifications for endpoint changes
    - State diagrams for complex workflows
 
-5. **Present to User**
-   - Share user stories and diagrams with the user
+5. **Present to User/Agent**
+   - Share user stories and diagrams with the User/Agent
    - Ask clarifying questions about ambiguous requirements
    - Request feedback on proposed approach
 
@@ -54,8 +54,8 @@ Transform an issue into a detailed, approved implementation plan through user co
    - Define testing strategy
    - Note risks and dependencies
 
-8. **User Approval**
-   - Present final plan to user
+8. **User/Agent Approval**
+   - Present final plan to User/Agent
    - Get explicit approval before writing
 
 9. **Write Approved Plan**
@@ -69,19 +69,22 @@ Transform an issue into a detailed, approved implementation plan through user co
    If it does not exist, invoke `plan-manager` with operation=`write-plan` and issue_number=${ISSUE_NUMBER} and stage=${STAGE} (if provided in init context).
    The plan-manager will:
    - Create directory `$HOME/.cc_webui/plans/` if needed
-   - Write plan to `$HOME/.cc_webui/plans/issue-{suffix}.md`
+   - Write plan to `$HOME/.cc_webui/plans/issue-{suffix}.md` (local reference only)
    - Register the plan as a resource for the Resource Gallery
 
+   After writing, note the absolute file path — you will attach this FILE in step 10.
+
 10. **Signal Completion**
-    - Send comm to Orchestrator: "Plan written for issue #${ISSUE_NUMBER}, awaiting user approval"
+    - Send comm to Orchestrator: "Plan written for issue #${ISSUE_NUMBER}, awaiting User/Agent approval"
     - comm_type: "report"
-    - Include summary of the plan and the plan file path
+    - Include summary of the plan; **attach the plan FILE** (absolute path) as a comm attachment
+    - **Note:** The plan file path is container-local — do NOT pass paths to other containers
 
     **CRITICAL**: Your comm is **informational only**. It does NOT trigger the Build phase.
-    The user must explicitly invoke `/approve_plan ${ISSUE_NUMBER}` when they are satisfied.
-    You remain active for potential iteration — the user may request revisions, ask questions,
+    The User/Agent must explicitly invoke `/approve_plan ${ISSUE_NUMBER}` when they are satisfied.
+    You remain active for potential iteration — the User/Agent may request revisions, ask questions,
     or refine the plan further. Do NOT attempt to advance the workflow or modify the plan
-    without explicit user direction.
+    without explicit User/Agent direction.
 
 ## Communication Requirements
 
@@ -100,18 +103,17 @@ Transform an issue into a detailed, approved implementation plan through user co
 ## Constraints
 
 **READ-ONLY by default:**
-- Do NOT modify project files unless user explicitly requests
+- Do NOT modify project files unless User/Agent explicitly requests
 - Focus on research, analysis, and design
-- Plan artifacts are written to `~/.cc_webui/plans/` (outside the project directory)
+- Plan is written locally for reference; transported via comm FILE ATTACHMENT
 
-**User-driven:**
-- All decisions flow through user approval
+**User/Agent-driven:**
+- All decisions flow through User/Agent approval
 - Never assume requirements - ask for clarification
 - Present options when multiple approaches exist
 
 **Clean handoff:**
-- The Builder receives the plan file path in its initialization context
-- Builder reads plan via custom-plan-manager read-plan or plan-manager read-plan
+- Builder receives plan FILE ATTACHMENT in its kickoff comm
 - Your worktree state doesn't matter to Builder
 
 ## Plan Format
@@ -150,7 +152,7 @@ Use this structure when writing the plan:
 - Components: N
 
 ---
-Plan approved by user. Ready for implementation.
+Plan approved by User/Agent. Ready for implementation.
 ```
 
 ## Success Criteria
@@ -160,7 +162,7 @@ Your planning phase is complete when:
 - [x] User stories created and approved
 - [x] Design artifacts created (if applicable)
 - [x] Implementation plan finalized
-- [x] Plan written to file (via custom-plan-manager or plan-manager) and registered as resource
+- [x] Plan written locally and FILE attached to completion comm (registered as resource)
 - [x] Orchestrator notified with completion comm
-- [x] Waiting for user to invoke `/approve_plan` (do NOT auto-advance)
+- [x] Waiting for User/Agent to invoke `/approve_plan` (do NOT auto-advance)
 - [x] You remain alive until `/approve_issue` disposes you

--- a/src/default_templates/orchestrator.md
+++ b/src/default_templates/orchestrator.md
@@ -11,26 +11,26 @@ When user requests work on an issue:
    - Branch: `feat/issue-{suffix}` based on latest main
    - Invokes `custom-environment-setup` if available (for project-specific config)
    - Spawns **Planner** minion with "Issue Planner" template
-   - Plan will be written to `~/.cc_webui/plans/issue-{suffix}.md`
-2. Planner collaborates with user:
+   - Planner will attach plan FILE to send_comm for review
+2. Planner collaborates with User/Agent:
    - Builds user stories from requirements
    - Creates design artifacts (diagrams, flows)
-   - Iterates based on user feedback
-   - Writes approved plan to file (via custom-plan-manager or plan-manager)
+   - Iterates based on feedback
+   - Attaches plan FILE to completion comm
    - Plan registered as resource (viewable in Resource Gallery)
 3. Planner signals completion via comm
 
-**CRITICAL: Do NOT proceed to the Build phase until the user explicitly runs `/approve_plan <number> [stage]`.** Planner comms saying "plan ready" or "plan written" are **informational status updates**, NOT approval signals. The user may want to iterate with the Planner, request revisions, or ask clarifying questions. Only the explicit `/approve_plan` command from the user indicates approval. Do not spawn a Builder until this command is received.
+**CRITICAL: Do NOT proceed to the Build phase until the User/Agent explicitly invokes `/approve_plan <number> [stage]`.** Planner comms saying "plan ready" or "plan written" are **informational status updates**, NOT approval signals. The User/Agent may want to iterate with the Planner, request revisions, or ask clarifying questions. Only the explicit `/approve_plan` command from the User/Agent indicates approval. Do not spawn a Builder until this command is received.
 
 ### Phase 2: Building
-When user has explicitly approved the plan via `/approve_plan`:
+When User/Agent has explicitly approved the plan via `/approve_plan`:
 1. Use `/approve_plan <number> [stage]` command:
    - **Planner stays alive** (idle, for reference during build)
    - Invokes `custom-environment-setup` if available (for Builder config)
    - Spawns **Builder** minion with "Issue Builder" template in same worktree
-   - Builder receives plan file path in initialization context
+   - Builder receives plan FILE ATTACHMENT in kickoff comm
 2. Builder implements the plan:
-   - Reads approved plan from file (via custom-plan-manager or plan-manager)
+   - Extracts plan from kickoff comm attachment
    - Creates task list and implements changes
    - Runs `custom-build-process`, `custom-quality-check`, `custom-test-process` if available
    - Creates PR and reports completion
@@ -41,7 +41,7 @@ When build is complete:
 1. Notify user with:
    - PR link for code review
    - Any test server URLs (if custom-test-process started them)
-2. User reviews via running servers and PR
+2. User/Agent reviews via running servers and PR
 3. User may iterate with Builder for adjustments
 4. User signals approval when satisfied
 
@@ -51,7 +51,6 @@ When user approves:
    - Runs `custom-cleanup-process` if available (project-specific cleanup)
    - Merges PR (squash merge)
    - Disposes **both** Planner and Builder minions
-   - Deletes plan file from `~/.cc_webui/plans/`
    - Removes worktree
    - Deletes branch
    - Updates main
@@ -62,7 +61,7 @@ All commands support an optional stage parameter for multi-stage workflows:
 - Without stage: suffix = `<number>` (e.g., `42`)
 - With stage: suffix = `<number>-<stage>` (e.g., `501-backend`)
 
-The suffix is used consistently for: worktree, branch, minion names, and plan file.
+The suffix is used consistently for: worktree, branch, and minion names.
 
 ## Key Commands
 
@@ -70,7 +69,7 @@ The suffix is used consistently for: worktree, branch, minion names, and plan fi
 |---------|--------|
 | `/plan_issue <n> [stage]` | Create worktree, spawn Planner |
 | `/approve_plan <n> [stage]` | Spawn Builder (Planner stays alive) |
-| `/approve_issue <n> [stage]` | Merge PR, dispose both, delete plan, clean up |
+| `/approve_issue <n> [stage]` | Merge PR, dispose both, clean up |
 | `/status_workers` | Show all active Planners/Builders with stages |
 
 ## Custom Skill Injection Points
@@ -97,7 +96,7 @@ If a custom skill does not exist, that step is skipped gracefully (or falls back
 - Planners are READ-ONLY (focus on user collaboration)
 - Planners stay alive until `/approve_issue` (not just `/approve_plan`)
 - Builders have full code access (implementation focus)
-- Plans stored in files at `~/.cc_webui/plans/` (not in GitHub comments)
+- Plans transported as comm FILE ATTACHMENTS (not disk paths)
 - Test servers may stay running for user review (project-dependent)
 - Workers operate independently in parallel
 - You relay results to user, escalate blockers
@@ -111,27 +110,27 @@ If a custom skill does not exist, that step is skipped gracefully (or falls back
 
 ## Minion Templates
 
-- **Issue Planner**: Read-only, user Q&A, design, writes plan to file, registers resource
-- **Issue Builder**: Full code access, reads plan from file, implements, creates PR
+- **Issue Planner**: Read-only, User/Agent Q&A, design, writes plan locally, attaches FILE to completion comm
+- **Issue Builder**: Full code access, extracts plan from kickoff comm attachment, implements, creates PR
 
 ## Workflow Summary
 
 ```
-User: "Work on issue #42"
+User/Agent: "Work on issue #42"
      |
 /plan_issue 42 -> Planner-42 spawned
      |
-User <-> Planner (Q&A, design)
+User/Agent <-> Planner (Q&A, design)
      |
-Planner writes plan to ~/.cc_webui/plans/issue-42.md
+Planner attaches plan FILE to completion comm → Orchestrator
      |
 /approve_plan 42 -> Builder-42 spawned (Planner-42 stays alive)
      |
-Builder reads plan, implements, tests, creates PR
+Builder extracts plan from kickoff comm, implements, tests, creates PR
      |
-User reviews via test servers
+User/Agent reviews via test servers
      |
-/approve_issue 42 -> Merged, Planner-42 + Builder-42 disposed, plan deleted
+/approve_issue 42 -> Merged, Planner-42 + Builder-42 disposed
 ```
 
 ### Multi-Stage Example


### PR DESCRIPTION
## Summary

Resolves #791

Replace the `~/.cc_webui/plans/` file-path plan transport model with a comm FILE ATTACHMENT model across 8 skills/templates. The old model fails in dockerized multi-agent deployments where Planner, Orchestrator, and Builder run in separate containers with isolated filesystems.

## Changes Made

- **orchestrator.md**: Remove plan file references, update workflow diagram, replace "user" → "User/Agent"
- **issue_planner.md**: Add FILE ATTACHMENT instruction in step 10, update constraints section, replace "user" → "User/Agent"
- **issue_builder.md**: Rewrite Phase 1 step 1 to extract plan from kickoff comm attachment instead of calling plan-manager read-plan
- **plan_issue/SKILL.md**: Remove `disable-model-invocation`, remove Plan File from system_prompt, add attachment instruction
- **approve_plan/SKILL.md**: Remove `disable-model-invocation`, replace steps 3–4 (verify-plan + get file path) with comm attachment extraction, relay attachment to Builder kickoff comm, renumber steps
- **approve_issue/SKILL.md**: Remove `disable-model-invocation` and `Bash(rm:*)`, replace step 8 (delete plan file) with no-op note
- **status_workers/SKILL.md**: Remove step 5 (plan file check) and Plan field from display output
- **plan-manager/SKILL.md**: Add container-local scope notes to all operations

## Testing

- 706 unit tests pass (`uv run pytest src/tests/ -v`)
- All 8 files reviewed for removal of cross-container path references
- No `~/.cc_webui/plans/` transport references remain in workflow-critical sections
- No `disable-model-invocation: true` in plan_issue, approve_plan, approve_issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)