### PR TITLE
fix: sanitize 500 error responses to prevent internal detail leakage

### DIFF
--- a/src/exception_handlers.py
+++ b/src/exception_handlers.py
@@ -7,6 +7,8 @@ import logging
 
 from fastapi import HTTPException
 
+from src.logging_config import get_debug_flag
+
 logger = logging.getLogger(__name__)
 
 
@@ -39,9 +41,11 @@ def handle_exceptions(action: str, *, value_error_status: int | None = None):
                 if value_error_status is not None:
                     raise HTTPException(status_code=value_error_status, detail=str(e)) from e
                 logger.exception("Failed to %s", action)
-                raise HTTPException(status_code=500, detail=str(e)) from e
+                detail = str(e) if get_debug_flag('debug_error_handler') else "An internal error occurred"
+                raise HTTPException(status_code=500, detail=detail) from e
             except Exception as e:
                 logger.exception("Failed to %s", action)
-                raise HTTPException(status_code=500, detail=str(e)) from e
+                detail = str(e) if get_debug_flag('debug_error_handler') else "An internal error occurred"
+                raise HTTPException(status_code=500, detail=detail) from e
         return wrapper
     return decorator

--- a/src/logging_config.py
+++ b/src/logging_config.py
@@ -357,3 +357,15 @@ def get_logger(name: str, category: str | None = None) -> logging.Logger:
 def get_main_logger() -> logging.Logger:
     """Get the main application logger for general errors."""
     return logging.getLogger()
+
+
+def get_debug_flag(key: str) -> bool:
+    """Return True if the named debug flag is currently enabled.
+
+    Args:
+        key: A key from _log_config (e.g., 'debug_error_handler', 'debug_all')
+
+    Returns:
+        True if the flag is enabled, False if disabled or not yet configured.
+    """
+    return bool(_log_config.get(key, False))

--- a/src/tests/test_exception_handlers.py
+++ b/src/tests/test_exception_handlers.py
@@ -1,10 +1,12 @@
-"""Unit tests for the handle_exceptions decorator (Issue #855)."""
+"""Unit tests for the handle_exceptions decorator (Issues #855, #852)."""
 
 import logging
+from unittest.mock import patch
 
 import pytest
 from fastapi import HTTPException
 
+import src.logging_config as logging_config
 from src.exception_handlers import handle_exceptions
 
 
@@ -64,7 +66,7 @@ async def test_issue_855_value_error_without_status_returns_500():
 
 @pytest.mark.asyncio
 async def test_issue_855_generic_exception_returns_500(caplog):
-    """Generic Exception is logged and raised as HTTPException(500)."""
+    """Generic Exception is logged and raised as HTTPException(500) with generic detail."""
     @handle_exceptions("do something")
     async def handler():
         raise RuntimeError("Unexpected error")
@@ -74,7 +76,7 @@ async def test_issue_855_generic_exception_returns_500(caplog):
             await handler()
 
     assert exc_info.value.status_code == 500
-    assert exc_info.value.detail == "Unexpected error"
+    assert exc_info.value.detail == "An internal error occurred"
     assert "Failed to do something" in caplog.text
 
 
@@ -100,3 +102,99 @@ async def test_issue_855_value_error_with_status_logs():
     with pytest.raises(HTTPException) as exc_info:
         await handler()
     assert exc_info.value.status_code == 400
+
+
+# --- Issue #852: debug flag controls 500 response detail ---
+
+
+@pytest.mark.asyncio
+async def test_issue_852_debug_off_returns_generic_detail():
+    """With debug_error_handler=False (default), 500 detail is sanitized."""
+    @handle_exceptions("do something")
+    async def handler():
+        raise RuntimeError("internal/path/secret")
+
+    with patch.object(logging_config, '_log_config', {'debug_error_handler': False}):
+        with pytest.raises(HTTPException) as exc_info:
+            await handler()
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail == "An internal error occurred"
+    assert "internal/path/secret" not in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_issue_852_debug_on_returns_full_detail():
+    """With debug_error_handler=True, 500 detail contains the original exception string."""
+    @handle_exceptions("do something")
+    async def handler():
+        raise RuntimeError("internal/path/secret")
+
+    with patch.object(logging_config, '_log_config', {'debug_error_handler': True}):
+        with pytest.raises(HTTPException) as exc_info:
+            await handler()
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail == "internal/path/secret"
+
+
+@pytest.mark.asyncio
+async def test_issue_852_value_error_with_status_unaffected_by_debug_flag():
+    """ValueError with value_error_status=400 always returns str(e) regardless of debug flag."""
+    @handle_exceptions("create schedule", value_error_status=400)
+    async def handler():
+        raise ValueError("Invalid cron expression")
+
+    for flag_value in (True, False):
+        with patch.object(logging_config, '_log_config', {'debug_error_handler': flag_value}):
+            with pytest.raises(HTTPException) as exc_info:
+                await handler()
+
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail == "Invalid cron expression"
+
+
+@pytest.mark.asyncio
+async def test_issue_852_http_exception_unaffected_by_debug_flag():
+    """HTTPException is re-raised unchanged regardless of debug flag."""
+    @handle_exceptions("test action")
+    async def handler():
+        raise HTTPException(status_code=403, detail="Forbidden")
+
+    for flag_value in (True, False):
+        with patch.object(logging_config, '_log_config', {'debug_error_handler': flag_value}):
+            with pytest.raises(HTTPException) as exc_info:
+                await handler()
+
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.detail == "Forbidden"
+
+
+@pytest.mark.asyncio
+async def test_issue_852_value_error_no_status_sanitized_in_non_debug(caplog):
+    """ValueError without value_error_status falls to 500 and is sanitized when debug is off."""
+    @handle_exceptions("some action")
+    async def handler():
+        raise ValueError("internal detail")
+
+    with patch.object(logging_config, '_log_config', {'debug_error_handler': False}):
+        with pytest.raises(HTTPException) as exc_info:
+            await handler()
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail == "An internal error occurred"
+
+
+@pytest.mark.asyncio
+async def test_issue_852_logger_exception_called_regardless_of_debug(caplog):
+    """logger.exception is always called for 500 errors, regardless of debug flag."""
+    @handle_exceptions("do something")
+    async def handler():
+        raise RuntimeError("secret details")
+
+    with caplog.at_level(logging.ERROR, logger="src.exception_handlers"):
+        with patch.object(logging_config, '_log_config', {'debug_error_handler': False}):
+            with pytest.raises(HTTPException):
+                await handler()
+
+    assert "Failed to do something" in caplog.text


### PR DESCRIPTION
## Summary
Resolves #852

Unhandled server exceptions were leaking internal details (file paths, SDK messages, stack trace strings) in HTTP 500 responses. This fix sanitizes 500 responses in production while preserving full detail for local debugging.

## Changes Made
- Add `get_debug_flag(key)` to `logging_config.py` — reads from the module-level `_log_config` dict at call time
- Gate `handle_exceptions` 500 response `detail` on `debug_error_handler` flag: returns `"An internal error occurred"` in production, full `str(e)` when `--debug-error-handler`/`--debug-all` is set
- 400 `ValueError` path (`value_error_status`) unchanged — those are intentional user-facing validation messages
- `logger.exception()` always called server-side, so no information is lost regardless of debug mode
- 13 tests covering debug-off sanitized, debug-on full detail, 400 path unaffected, HTTPException unaffected, logger always called

## Testing
- [ ] `uv run pytest src/tests/test_exception_handlers.py -v` — all 13 tests pass
- [ ] Start server without `--debug-error-handler`, trigger unhandled exception, confirm `"An internal error occurred"` in response
- [ ] Repeat with `--debug-error-handler`, confirm full exception detail returned in response

🤖 Generated with [Claude Code](https://claude.com/claude-code)