### PR TITLE
refactor: replace stringly-typed MCP server types with McpServerType enum

### DIFF
--- a/src/mcp_config_manager.py
+++ b/src/mcp_config_manager.py
@@ -13,6 +13,7 @@ import re
 import uuid
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
+from enum import Enum
 from pathlib import Path
 from typing import Any
 
@@ -20,6 +21,12 @@ from .logging_config import get_logger
 
 mcp_logger = get_logger('mcp_config', category='MCP_CONFIG')
 logger = logging.getLogger(__name__)
+
+
+class McpServerType(str, Enum):
+    STDIO = "stdio"
+    SSE = "sse"
+    HTTP = "http"
 
 
 def _slugify(name: str) -> str:
@@ -35,7 +42,7 @@ class McpServerConfig:
     id: str
     name: str
     slug: str
-    type: str  # "stdio" | "sse" | "http"
+    type: McpServerType
     # stdio fields
     command: str | None = None
     args: list[str] = field(default_factory=list)
@@ -65,6 +72,8 @@ class McpServerConfig:
         data.setdefault('headers', {})
         data.setdefault('enabled', True)
         data.setdefault('oauth_enabled', False)
+        if 'type' in data and isinstance(data['type'], str):
+            data['type'] = McpServerType(data['type'])
         if isinstance(data.get('created_at'), str):
             data['created_at'] = datetime.fromisoformat(data['created_at'])
         if isinstance(data.get('updated_at'), str):
@@ -79,26 +88,26 @@ class McpServerConfig:
         - sse: McpSSEServerConfig
         - http: McpHttpServerConfig
         """
-        if self.type == "stdio":
+        if self.type == McpServerType.STDIO:
             config: dict[str, Any] = {
-                "type": "stdio",
+                "type": self.type.value,
                 "command": self.command,
                 "args": self.args,
             }
             if self.env:
                 config["env"] = self.env
             return config
-        elif self.type == "sse":
+        elif self.type == McpServerType.SSE:
             config = {
-                "type": "sse",
+                "type": self.type.value,
                 "url": self.url,
             }
             if self.headers:
                 config["headers"] = self.headers
             return config
-        elif self.type == "http":
+        elif self.type == McpServerType.HTTP:
             config = {
-                "type": "http",
+                "type": self.type.value,
                 "url": self.url,
             }
             if self.headers:
@@ -141,7 +150,7 @@ class McpConfigManager:
     async def create_config(
         self,
         name: str,
-        server_type: str,
+        server_type: str | McpServerType,
         command: str | None = None,
         args: list[str] | None = None,
         env: dict[str, str] | None = None,
@@ -154,14 +163,16 @@ class McpConfigManager:
         if not name or not name.strip():
             raise ValueError("MCP server name cannot be empty")
 
-        if server_type not in ("stdio", "sse", "http"):
-            raise ValueError(f"Invalid server type: {server_type}. Must be stdio, sse, or http")
+        try:
+            server_type_enum = McpServerType(server_type)
+        except ValueError:
+            raise ValueError(f"Invalid server type: {server_type}. Must be stdio, sse, or http") from None
 
-        if server_type == "stdio" and not command:
+        if server_type_enum == McpServerType.STDIO and not command:
             raise ValueError("Command is required for stdio MCP servers")
 
-        if server_type in ("sse", "http") and not url:
-            raise ValueError(f"URL is required for {server_type} MCP servers")
+        if server_type_enum in (McpServerType.SSE, McpServerType.HTTP) and not url:
+            raise ValueError(f"URL is required for {server_type_enum.value} MCP servers")
 
         slug = _slugify(name)
         # Check slug uniqueness
@@ -172,7 +183,7 @@ class McpConfigManager:
             id=str(uuid.uuid4()),
             name=name.strip(),
             slug=slug,
-            type=server_type,
+            type=server_type_enum,
             command=command,
             args=args or [],
             env=env or {},
@@ -223,9 +234,10 @@ class McpConfigManager:
             config.slug = new_slug
 
         if server_type is not None:
-            if server_type not in ("stdio", "sse", "http"):
-                raise ValueError(f"Invalid server type: {server_type}")
-            config.type = server_type
+            try:
+                config.type = McpServerType(server_type)
+            except ValueError:
+                raise ValueError(f"Invalid server type: {server_type}") from None
 
         if command is not None:
             config.command = command

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -23,6 +23,7 @@ from .claude_sdk import ClaudeSDK
 from .data_storage import DataStorageManager
 from .hooks.pretooluse_handler import InternalPermissionHandler
 from .logging_config import get_logger
+from .mcp_config_manager import McpServerType
 from .message_parser import MessageParser, MessageProcessor
 from .models.messages import (
     DisplayProjection,
@@ -173,7 +174,7 @@ class SessionCoordinator:
         import time as _time
 
         config = mcp_cfg.to_sdk_config()
-        if mcp_cfg.oauth_enabled and mcp_cfg.type in ("sse", "http"):
+        if mcp_cfg.oauth_enabled and mcp_cfg.type in (McpServerType.SSE, McpServerType.HTTP):
             try:
                 token = await self.oauth_manager.get_stored_token(mcp_cfg.id)
                 if token:

--- a/src/tests/test_issue_813_oauth.py
+++ b/src/tests/test_issue_813_oauth.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
 
+from src.mcp_config_manager import McpServerType
 from src.oauth_manager import FernetTokenStore, OAuthFlowManager
 
 # ---------------------------------------------------------------------------
@@ -242,7 +243,7 @@ async def test_get_mcp_sdk_config_injects_bearer_token(tmp_path: Path):
     # Build a minimal McpServerConfig stub
     mcp_cfg = MagicMock()
     mcp_cfg.id = "srv-oauth"
-    mcp_cfg.type = "http"
+    mcp_cfg.type = McpServerType.HTTP
     mcp_cfg.oauth_enabled = True
     mcp_cfg.to_sdk_config.return_value = {
         "type": "http",
@@ -264,7 +265,7 @@ async def test_get_mcp_sdk_config_no_token_no_header(tmp_path: Path):
 
     mcp_cfg = MagicMock()
     mcp_cfg.id = "srv-no-token"
-    mcp_cfg.type = "http"
+    mcp_cfg.type = McpServerType.HTTP
     mcp_cfg.oauth_enabled = True
     mcp_cfg.to_sdk_config.return_value = {
         "type": "http",
@@ -287,7 +288,7 @@ async def test_get_mcp_sdk_config_non_oauth_passthrough(tmp_path: Path):
     expected = {"type": "stdio", "command": "npx", "args": ["-y", "@modelcontextprotocol/server-everything"]}
     mcp_cfg = MagicMock()
     mcp_cfg.id = "srv-stdio"
-    mcp_cfg.type = "stdio"
+    mcp_cfg.type = McpServerType.STDIO
     mcp_cfg.oauth_enabled = False
     mcp_cfg.to_sdk_config.return_value = expected
 

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -31,6 +31,7 @@ from pydantic import BaseModel
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from .file_upload import FileUploadError, FileUploadManager
+from .mcp_config_manager import McpServerType
 from .message_parser import MessageParser, MessageProcessor
 from .models.messages import (
     PermissionInfo,
@@ -315,7 +316,7 @@ class TemplateUpdateRequest(BaseModel):
 # MCP config request models (issue #676)
 class McpConfigCreateRequest(BaseModel):
     name: str
-    type: str  # "stdio" | "sse" | "http"
+    type: McpServerType
     command: str | None = None
     args: list[str] | None = None
     env: dict[str, str] | None = None
@@ -3337,8 +3338,8 @@ class ClaudeWebUI:
                     all_configs = [c for c in all_configs if c.id in id_set]
                 portable: dict = {}
                 for c in all_configs:
-                    entry: dict = {"type": c.type, "enabled": c.enabled}
-                    if c.type == "stdio":
+                    entry: dict = {"type": c.type.value, "enabled": c.enabled}
+                    if c.type == McpServerType.STDIO:
                         entry["command"] = c.command
                         if c.args:
                             entry["args"] = c.args
@@ -3370,16 +3371,18 @@ class ClaudeWebUI:
                         preview.append({"name": "", "action": "skip", "reason": "Missing name"})
                         continue
 
-                    server_type = server_data.get("type", "stdio")
-                    if server_type not in ("stdio", "sse", "http"):
-                        preview.append({"name": name, "action": "skip", "reason": f"Invalid type: {server_type}"})
+                    server_type_raw = server_data.get("type", "stdio")
+                    try:
+                        server_type = McpServerType(server_type_raw)
+                    except ValueError:
+                        preview.append({"name": name, "action": "skip", "reason": f"Invalid type: {server_type_raw}"})
                         continue
 
-                    if server_type == "stdio" and not server_data.get("command"):
+                    if server_type == McpServerType.STDIO and not server_data.get("command"):
                         preview.append({"name": name, "action": "skip", "reason": "Missing command for stdio server"})
                         continue
 
-                    if server_type in ("sse", "http") and not server_data.get("url"):
+                    if server_type in (McpServerType.SSE, McpServerType.HTTP) and not server_data.get("url"):
                         preview.append({"name": name, "action": "skip", "reason": f"Missing url for {server_type} server"})
                         continue
 


### PR DESCRIPTION
## Summary
Resolves #830

Introduces `McpServerType(str, Enum)` to replace bare string literals `"stdio"`, `"sse"`, `"http"` used as MCP server type identifiers throughout the codebase.

## Changes Made
- **`src/mcp_config_manager.py`**: Add `McpServerType` enum inheriting from `str`; update `McpServerConfig.type` annotation; add coercion in `from_dict()` for backward-compatible loading of stored JSON; update `to_sdk_config()`, `create_config()`, and `update_config()` to use enum members and enum-based validation
- **`src/web_server.py`**: Import `McpServerType`; update `McpConfigCreateRequest.type` annotation; update export and import validation logic to use enum
- **`src/session_coordinator.py`**: Import `McpServerType`; update OAuth check to use enum members
- **`src/tests/test_issue_813_oauth.py`**: Update test fixtures to use `McpServerType` members

## Testing
- All 36 MCP-related tests pass
- Full suite: 722 passed, 0 failures
- Backward compatibility verified: `str` enum serializes as its string value so stored JSON configs, API responses, and SDK dicts are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)