### PR TITLE
fix: surface fire-and-forget task errors with done-callbacks and UI alerts

### DIFF
--- a/frontend/src/components/layout/RightSidebar.vue
+++ b/frontend/src/components/layout/RightSidebar.vue
@@ -23,7 +23,8 @@
         @click="uiStore.setRightSidebarTab(tab.id)"
       >
         {{ tab.label }}
-        <span v-if="tab.badge > 0" class="tab-badge">{{ tab.badge }}</span>
+        <span v-if="tab.badge > 0" class="tab-badge" :class="{ 'tab-badge-error': tab.badgeError }">{{ tab.badge }}</span>
+        <span v-else-if="tab.badgeError" class="tab-badge tab-badge-error">!</span>
       </button>
     </div>
 
@@ -87,12 +88,18 @@ const schedulesCount = computed(() => {
   return all.filter(s => s.status === 'active').length
 })
 
+const schedulesHasError = computed(() => {
+  const projectId = sessionStore.currentSession?.project_id
+  if (!projectId) return false
+  return scheduleStore.getSchedules(projectId).some(s => s.monitor_error)
+})
+
 // Tab definitions
 const tabs = computed(() => [
   { id: 'diff', label: 'Diff', badge: diffFileCount.value },
   { id: 'tasks', label: 'Tasks', badge: taskStats.value.total > 0 ? taskStats.value.total : 0 },
   { id: 'resources', label: 'Resources', badge: resourceCount.value },
-  { id: 'schedules', label: 'Sched', badge: schedulesCount.value }
+  { id: 'schedules', label: 'Sched', badge: schedulesCount.value, badgeError: schedulesHasError.value }
 ])
 
 const isOverlay = computed(() => uiStore.windowWidth < 768)
@@ -197,6 +204,10 @@ function stopResize() {
 
 .sidebar-tab.active .tab-badge {
   background: #3b82f6;
+}
+
+.tab-badge.tab-badge-error {
+  background: #dc3545;
 }
 
 /* Tab content */

--- a/frontend/src/components/schedules/ScheduleItem.vue
+++ b/frontend/src/components/schedules/ScheduleItem.vue
@@ -24,6 +24,11 @@
       <div class="header-badges">
         <span v-if="isEphemeral" class="type-badge ephemeral" title="Ephemeral — dedicated agent for this schedule">Ephemeral</span>
         <span v-if="isAgentRunning" class="type-badge running" title="Agent session currently active">Running</span>
+        <span
+          v-if="schedule.monitor_error"
+          class="type-badge monitor-error"
+          :title="`Monitor error: ${schedule.monitor_error}`"
+        >Error</span>
         <span class="status-badge" :class="schedule.status">{{ schedule.status }}</span>
       </div>
     </div>
@@ -682,6 +687,11 @@ watch(() => scheduleStore.executionHistory, (storeHistory) => {
   background: #dcfce7;
   color: #166534;
   animation: pulse 2s ease-in-out infinite;
+}
+
+.type-badge.monitor-error {
+  background: #dc3545;
+  color: #fff;
 }
 
 @keyframes pulse {

--- a/frontend/src/composables/useNotifications.js
+++ b/frontend/src/composables/useNotifications.js
@@ -18,7 +18,8 @@ const DEFAULT_SETTINGS = {
     permission_prompt: true,
     task_complete: true,
     session_error: true,
-    minion_comm: false
+    minion_comm: false,
+    session_restart_error: true,
   }
 }
 
@@ -40,6 +41,10 @@ const TTS_TEMPLATES = {
     const from = ctx?.fromMinion || 'A minion'
     const type = ctx?.commType || 'message'
     return `${from} sent a ${type}`
+  },
+  session_restart_error: (ctx) => {
+    const id = ctx?.sessionId || 'Session'
+    return `Restart error for ${id}: ${ctx?.error || 'unknown error'}`
   }
 }
 
@@ -143,6 +148,10 @@ const TONE_DEFS = {
   minion_comm(gain) {
     // Subtle sine ping
     playTone(660, 0.15, 'sine', gain)
+  },
+  session_restart_error(gain) {
+    // Low square wave warning (same as session_error)
+    playTone(220, 0.4, 'square', gain * 0.5)
   }
 }
 

--- a/frontend/src/stores/schedule.js
+++ b/frontend/src/stores/schedule.js
@@ -184,6 +184,7 @@ export const useScheduleStore = defineStore('schedule', () => {
   /**
    * Handle WebSocket schedule_execution event (Issue #670)
    * Prepends execution to history if the matching schedule is selected.
+   * Also auto-clears any monitor_error on the schedule (transient errors don't persist).
    */
   function handleScheduleExecution(legionId, event) {
     if (!event || !event.execution) return
@@ -194,6 +195,27 @@ export const useScheduleStore = defineStore('schedule', () => {
       executionHistory.value = [event.execution, ...executionHistory.value]
     }
 
+    // Clear any monitor_error when a new execution fires
+    const schedules = schedulesByLegion.value.get(legionId) || []
+    const idx = schedules.findIndex(s => s.schedule_id === scheduleId)
+    if (idx >= 0 && schedules[idx].monitor_error) {
+      schedules[idx] = { ...schedules[idx], monitor_error: null }
+      schedulesByLegion.value.set(legionId, [...schedules])
+    }
+  }
+
+  /**
+   * Handle WebSocket schedule_monitor_error event (Issue #857)
+   * Sets monitor_error on the affected schedule item.
+   */
+  function handleScheduleMonitorError(legionId, event) {
+    if (!event || !event.schedule_id) return
+    const schedules = schedulesByLegion.value.get(legionId) || []
+    const idx = schedules.findIndex(s => s.schedule_id === event.schedule_id)
+    if (idx >= 0) {
+      schedules[idx] = { ...schedules[idx], monitor_error: event.error }
+      schedulesByLegion.value.set(legionId, [...schedules])
+    }
   }
 
   // ========== INTERNAL HELPERS ==========
@@ -278,5 +300,6 @@ export const useScheduleStore = defineStore('schedule', () => {
     runNow,
     handleScheduleEvent,
     handleScheduleExecution,
+    handleScheduleMonitorError,
   }
 })

--- a/frontend/src/stores/websocket.js
+++ b/frontend/src/stores/websocket.js
@@ -383,6 +383,25 @@ export const useWebSocketStore = defineStore('websocket', () => {
         })
         break
 
+      case 'schedule_monitor_error':
+        import('./schedule').then(({ useScheduleStore }) => {
+          const scheduleStore = useScheduleStore()
+          scheduleStore.handleScheduleMonitorError(
+            payload.legion_id || payload.data?.legion_id, payload
+          )
+        })
+        break
+
+      case 'session_restart_error':
+        console.error(
+          `[session_restart_error] Session ${payload.data?.session_id}: ${payload.data?.error}`
+        )
+        notify('session_restart_error', {
+          sessionId: payload.data?.session_id,
+          error: payload.data?.error,
+        })
+        break
+
       default:
         console.warn('Unknown UI poll message type:', payload.type)
     }

--- a/src/claude_sdk.py
+++ b/src/claude_sdk.py
@@ -17,6 +17,7 @@ from .logging_config import get_logger
 from .message_parser import MessageParser, MessageProcessor
 from .models.messages import sdk_message_to_stored
 from .session_config import SessionConfig
+from .task_utils import task_done_log_exception
 
 # Import SDK components
 try:
@@ -58,16 +59,10 @@ perm_logger = get_logger('sdk_debug', category='PERMISSIONS')
 logger = logging.getLogger(__name__)
 
 
-def _task_done_log_exception(task: asyncio.Task) -> None:
-    """Done callback: log any exception not already caught inside the coroutine."""
-    if not task.cancelled() and (exc := task.exception()):
-        logger.error("Unhandled exception in background task %s: %s", task.get_name(), exc, exc_info=exc)
-
-
 def _schedule_coro(coro: Coroutine) -> None:
     """Schedule a coroutine as a task and attach error logging done callback."""
     task = asyncio.ensure_future(coro)
-    task.add_done_callback(_task_done_log_exception)
+    task.add_done_callback(task_done_log_exception)
 
 
 class SessionState(Enum):
@@ -101,7 +96,8 @@ class SDKErrorDetectionHandler(logging.Handler):
                     # Schedule the error callback to run in the event loop
                     loop = asyncio.get_event_loop()
                     if loop.is_running():
-                        loop.create_task(self._trigger_error_callback(record.getMessage()))
+                        t = loop.create_task(self._trigger_error_callback(record.getMessage()))
+                        t.add_done_callback(task_done_log_exception)
                     else:
                         asyncio.run(self._trigger_error_callback(record.getMessage()))
         except Exception:

--- a/src/legion/archive_manager.py
+++ b/src/legion/archive_manager.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 from src.history_distiller import distill_session_history
 from src.logging_config import get_logger
 from src.models.archive_models import ArchiveResult, DisposalMetadata
+from src.task_utils import task_done_log_exception
 
 if TYPE_CHECKING:
     from src.legion_system import LegionSystem
@@ -159,9 +160,10 @@ class ArchiveManager:
                 if archived_messages.exists():
                     history_output = archive_dir / "history.md"
                     archive_ts = datetime.now(UTC).isoformat()
-                    asyncio.create_task(
+                    t = asyncio.create_task(
                         distill_session_history(archived_messages, history_output, minion_id, archive_ts)
                     )
+                    t.add_done_callback(task_done_log_exception)
                     archive_logger.debug(f"Launched history distillation for minion {minion_id}")
 
             return ArchiveResult(

--- a/src/legion/mcp/legion_mcp_tools.py
+++ b/src/legion/mcp/legion_mcp_tools.py
@@ -28,6 +28,7 @@ except ImportError:
 
 from src.docker_utils import translate_docker_tmp_path
 from src.session_config import SessionConfig
+from src.task_utils import task_done_log_exception
 
 logger = logging.getLogger(__name__)
 
@@ -2334,7 +2335,8 @@ class LegionMCPTools:
         )
 
         # Spawn background monitor task
-        asyncio.create_task(self._restart_monitor(session_id, restart_id, reason))
+        t = asyncio.create_task(self._restart_monitor(session_id, restart_id, reason))
+        t.add_done_callback(task_done_log_exception)
 
         return {
             "content": [{
@@ -2422,6 +2424,18 @@ class LegionMCPTools:
             )
 
         except Exception as e:
-            logger.error(f"Restart monitor error for session {session_id}: {e}")
+            logger.error(
+                f"Restart monitor unhandled error for session {session_id}: {e}", exc_info=True
+            )
+            if self.system.ui_queue:
+                self.system.ui_queue.append({
+                    "type": "session_restart_error",
+                    "data": {
+                        "session_id": session_id,
+                        "restart_id": restart_id,
+                        "error": str(e),
+                        "timestamp": datetime.now(UTC).isoformat(),
+                    }
+                })
         finally:
             self._pending_restarts.discard(session_id)

--- a/src/legion/scheduler_service.py
+++ b/src/legion/scheduler_service.py
@@ -19,6 +19,7 @@ from src.models.schedule_models import (
     get_next_run,
     validate_cron_expression,
 )
+from src.task_utils import task_done_log_exception
 
 if TYPE_CHECKING:
     from src.legion_system import LegionSystem
@@ -583,9 +584,10 @@ class SchedulerService:
             schedule.failure_count = 0
 
             # Launch monitoring task
-            asyncio.create_task(
-                self._monitor_ephemeral_session(schedule.schedule_id, agent_id)
+            t = asyncio.create_task(
+                self._monitor_ephemeral_session(schedule.schedule_id, agent_id, schedule.legion_id)
             )
+            t.add_done_callback(task_done_log_exception)
 
             legion_logger.info(
                 f"Ephemeral schedule {schedule.schedule_id} fired — agent {agent_id} started"
@@ -640,7 +642,7 @@ class SchedulerService:
             )
             return None
 
-    async def _monitor_ephemeral_session(self, schedule_id: str, session_id: str):
+    async def _monitor_ephemeral_session(self, schedule_id: str, session_id: str, legion_id: str):
         """Monitor an ephemeral session and archive+terminate when it finishes.
 
         Polls every 10 seconds. Once idle for a grace period, archives session
@@ -719,8 +721,19 @@ class SchedulerService:
             return
         except Exception as e:
             legion_logger.error(
-                f"Error monitoring ephemeral session {session_id}: {e}"
+                f"Ephemeral monitor failed for schedule {schedule_id}: {e}", exc_info=True
             )
+            if self._schedule_broadcast_callback:
+                try:
+                    await self._schedule_broadcast_callback(legion_id, {
+                        "type": "schedule_monitor_error",
+                        "legion_id": legion_id,
+                        "schedule_id": schedule_id,
+                        "error": str(e),
+                        "timestamp": datetime.now(UTC).isoformat(),
+                    })
+                except Exception:
+                    legion_logger.exception("Failed to broadcast schedule_monitor_error")
 
         # Archive on completion: archive data, clear messages, terminate
         try:

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -40,21 +40,13 @@ from .queue_manager import QueueManager
 from .queue_processor import QueueProcessor
 from .session_config import SessionConfig
 from .session_manager import SessionManager, SessionState
+from .task_utils import task_done_log_exception
 from .timestamp_utils import get_unix_timestamp
 
 # Get specialized logger for coordinator actions
 coord_logger = get_logger('coordinator', category='COORDINATOR')
 # Keep standard logger for errors
 logger = logging.getLogger(__name__)
-
-
-def _task_done_log_exception(task: asyncio.Task) -> None:
-    """Done callback: log any exception not already caught inside the coroutine."""
-    if not task.cancelled() and (exc := task.exception()):
-        coord_logger.error(
-            "Unhandled exception in background task %s: %s", task.get_name(), exc, exc_info=exc
-        )
-
 
 # Issue #871: Docker wrapper startup noise filtering
 _DOCKER_WRAPPER_PREFIX = '[claude-docker] '
@@ -1930,9 +1922,10 @@ class SessionCoordinator:
 
                     history_output = session_dir / "history" / f"{timestamp}.md"
                     archive_ts = datetime.now(UTC).isoformat()
-                    asyncio.create_task(
+                    t = asyncio.create_task(
                         distill_session_history(archived_messages, history_output, session_id, archive_ts)
                     )
+                    t.add_done_callback(task_done_log_exception)
                     coord_logger.debug(f"Launched history distillation for session {session_id}")
 
             coord_logger.info(f"Archived session {session_id} to {archive_dir}")
@@ -2717,7 +2710,7 @@ class SessionCoordinator:
         task = asyncio.ensure_future(
             self._write_tool_call_update(storage, stored_dict, tool_call.tool_use_id)
         )
-        task.add_done_callback(_task_done_log_exception)
+        task.add_done_callback(task_done_log_exception)
 
     async def _write_tool_call_update(
         self,

--- a/src/task_utils.py
+++ b/src/task_utils.py
@@ -1,0 +1,15 @@
+"""Shared asyncio task utilities."""
+
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def task_done_log_exception(task: asyncio.Task) -> None:
+    """Done callback: log any unhandled exception from a background task."""
+    if not task.cancelled() and (exc := task.exception()):
+        logger.error(
+            "Unhandled exception in background task %s: %s",
+            task.get_name(), exc, exc_info=exc,
+        )

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -41,17 +41,12 @@ from .session_config import SessionConfigBase
 from .session_coordinator import SessionCoordinator
 from .session_manager import SessionState
 from .skill_manager import SkillManager
+from .task_utils import task_done_log_exception
 from .template_manager import TemplateConflictError
 from .timestamp_utils import normalize_timestamp
 
 # Keep standard logger for errors
 logger = logging.getLogger(__name__)
-
-
-def _task_done_log_exception(task: asyncio.Task) -> None:
-    """Done callback: log any exception not already caught inside the coroutine."""
-    if not task.cancelled() and (exc := task.exception()):
-        logger.error("Unhandled exception in background task %s: %s", task.get_name(), exc, exc_info=exc)
 
 
 class AuthMiddleware(BaseHTTPMiddleware):
@@ -518,7 +513,7 @@ class ClaudeWebUI:
                     logger.exception(f"Error broadcasting project_updated for session {session_id}")
 
             task = asyncio.create_task(_broadcast_session_added(), name="broadcast_session_added")
-            task.add_done_callback(_task_done_log_exception)
+            task.add_done_callback(task_done_log_exception)
 
         return registrar
 


### PR DESCRIPTION
## Summary
Resolves #857

Audits every `asyncio.create_task()` / `ensure_future()` fire-and-forget call in the codebase, adds missing done-callbacks, consolidates the repeated helper into a shared module, and surfaces the two user-visible failures (ephemeral schedule monitor crash and session restart monitor crash) to the UI.

## Changes Made

### Backend
- **`src/task_utils.py`** (new): shared `task_done_log_exception` done-callback helper
- **`src/web_server.py`**, **`src/claude_sdk.py`**, **`src/session_coordinator.py`**: remove three identical local copies; import from `task_utils`
- Add `task.add_done_callback(task_done_log_exception)` to five previously unguarded tasks:
  - `_trigger_error_callback` (claude_sdk.py)
  - history distillation on reset (session_coordinator.py)
  - history distillation on archival (archive_manager.py)
  - `_monitor_ephemeral_session` (scheduler_service.py)
  - `_restart_monitor` (legion_mcp_tools.py)
- **`scheduler_service.py`**: pass `legion_id` to `_monitor_ephemeral_session`; broadcast `schedule_monitor_error` WebSocket event on exception
- **`legion_mcp_tools.py`**: append `session_restart_error` to `ui_queue` on exception in `_restart_monitor`

### Frontend
- **`stores/schedule.js`**: add `handleScheduleMonitorError` action; `handleScheduleExecution` auto-clears `monitor_error` on next successful run
- **`stores/websocket.js`**: add `schedule_monitor_error` and `session_restart_error` cases in `handleUIMessage`
- **`components/schedules/ScheduleItem.vue`**: display-only error badge when `schedule.monitor_error` is set
- **`components/layout/RightSidebar.vue`**: `schedulesHasError` computed; Schedules tab badge turns red when any schedule has a monitor error
- **`composables/useNotifications.js`**: add `session_restart_error` event type with sound and TTS support

## Testing
- Ruff linting passes with zero violations on all changed Python files
- Error badge renders on ScheduleItem when `monitor_error` is set; clears on next execution event
- Schedules tab badge turns red when any schedule in the legion has a monitor error

🤖 Generated with [Claude Code](https://claude.com/claude-code)