### PR TITLE
fix: mount history/ dir in Docker sessions (read-only)

### DIFF
--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -936,7 +936,9 @@ class SessionCoordinator:
             docker_env_vars = {}
             if session_info.docker_enabled and not session_info.cli_path:
                 from src.docker_utils import resolve_docker_cli_path
-                # Persistent data dir for Claude session transcripts (enables --resume)
+                # Persistent data dir for Claude session transcripts (enables --resume).
+                # Nested inside session_dir so Claude CLI internals and WebUI session data
+                # are created, backed up, and cleaned up together.
                 docker_data_dir = str(session_dir / "docker_claude_data")
                 # Issue #759: Mount session memory dir into Docker container (RW, at host path)
                 extra_mounts = list(session_info.docker_extra_mounts or [])
@@ -946,10 +948,11 @@ class SessionCoordinator:
                     extra_mounts.append(f"{memory_dir}:{memory_dir}")
                 # Issue #773: Mount session data dirs into Docker (read-only)
                 # These host-side dirs contain files the agent needs to Read:
-                #   resources/ - MCP-registered resources, comm file attachments
+                #   resources/   - MCP-registered resources, comm file attachments
                 #   attachments/ - User-uploaded files via InputArea
+                #   history/     - Distilled history .md files (issue #691)
                 # Mounted at the same absolute path so paths work identically.
-                for subdir in ("resources", "attachments"):
+                for subdir in ("resources", "attachments", "history"):
                     host_dir = session_dir / subdir
                     host_dir.mkdir(exist_ok=True)
                     extra_mounts.append(f"{host_dir}:{host_dir}:ro")

--- a/src/tests/test_session_coordinator.py
+++ b/src/tests/test_session_coordinator.py
@@ -675,3 +675,50 @@ class TestIssue811IsProcessingStuck:
         assert coordinator._pending_results.get(session_id, 0) == 0, (
             "Exception in send_message() must decrement _pending_results so is_processing can clear"
         )
+
+
+class TestIssue819DockerHistoryMount:
+    """Regression tests for issue #819 — history/ dir must be mounted in Docker sessions."""
+
+    @pytest.mark.asyncio
+    async def test_issue_819_history_in_extra_mounts(self, temp_coordinator):
+        """start_session() must include history/ in Docker extra mounts (read-only)."""
+        import uuid
+
+        coordinator = temp_coordinator
+
+        project = await coordinator.project_manager.create_project(
+            name="Test Project",
+            working_directory="/test/project",
+        )
+
+        session_id = str(uuid.uuid4())
+        await coordinator.create_session(
+            session_id=session_id,
+            project_id=project.project_id,
+            config=SessionConfig(docker_enabled=True, docker_image="claude-code:local"),
+        )
+
+        captured_mounts = []
+
+        def fake_resolve(docker_image, docker_extra_mounts, workspace, session_data_dir, docker_home_directory):
+            captured_mounts.extend(docker_extra_mounts or [])
+            return "/usr/bin/docker", {}
+
+        mock_sdk = AsyncMock()
+        mock_sdk.start.return_value = True
+        mock_sdk.is_running.return_value = False
+        coordinator.set_sdk_factory(Mock(return_value=mock_sdk))
+
+        with patch("src.docker_utils.resolve_docker_cli_path", fake_resolve):
+            with patch("src.skill_manager.NEW_GLOBAL_SKILLS_DIR") as mock_skills_dir:
+                mock_skills_dir.exists.return_value = False
+                await coordinator.start_session(session_id)
+
+        history_mounts = [m for m in captured_mounts if "/history" in m]
+        assert history_mounts, (
+            f"history/ must appear in Docker extra_mounts. Got: {captured_mounts}"
+        )
+        assert any(m.endswith(":ro") for m in history_mounts), (
+            "history/ must be mounted read-only (:ro)"
+        )


### PR DESCRIPTION
## Summary
Resolves #819

Audit of Docker mount points revealed that `history/` (distilled history .md files, introduced in #691) was not being mounted into Docker containers. Agents running in Docker mode reference these files in their system prompts, so the missing mount caused read failures.

## Changes Made
- Add `"history"` to the read-only session subdirs mounted into Docker containers (`src/session_coordinator.py`)
- Clarify the `docker_claude_data/` comment explaining its co-location rationale
- Add regression test `test_issue_819_history_in_extra_mounts` verifying `history/` appears in extra mounts with `:ro` flag

## Testing
- `uv run pytest src/tests/test_session_coordinator.py::TestIssue819DockerHistoryMount` — new regression test passes
- `uv run pytest src/tests/` — 707 tests passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)