### PR TITLE
refactor: extract Docker /tmp helpers into docker_utils.py

### DIFF
--- a/src/docker_utils.py
+++ b/src/docker_utils.py
@@ -7,6 +7,7 @@ for Docker session isolation.
 
 import asyncio
 import logging
+import shutil
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -116,3 +117,40 @@ def resolve_docker_cli_path(
         env_vars["CLAUDE_DOCKER_HOME"] = docker_home_directory
 
     return wrapper_path, env_vars
+
+
+async def translate_docker_tmp_path(
+    file_path: str,
+    session_id: str,
+    session_coordinator,
+) -> str:
+    """Translate /tmp paths to session-scoped tmp dir for Docker sessions."""
+    if not file_path.startswith("/tmp/"):
+        return file_path
+    try:
+        session_info = await session_coordinator.session_manager.get_session_info(session_id)
+        if session_info and getattr(session_info, "docker_enabled", False):
+            session_dir = session_coordinator.data_dir / "sessions" / session_id
+            relative = file_path[len("/tmp/"):]
+            translated = str(session_dir / "tmp" / relative)
+            logger.debug(f"Translated /tmp path for Docker session {session_id}: {translated}")
+            return translated
+    except Exception as e:
+        logger.warning(f"Failed to check docker_enabled for path translation: {e}")
+    return file_path
+
+
+def get_session_tmp_dir(session_dir: Path) -> Path:
+    """Get session's /tmp directory."""
+    return session_dir / "tmp"
+
+
+def cleanup_session_tmp(session_id: str, sessions_dir: Path) -> None:
+    """Clean up session's temporary directory."""
+    try:
+        tmp_dir = sessions_dir / session_id / "tmp"
+        if tmp_dir.exists():
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+            logger.info(f"Cleaned up /tmp for session {session_id}")
+    except Exception:
+        logger.exception(f"Failed to clean up /tmp for session {session_id}")

--- a/src/legion/mcp/legion_mcp_tools.py
+++ b/src/legion/mcp/legion_mcp_tools.py
@@ -26,6 +26,7 @@ except ImportError:
     tool = None
     create_sdk_mcp_server = None
 
+from src.docker_utils import translate_docker_tmp_path
 from src.session_config import SessionConfig
 
 logger = logging.getLogger(__name__)
@@ -617,16 +618,9 @@ class LegionMCPTools:
 
             for fpath_str in file_paths:
                 # Issue #824: Translate /tmp/ paths for Docker sessions
-                if fpath_str.startswith("/tmp/"):
-                    try:
-                        session_info = await self.system.session_coordinator.session_manager.get_session_info(from_minion_id)
-                        if session_info and getattr(session_info, "docker_enabled", False):
-                            session_dir = self.system.session_coordinator.data_dir / "sessions" / from_minion_id
-                            relative = fpath_str[len("/tmp/"):]
-                            fpath_str = str(session_dir / "tmp" / relative)
-                            logger.debug(f"Translated /tmp path for Docker session {from_minion_id}: {fpath_str}")
-                    except Exception as e:
-                        logger.warning(f"Failed to check docker_enabled for path translation: {e}")
+                fpath_str = await translate_docker_tmp_path(
+                    fpath_str, from_minion_id, self.system.session_coordinator
+                )
                 fpath = Path(fpath_str)
                 # Validate existence
                 if not fpath.exists():

--- a/src/mcp/resource_mcp_tools.py
+++ b/src/mcp/resource_mcp_tools.py
@@ -24,6 +24,8 @@ except ImportError:
     tool = None
     create_sdk_mcp_server = None
 
+from src.docker_utils import translate_docker_tmp_path
+
 if TYPE_CHECKING:
     from src.session_coordinator import SessionCoordinator
 
@@ -284,18 +286,9 @@ At least one of resource_id or filename must be provided.""",
                 }
 
             # Issue #820: Translate /tmp/ paths for Docker sessions
-            if file_path_str.startswith("/tmp/"):
-                try:
-                    session_info = await self.session_coordinator.session_manager.get_session_info(session_id)
-                    if session_info and getattr(session_info, "docker_enabled", False):
-                        session_dir = self.session_coordinator.data_dir / "sessions" / session_id
-                        relative = file_path_str[len("/tmp/"):]
-                        file_path_str = str(session_dir / "tmp" / relative)
-                        logger.debug(
-                            f"Translated /tmp path for Docker session {session_id}: {file_path_str}"
-                        )
-                except Exception as e:
-                    logger.warning(f"Failed to check docker_enabled for path translation: {e}")
+            file_path_str = await translate_docker_tmp_path(
+                file_path_str, session_id, self.session_coordinator
+            )
 
             # Resolve and validate path
             file_path = Path(file_path_str).expanduser().resolve()

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -17,6 +17,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from src.docker_utils import cleanup_session_tmp
 from src.legion.minion_system_prompts import get_legion_guide_only
 
 from .claude_sdk import ClaudeSDK
@@ -936,7 +937,7 @@ class SessionCoordinator:
             effective_cli_path = session_info.cli_path
             docker_env_vars = {}
             if session_info.docker_enabled and not session_info.cli_path:
-                from src.docker_utils import resolve_docker_cli_path
+                from src.docker_utils import get_session_tmp_dir, resolve_docker_cli_path
                 # Persistent data dir for Claude session transcripts (enables --resume).
                 # Nested inside session_dir so Claude CLI internals and WebUI session data
                 # are created, backed up, and cleaned up together.
@@ -974,7 +975,7 @@ class SessionCoordinator:
                 # Issue #820: Mount session-specific /tmp dir so container /tmp is host-accessible
                 # IMPORTANT: mkdir must happen BEFORE adding to extra_mounts — Docker bind-mount
                 # fails at container start if the host source path does not already exist.
-                tmp_dir = session_dir / "tmp"
+                tmp_dir = get_session_tmp_dir(session_dir)
                 tmp_dir.mkdir(exist_ok=True)
                 extra_mounts.append(f"{tmp_dir}:/tmp")
                 effective_cli_path, docker_env_vars = resolve_docker_cli_path(
@@ -1152,13 +1153,7 @@ class SessionCoordinator:
             success = await self.session_manager.terminate_session(session_id)
 
             # Issue #820: Clean up session /tmp directory on session end
-            try:
-                tmp_dir = self.session_manager.sessions_dir / session_id / "tmp"
-                if tmp_dir.exists():
-                    shutil.rmtree(tmp_dir, ignore_errors=True)
-                    coord_logger.info(f"Cleaned up /tmp for session {session_id}")
-            except Exception:
-                logger.exception(f"Failed to clean up /tmp for session {session_id}")
+            cleanup_session_tmp(session_id, self.session_manager.sessions_dir)
 
             # Cleanup storage and callbacks
             if session_id in self._storage_managers:

--- a/src/tests/test_docker_utils.py
+++ b/src/tests/test_docker_utils.py
@@ -1,0 +1,129 @@
+"""
+Tests for src/docker_utils.py — shared Docker /tmp helpers (issue #832).
+"""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.docker_utils import cleanup_session_tmp, get_session_tmp_dir, translate_docker_tmp_path
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_coordinator(session_id: str, docker_enabled: bool, data_dir: Path):
+    """Build a minimal mock SessionCoordinator for path-translation tests."""
+    session_info = MagicMock()
+    session_info.docker_enabled = docker_enabled
+
+    session_manager = MagicMock()
+    session_manager.get_session_info = AsyncMock(return_value=session_info)
+
+    coordinator = MagicMock()
+    coordinator.session_manager = session_manager
+    coordinator.data_dir = data_dir
+    return coordinator
+
+
+# ---------------------------------------------------------------------------
+# translate_docker_tmp_path
+# ---------------------------------------------------------------------------
+
+
+class TestTranslateDockerTmpPath:
+    @pytest.mark.asyncio
+    async def test_non_tmp_path_returned_unchanged(self, tmp_path):
+        coord = _make_coordinator("sess-1", docker_enabled=True, data_dir=tmp_path)
+        result = await translate_docker_tmp_path("/home/user/file.txt", "sess-1", coord)
+        assert result == "/home/user/file.txt"
+        # get_session_info should NOT be called for non-/tmp paths
+        coord.session_manager.get_session_info.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_docker_enabled_translates_path(self, tmp_path):
+        coord = _make_coordinator("sess-1", docker_enabled=True, data_dir=tmp_path)
+        result = await translate_docker_tmp_path("/tmp/output.json", "sess-1", coord)
+        expected = str(tmp_path / "sessions" / "sess-1" / "tmp" / "output.json")
+        assert result == expected
+
+    @pytest.mark.asyncio
+    async def test_docker_disabled_no_translation(self, tmp_path):
+        coord = _make_coordinator("sess-1", docker_enabled=False, data_dir=tmp_path)
+        result = await translate_docker_tmp_path("/tmp/output.json", "sess-1", coord)
+        assert result == "/tmp/output.json"
+
+    @pytest.mark.asyncio
+    async def test_session_info_none_no_translation(self, tmp_path):
+        session_manager = MagicMock()
+        session_manager.get_session_info = AsyncMock(return_value=None)
+        coord = MagicMock()
+        coord.session_manager = session_manager
+        coord.data_dir = tmp_path
+        result = await translate_docker_tmp_path("/tmp/foo.txt", "sess-x", coord)
+        assert result == "/tmp/foo.txt"
+
+    @pytest.mark.asyncio
+    async def test_exception_in_get_session_info_returns_original(self, tmp_path):
+        session_manager = MagicMock()
+        session_manager.get_session_info = AsyncMock(side_effect=RuntimeError("boom"))
+        coord = MagicMock()
+        coord.session_manager = session_manager
+        coord.data_dir = tmp_path
+        result = await translate_docker_tmp_path("/tmp/bar.txt", "sess-y", coord)
+        assert result == "/tmp/bar.txt"
+
+    @pytest.mark.asyncio
+    async def test_nested_path_preserved(self, tmp_path):
+        coord = _make_coordinator("sess-2", docker_enabled=True, data_dir=tmp_path)
+        result = await translate_docker_tmp_path("/tmp/subdir/deep/file.png", "sess-2", coord)
+        expected = str(tmp_path / "sessions" / "sess-2" / "tmp" / "subdir" / "deep" / "file.png")
+        assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# get_session_tmp_dir
+# ---------------------------------------------------------------------------
+
+
+class TestGetSessionTmpDir:
+    def test_returns_tmp_subdir(self, tmp_path):
+        result = get_session_tmp_dir(tmp_path / "sessions" / "abc")
+        assert result == tmp_path / "sessions" / "abc" / "tmp"
+
+    def test_return_type_is_path(self, tmp_path):
+        result = get_session_tmp_dir(tmp_path)
+        assert isinstance(result, Path)
+
+
+# ---------------------------------------------------------------------------
+# cleanup_session_tmp
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupSessionTmp:
+    def test_existing_dir_is_removed(self, tmp_path):
+        sessions_dir = tmp_path / "sessions"
+        tmp_dir = sessions_dir / "sess-1" / "tmp"
+        tmp_dir.mkdir(parents=True)
+        (tmp_dir / "file.txt").write_text("hello")
+
+        cleanup_session_tmp("sess-1", sessions_dir)
+        assert not tmp_dir.exists()
+
+    def test_missing_dir_is_noop(self, tmp_path):
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        # Should not raise
+        cleanup_session_tmp("sess-missing", sessions_dir)
+
+    def test_exception_is_logged_not_raised(self, tmp_path):
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        tmp_dir = sessions_dir / "sess-err" / "tmp"
+        tmp_dir.mkdir(parents=True)
+
+        with patch("src.docker_utils.shutil.rmtree", side_effect=OSError("disk error")):
+            # Should not propagate the exception
+            cleanup_session_tmp("sess-err", sessions_dir)


### PR DESCRIPTION
## Summary
Resolves #832

Centralizes duplicated Docker `/tmp` path-handling logic that was previously copied across three modules into shared helpers in `src/docker_utils.py`.

## Changes Made
- **`src/docker_utils.py`**: Added `import shutil` + 3 new helpers:
  - `translate_docker_tmp_path` (async) — translates `/tmp/…` paths to session-scoped host paths for Docker sessions; no-ops for non-`/tmp` paths, non-Docker sessions, `None` session info, or on error
  - `get_session_tmp_dir` — returns `session_dir / "tmp"`
  - `cleanup_session_tmp` — removes session tmp dir on session end, logging exceptions instead of raising
- **`src/mcp/resource_mcp_tools.py`**: Replace 13-line `/tmp` block with 2-line call to `translate_docker_tmp_path`
- **`src/legion/mcp/legion_mcp_tools.py`**: Replace 11-line `/tmp` block with 2-line call to `translate_docker_tmp_path`
- **`src/session_coordinator.py`**: Replace inline tmp-dir creation with `get_session_tmp_dir`; replace 8-line cleanup try/except with `cleanup_session_tmp` call
- **`src/tests/test_docker_utils.py`** (new): 11 unit tests for all 3 helpers

## Testing
- `uv run ruff check --fix` on modified files: 2 violations auto-fixed, 0 remaining
- New tests: **11/11 passed** (`src/tests/test_docker_utils.py`)
- Full test suite: **733 passed, 0 failed** (`uv run pytest src/tests/ -v`)
- No regressions introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)