### PR TITLE
refactor: replace stringly-typed OAuth status values with constants

### DIFF
--- a/frontend/src/components/configuration/McpConfigTab.vue
+++ b/frontend/src/components/configuration/McpConfigTab.vue
@@ -32,7 +32,7 @@
           <!-- OAuth Connect/Disconnect buttons -->
           <template v-if="config.oauth_enabled && (config.type === 'http' || config.type === 'sse')">
             <button
-              v-if="oauthStatusFor(config.id) !== 'authenticated'"
+              v-if="oauthStatusFor(config.id) !== OAUTH_STATUS.AUTHENTICATED"
               class="btn btn-xs btn-outline-success"
               :disabled="connectingId === config.id"
               @click="connectOAuth(config)"
@@ -302,7 +302,7 @@
 
 <script setup>
 import { ref, reactive, onMounted } from 'vue'
-import { useMcpConfigStore } from '@/stores/mcpConfig'
+import { useMcpConfigStore, OAUTH_STATUS } from '@/stores/mcpConfig'
 
 const configStore = useMcpConfigStore()
 
@@ -358,20 +358,20 @@ onMounted(async () => {
 
 // OAuth helpers
 function oauthStatusFor(configId) {
-  return configStore.oauthStatus.get(configId) || 'unauthenticated'
+  return configStore.oauthStatus.get(configId) || OAUTH_STATUS.UNAUTHENTICATED
 }
 
 function oauthStatusLabel(configId) {
   const s = oauthStatusFor(configId)
-  if (s === 'authenticated') return '● auth'
-  if (s === 'expired') return '⚠ expired'
+  if (s === OAUTH_STATUS.AUTHENTICATED) return '● auth'
+  if (s === OAUTH_STATUS.EXPIRED) return '⚠ expired'
   return '○ unauth'
 }
 
 function oauthStatusClass(configId) {
   const s = oauthStatusFor(configId)
-  if (s === 'authenticated') return 'bg-success'
-  if (s === 'expired') return 'bg-warning text-dark'
+  if (s === OAUTH_STATUS.AUTHENTICATED) return 'bg-success'
+  if (s === OAUTH_STATUS.EXPIRED) return 'bg-warning text-dark'
   return 'bg-secondary'
 }
 

--- a/frontend/src/stores/mcpConfig.js
+++ b/frontend/src/stores/mcpConfig.js
@@ -9,6 +9,12 @@ import { api } from '../utils/api'
  * - CRUD operations for global MCP server definitions
  * - Loading configs for picker components
  */
+export const OAUTH_STATUS = {
+  AUTHENTICATED: 'authenticated',
+  EXPIRED: 'expired',
+  UNAUTHENTICATED: 'unauthenticated',
+}
+
 export const useMcpConfigStore = defineStore('mcpConfig', () => {
   // ========== STATE ==========
 
@@ -92,7 +98,7 @@ export const useMcpConfigStore = defineStore('mcpConfig', () => {
 
   // ========== OAuth Actions ==========
 
-  // Per-server OAuth status cache: configId → "authenticated" | "expired" | "unauthenticated"
+  // Per-server OAuth status cache: configId → OAUTH_STATUS value
   const oauthStatus = ref(new Map())
 
   async function fetchOAuthStatus(configId) {
@@ -100,7 +106,7 @@ export const useMcpConfigStore = defineStore('mcpConfig', () => {
       const data = await api.get(`/api/mcp-configs/${configId}/oauth/status`)
       oauthStatus.value = new Map(oauthStatus.value.set(configId, data.status))
     } catch {
-      oauthStatus.value = new Map(oauthStatus.value.set(configId, 'unauthenticated'))
+      oauthStatus.value = new Map(oauthStatus.value.set(configId, OAUTH_STATUS.UNAUTHENTICATED))
     }
   }
 
@@ -113,7 +119,7 @@ export const useMcpConfigStore = defineStore('mcpConfig', () => {
 
   async function disconnectOAuth(configId) {
     await api.post(`/api/mcp-configs/${configId}/oauth/disconnect`, {})
-    oauthStatus.value = new Map(oauthStatus.value.set(configId, 'unauthenticated'))
+    oauthStatus.value = new Map(oauthStatus.value.set(configId, OAUTH_STATUS.UNAUTHENTICATED))
   }
 
   return {


### PR DESCRIPTION
## Summary
Resolves #837

Replace raw OAuth status string literals with a named `OAUTH_STATUS` constants object, eliminating stringly-typed comparisons across the MCP configuration UI.

## Changes Made
- `frontend/src/stores/mcpConfig.js`: Export `OAUTH_STATUS = { AUTHENTICATED, EXPIRED, UNAUTHENTICATED }` constant; update per-server cache comment; replace two `'unauthenticated'` fallback literals
- `frontend/src/components/configuration/McpConfigTab.vue`: Import `OAUTH_STATUS` from the store; replace 7 string literal occurrences in status helpers and template

## Testing
- Pure refactor — no runtime behavior changes
- Manual: Open MCP Configuration tab, verify OAuth connect/disconnect buttons and badge colors/labels render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)