### PR TITLE
fix: eliminate race conditions in pending_permissions dict

### DIFF
--- a/src/permission_service.py
+++ b/src/permission_service.py
@@ -369,8 +369,7 @@ class PermissionService:
                 }
 
                 # Clean up the pending permission
-                if request_id in self.pending_permissions:
-                    del self.pending_permissions[request_id]
+                self.pending_permissions.pop(request_id, None)
 
             # Store permission response message using dataclass (Phase 0, Issue #310)
             decision_time = time.time()
@@ -502,16 +501,16 @@ class PermissionService:
                     "message": "Permission denied due to session interrupt",
                     "interrupt": True
                 })
-                del self.pending_permissions[request_id]
+                self.pending_permissions.pop(request_id, None)
 
     def resolve(self, request_id: str, response: dict) -> bool:
         """Resolve a pending permission request.
 
         Returns True on success, False if request_id not found or Future already done.
         """
-        if request_id not in self.pending_permissions:
+        pending_future = self.pending_permissions.pop(request_id, None)
+        if pending_future is None:
             return False
-        pending_future = self.pending_permissions.pop(request_id)
         if pending_future.done():
             return False
         pending_future.set_result(response)


### PR DESCRIPTION
## Summary
Resolves #860

Replace check-then-delete patterns with atomic `dict.pop(key, None)` in `permission_service.py` to eliminate `KeyError` race windows between concurrent asyncio coroutines.

## Changes Made
- `error handler` (~line 372): `if key in d: del d[key]` → `d.pop(key, None)`
- `deny_all_for_interrupt` (~line 505): `del d[key]` → `d.pop(key, None)`
- `resolve` (~line 512): split check-then-pop → single `pop(key, None)` with `None` guard

All three sites could raise `KeyError` when cleanup, interrupt, and resolve coroutines interleaved across `await` points. `dict.pop()` is a single C-level operation with no internal yield, making it safe without locking.

## Testing
- All 784 existing tests pass (`uv run pytest src/tests/ -v`)
- Ruff linting clean on modified file

🤖 Generated with [Claude Code](https://claude.com/claude-code)