### PR TITLE
feat: add session-specific /tmp mount with path translation for Docker sessions

### DIFF
--- a/src/mcp/resource_mcp_tools.py
+++ b/src/mcp/resource_mcp_tools.py
@@ -283,6 +283,20 @@ At least one of resource_id or filename must be provided.""",
                     "is_error": True
                 }
 
+            # Issue #820: Translate /tmp/ paths for Docker sessions
+            if file_path_str.startswith("/tmp/"):
+                try:
+                    session_info = await self.session_coordinator.session_manager.get_session_info(session_id)
+                    if session_info and getattr(session_info, "docker_enabled", False):
+                        session_dir = self.session_coordinator.data_dir / "sessions" / session_id
+                        relative = file_path_str[len("/tmp/"):]
+                        file_path_str = str(session_dir / "tmp" / relative)
+                        logger.debug(
+                            f"Translated /tmp path for Docker session {session_id}: {file_path_str}"
+                        )
+                except Exception as e:
+                    logger.warning(f"Failed to check docker_enabled for path translation: {e}")
+
             # Resolve and validate path
             file_path = Path(file_path_str).expanduser().resolve()
 

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -970,6 +970,12 @@ class SessionCoordinator:
                 gh_config = Path.home() / ".config" / "gh"
                 if gh_config.exists():
                     extra_mounts.append(f"{gh_config}:{docker_home}/.config/gh:ro")
+                # Issue #820: Mount session-specific /tmp dir so container /tmp is host-accessible
+                # IMPORTANT: mkdir must happen BEFORE adding to extra_mounts — Docker bind-mount
+                # fails at container start if the host source path does not already exist.
+                tmp_dir = session_dir / "tmp"
+                tmp_dir.mkdir(exist_ok=True)
+                extra_mounts.append(f"{tmp_dir}:/tmp")
                 effective_cli_path, docker_env_vars = resolve_docker_cli_path(
                     docker_image=session_info.docker_image,
                     docker_extra_mounts=extra_mounts or None,
@@ -1143,6 +1149,15 @@ class SessionCoordinator:
 
             # Terminate session through manager
             success = await self.session_manager.terminate_session(session_id)
+
+            # Issue #820: Clean up session /tmp directory on session end
+            try:
+                tmp_dir = self.session_manager.sessions_dir / session_id / "tmp"
+                if tmp_dir.exists():
+                    shutil.rmtree(tmp_dir, ignore_errors=True)
+                    coord_logger.info(f"Cleaned up /tmp for session {session_id}")
+            except Exception:
+                logger.exception(f"Failed to clean up /tmp for session {session_id}")
 
             # Cleanup storage and callbacks
             if session_id in self._storage_managers:

--- a/src/tests/integration/test_api_resources.py
+++ b/src/tests/integration/test_api_resources.py
@@ -244,3 +244,50 @@ class TestLegacyImages:
 
         resp = await client.get(f"/api/sessions/{sid}/images/nonexistent")
         assert resp.status_code == 404
+
+
+class TestSessionTmpEndpoint:
+    """Tests for GET /api/sessions/{session_id}/tmp/{path} (Issue #820)."""
+
+    async def test_get_existing_tmp_file(self, api_integration_env):
+        """Returns file content for a file that exists in the session tmp dir."""
+        client = api_integration_env["client"]
+        coordinator = api_integration_env["coordinator"]
+        session = await _create_session_with_project(api_integration_env)
+        sid = session["session_id"]
+
+        # Create the tmp dir and write a file directly (simulating container write)
+        tmp_dir = coordinator.data_dir / "sessions" / sid / "tmp"
+        tmp_dir.mkdir(parents=True, exist_ok=True)
+        (tmp_dir / "hello.txt").write_text("hello from container")
+
+        resp = await client.get(f"/api/sessions/{sid}/tmp/hello.txt")
+        assert resp.status_code == 200
+        assert resp.content == b"hello from container"
+
+    async def test_get_nonexistent_tmp_file_returns_404(self, api_integration_env):
+        """Returns 404 when the requested file does not exist."""
+        client = api_integration_env["client"]
+        session = await _create_session_with_project(api_integration_env)
+        sid = session["session_id"]
+
+        resp = await client.get(f"/api/sessions/{sid}/tmp/nonexistent.txt")
+        assert resp.status_code == 404
+
+    async def test_path_traversal_returns_403_or_404(self, api_integration_env):
+        """Path traversal attempts are blocked — either 403 (our check) or 404 (URL normalization)."""
+        client = api_integration_env["client"]
+        session = await _create_session_with_project(api_integration_env)
+        sid = session["session_id"]
+
+        # httpx normalizes the URL path before sending, so ../../../etc/passwd may be stripped
+        # by the HTTP layer; either way, the file must not be served (403 or 404 are both safe).
+        resp = await client.get(f"/api/sessions/{sid}/tmp/../../../etc/passwd")
+        assert resp.status_code in (403, 404)
+
+    async def test_invalid_session_returns_404(self, api_integration_env):
+        """Returns 404 for a session that does not exist."""
+        client = api_integration_env["client"]
+
+        resp = await client.get("/api/sessions/nonexistent-session-id/tmp/file.txt")
+        assert resp.status_code == 404

--- a/src/tests/test_session_coordinator.py
+++ b/src/tests/test_session_coordinator.py
@@ -722,3 +722,48 @@ class TestIssue819DockerHistoryMount:
         assert any(m.endswith(":ro") for m in history_mounts), (
             "history/ must be mounted read-only (:ro)"
         )
+
+
+class TestIssue820TmpMount:
+    """Tests for session-specific /tmp mount (Issue #820)."""
+
+    @pytest.mark.asyncio
+    async def test_issue_820_terminate_session_cleans_tmp_dir(self, temp_coordinator, sample_session_config):
+        """terminate_session() removes the {session_dir}/tmp/ directory when it exists."""
+        coordinator = temp_coordinator
+        session_id = await coordinator.create_session(**sample_session_config)
+
+        # Create the tmp directory and a file inside it
+        session_dir = coordinator.session_manager.sessions_dir / session_id
+        tmp_dir = session_dir / "tmp"
+        tmp_dir.mkdir(exist_ok=True)
+        (tmp_dir / "test.txt").write_text("hello")
+
+        assert tmp_dir.exists()
+
+        mock_sdk = AsyncMock()
+        coordinator._active_sdks[session_id] = mock_sdk
+
+        with patch.object(coordinator.session_manager, "terminate_session", return_value=True):
+            await coordinator.terminate_session(session_id)
+
+        # tmp directory must be removed
+        assert not tmp_dir.exists()
+
+    @pytest.mark.asyncio
+    async def test_issue_820_terminate_session_no_tmp_dir_is_safe(self, temp_coordinator, sample_session_config):
+        """terminate_session() succeeds even when {session_dir}/tmp/ does not exist."""
+        coordinator = temp_coordinator
+        session_id = await coordinator.create_session(**sample_session_config)
+
+        session_dir = coordinator.session_manager.sessions_dir / session_id
+        tmp_dir = session_dir / "tmp"
+        assert not tmp_dir.exists()
+
+        mock_sdk = AsyncMock()
+        coordinator._active_sdks[session_id] = mock_sdk
+
+        with patch.object(coordinator.session_manager, "terminate_session", return_value=True):
+            success = await coordinator.terminate_session(session_id)
+
+        assert success is True

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -1692,6 +1692,36 @@ class ClaudeWebUI:
                 logger.exception("Failed to download resource")
                 raise HTTPException(status_code=500, detail=str(e)) from e
 
+        # Issue #820: Serve session /tmp files directly (for containerized agents)
+        @self.app.get("/api/sessions/{session_id}/tmp/{path:path}")
+        async def get_session_tmp_file(session_id: str, path: str):
+            """Serve a file from the session's /tmp directory (for containerized agents)."""
+            import mimetypes
+
+            from fastapi.responses import FileResponse
+
+            # Validate session exists
+            session_info = await self.coordinator.session_manager.get_session_info(session_id)
+            if not session_info:
+                raise HTTPException(status_code=404, detail="Session not found")
+
+            tmp_dir = (self.coordinator.data_dir / "sessions" / session_id / "tmp").resolve()
+            requested = (tmp_dir / path).resolve()
+
+            # Security: path must remain within session tmp dir (prevent traversal)
+            if not str(requested).startswith(str(tmp_dir) + "/") and requested != tmp_dir:
+                raise HTTPException(status_code=403, detail="Access denied")
+
+            if not requested.exists() or not requested.is_file():
+                raise HTTPException(status_code=404, detail="File not found")
+
+            media_type, _ = mimetypes.guess_type(str(requested))
+            return FileResponse(
+                path=str(requested),
+                media_type=media_type or "application/octet-stream",
+                filename=requested.name,
+            )
+
         # Issue #423: Remove resource from session display (soft-remove)
         @self.app.delete("/api/sessions/{session_id}/resources/{resource_id}")
         async def remove_session_resource(session_id: str, resource_id: str):


### PR DESCRIPTION
## Summary
Resolves #820

Add a session-specific `/tmp` directory that is bind-mounted into Docker containers, enabling agents to write files to `/tmp` that are accessible from the host. Includes path translation at resource registration time and a direct file serving endpoint.

## Changes Made
- `src/session_coordinator.py`: Create `{session_dir}/tmp/` and mount it as `/tmp` in the Docker container at `start_session()`; clean it up in `terminate_session()`
- `src/mcp/resource_mcp_tools.py`: Translate `/tmp/` paths to host-side `{session_dir}/tmp/` equivalents in `_handle_register_resource()` when `docker_enabled=True`
- `src/web_server.py`: Add `GET /api/sessions/{session_id}/tmp/{path:path}` endpoint to serve session `/tmp` files directly (path traversal protected)
- `src/tests/test_session_coordinator.py`: Unit tests for `/tmp` cleanup in `terminate_session()`
- `src/tests/integration/test_api_resources.py`: Integration tests for the new endpoint (200, 404, 403/404 for traversal, invalid session)

## Testing
- 712 tests pass (`uv run pytest src/tests/ -v`)
- New unit tests verify `terminate_session()` cleans `{session_dir}/tmp/` when present and is safe when absent
- New integration tests verify: file served correctly, 404 for missing file, path traversal blocked, 404 for invalid session

🤖 Generated with [Claude Code](https://claude.com/claude-code)