### PR TITLE
chore: add done callbacks to background task fire-and-forget sites

### DIFF
--- a/src/claude_sdk.py
+++ b/src/claude_sdk.py
@@ -5,7 +5,7 @@ import contextlib
 import logging
 import tempfile
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Coroutine
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from enum import Enum
@@ -56,6 +56,18 @@ sdk_logger = get_logger('sdk_debug', category='SDK')
 perm_logger = get_logger('sdk_debug', category='PERMISSIONS')
 # Keep standard logger for errors
 logger = logging.getLogger(__name__)
+
+
+def _task_done_log_exception(task: asyncio.Task) -> None:
+    """Done callback: log any exception not already caught inside the coroutine."""
+    if not task.cancelled() and (exc := task.exception()):
+        logger.error("Unhandled exception in background task %s: %s", task.get_name(), exc, exc_info=exc)
+
+
+def _schedule_coro(coro: Coroutine) -> None:
+    """Schedule a coroutine as a task and attach error logging done callback."""
+    task = asyncio.ensure_future(coro)
+    task.add_done_callback(_task_done_log_exception)
 
 
 class SessionState(Enum):
@@ -903,7 +915,7 @@ class ClaudeSDK:
                 try:
                     loop = asyncio.get_running_loop()
                     loop.call_soon_threadsafe(
-                        asyncio.ensure_future,
+                        _schedule_coro,
                         self._safe_callback(self.stderr_callback, output)
                     )
                 except RuntimeError:

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -47,6 +47,15 @@ coord_logger = get_logger('coordinator', category='COORDINATOR')
 # Keep standard logger for errors
 logger = logging.getLogger(__name__)
 
+
+def _task_done_log_exception(task: asyncio.Task) -> None:
+    """Done callback: log any exception not already caught inside the coroutine."""
+    if not task.cancelled() and (exc := task.exception()):
+        coord_logger.error(
+            "Unhandled exception in background task %s: %s", task.get_name(), exc, exc_info=exc
+        )
+
+
 # Issue #871: Docker wrapper startup noise filtering
 _DOCKER_WRAPPER_PREFIX = '[claude-docker] '
 _DOCKER_ERROR_KEYWORDS = ('exited with code', 'was killed', 'crashed')
@@ -2686,7 +2695,10 @@ class SessionCoordinator:
                 f"Failed to build ToolCallUpdate for {tool_call.tool_use_id}"
             )
             return
-        asyncio.ensure_future(self._write_tool_call_update(storage, stored_dict, tool_call.tool_use_id))
+        task = asyncio.ensure_future(
+            self._write_tool_call_update(storage, stored_dict, tool_call.tool_use_id)
+        )
+        task.add_done_callback(_task_done_log_exception)
 
     async def _write_tool_call_update(
         self,

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -47,6 +47,12 @@ from .timestamp_utils import normalize_timestamp
 logger = logging.getLogger(__name__)
 
 
+def _task_done_log_exception(task: asyncio.Task) -> None:
+    """Done callback: log any exception not already caught inside the coroutine."""
+    if not task.cancelled() and (exc := task.exception()):
+        logger.error("Unhandled exception in background task %s: %s", task.get_name(), exc, exc_info=exc)
+
+
 class AuthMiddleware(BaseHTTPMiddleware):
     """Authentication middleware for HTTP requests (issue #728).
 
@@ -510,7 +516,8 @@ class ClaudeWebUI:
                 except Exception:
                     logger.exception(f"Error broadcasting project_updated for session {session_id}")
 
-            asyncio.ensure_future(_broadcast_session_added())
+            task = asyncio.create_task(_broadcast_session_added(), name="broadcast_session_added")
+            task.add_done_callback(_task_done_log_exception)
 
         return registrar
 


### PR DESCRIPTION
## Summary
Resolves #863

Add `_task_done_log_exception` done callbacks to all three `asyncio.ensure_future` / `create_task` call sites so any exception that escapes an inner `try/except` is logged rather than silently discarded as a "Task exception was never retrieved" warning.

## Changes Made
- `src/web_server.py`: Replace `ensure_future()` with `create_task(name=...)` + done callback on the `_broadcast_session_added` fire-and-forget
- `src/session_coordinator.py`: Add done callback to `ensure_future(_write_tool_call_update(...))` call
- `src/claude_sdk.py`: Introduce `_schedule_coro()` helper (creates task + attaches callback); replace bare `asyncio.ensure_future` reference passed to `call_soon_threadsafe`

No behavior change — all three coroutines already handle their own exceptions internally. The done callback is defense-in-depth only.

## Testing
- 754 unit tests pass with no regressions (`uv run pytest src/tests/ -v`)
- `uv run ruff check src/` passes with zero violations
- Backend health endpoint verified on port 8863

🤖 Generated with [Claude Code](https://claude.com/claude-code)