### PR TITLE
perf: replace O(n) EventQueue.events_since() scan with O(1) index lookup

### DIFF
--- a/src/web_server.py
+++ b/src/web_server.py
@@ -12,7 +12,6 @@ import subprocess
 import sys
 import time
 import uuid
-from collections import deque
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Annotated, Any
@@ -357,15 +356,17 @@ class EventQueue:
     MAX_SIZE = 5000
 
     def __init__(self):
-        self._events: deque[tuple[int, dict]] = deque()
+        self._events: list[dict] = []
         self._cursor: int = 0
+        self._oldest_cursor: int = 1
         self._waiters: list[asyncio.Event] = []
 
     def append(self, event: dict) -> int:
         self._cursor += 1
-        self._events.append((self._cursor, event))
+        self._events.append(event)
         if len(self._events) > self.MAX_SIZE:
-            self._events.popleft()
+            self._events.pop(0)
+            self._oldest_cursor += 1
         for waiter in self._waiters:
             waiter.set()
         self._waiters.clear()
@@ -374,10 +375,10 @@ class EventQueue:
     def events_since(self, cursor: int) -> tuple[list[dict], int]:
         if not self._events:
             return [], self._cursor
-        oldest_cursor = self._events[0][0]
-        if cursor < oldest_cursor - 1:
-            return [e for _, e in self._events], self._cursor
-        return [e for c, e in self._events if c > cursor], self._cursor
+        if cursor < self._oldest_cursor - 1:
+            return list(self._events), self._cursor
+        start_idx = max(0, cursor - self._oldest_cursor + 1)
+        return self._events[start_idx:], self._cursor
 
     async def wait_for_events(self, cursor: int, timeout: float) -> None:
         _, current = self.events_since(cursor)


### PR DESCRIPTION
## Summary
Resolves #828

Replace the O(n) linear scan in `EventQueue.events_since()` with an O(1) index calculation. Since cursors are monotonically-incrementing integers, the first relevant event index is computable directly from arithmetic.

## Changes Made
- Remove `deque[tuple[int, dict]]` and `deque` import
- Change `_events` to `list[dict]` (events only, no cursor tuple)
- Add `_oldest_cursor: int = 1` field to track the eviction offset
- `events_since()` computes `start_idx = max(0, cursor - _oldest_cursor + 1)` and returns a list slice — O(result_size) instead of O(total_size)
- `append()` uses `list.pop(0)` + `_oldest_cursor += 1` on eviction

## Testing
- All 27 existing tests in `src/tests/integration/test_issue_782_long_poll.py` pass unchanged
- `uv run ruff check src/web_server.py` — no violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)