### PR TITLE
refactor: store attachment metadata in message metadata field

### DIFF
--- a/frontend/src/components/messages/InputArea.vue
+++ b/frontend/src/components/messages/InputArea.vue
@@ -571,8 +571,19 @@ async function sendMessage() {
     }
   }
 
-  // Send via WebSocket
-  wsStore.sendMessage(messageContent)
+  // Build structured attachment metadata for new messages
+  const successfulAttachments = attachments.value.filter(a => a.uploaded && a.uploadedInfo)
+  const attachmentsMeta = successfulAttachments.map(a => ({
+    filename: a.name,
+    resource_id: a.uploadedInfo.resource_id ?? null,
+    size: a.size,
+    type: a.type,
+    stored_path: a.uploadedInfo.stored_path ?? null
+  }))
+
+  // Send via REST with optional metadata
+  const sendMetadata = attachmentsMeta.length > 0 ? { attachments: attachmentsMeta } : undefined
+  wsStore.sendMessage(messageContent, sendMetadata)
 
   // Clear input and attachments
   inputText.value = ''

--- a/frontend/src/components/messages/UserMessage.vue
+++ b/frontend/src/components/messages/UserMessage.vue
@@ -104,14 +104,15 @@ const cleanContent = computed(() => splitContent.value.main)
 const { renderedHtml: cleanRenderedContent } = useMarkdown(cleanContent)
 
 /**
- * Parse the attachment block into structured items.
+ * Parse the attachment block into structured items (regex fallback for old messages).
  * Each line follows: "- <name> (<size> KB): <stored_path>"
  * Optionally followed by "  Resource ID: <uuid>"
  * Falls back to extracting uuid from stored_path URL for gallery resources.
  */
-const attachmentItems = computed(() => {
-  const block = splitContent.value.block
-  if (!block) return []
+function parseAttachmentsFromContent(content) {
+  const idx = content.indexOf(ATTACHMENT_SEPARATOR)
+  if (idx === -1) return []
+  const block = content.slice(idx + ATTACHMENT_SEPARATOR.length)
 
   const items = []
   const lines = block.split('\n')
@@ -150,6 +151,24 @@ const attachmentItems = computed(() => {
     i++
   }
   return items
+}
+
+/**
+ * Two-tier attachment rendering:
+ * Tier 1: structured metadata from message.metadata.attachments (new messages)
+ * Tier 2: regex parse of content block (fallback for old messages)
+ */
+const attachmentItems = computed(() => {
+  const meta = props.message?.metadata?.attachments
+  if (meta && meta.length > 0) {
+    return meta.map(a => ({
+      filename: a.filename,
+      storedPath: a.stored_path,
+      resourceId: a.resource_id,
+      icon: getFileIcon(a.filename)
+    }))
+  }
+  return parseAttachmentsFromContent(props.message?.content ?? '')
 })
 
 function openPreview(item) {

--- a/frontend/src/stores/websocket.js
+++ b/frontend/src/stores/websocket.js
@@ -208,7 +208,7 @@ export const useWebSocketStore = defineStore('websocket', () => {
   }
 
   // ========== OUTBOUND REST ACTIONS ==========
-  async function sendMessage(content) {
+  async function sendMessage(content, metadata) {
     const sessionStore = useSessionStore()
     const sid = sessionStore.currentSessionId
     if (!sid) {
@@ -216,7 +216,9 @@ export const useWebSocketStore = defineStore('websocket', () => {
       return
     }
     try {
-      await api.post(`/api/sessions/${sid}/messages`, { message: content })
+      const payload = { message: content }
+      if (metadata) payload.metadata = metadata
+      await api.post(`/api/sessions/${sid}/messages`, payload)
       setTimeout(() => {
         import('./mcp').then(({ useMcpStore }) => {
           useMcpStore().fetchMcpStatus(sid)

--- a/src/message_parser.py
+++ b/src/message_parser.py
@@ -901,7 +901,7 @@ class UserMessageHandler(MessageHandler):
         # attached by CommRouter for comm-injected messages)
         orig_meta = message_data.get("metadata")
         if isinstance(orig_meta, dict):
-            for key in ("comm",):
+            for key in ("comm", "attachments"):
                 if key in orig_meta:
                     extracted["metadata"][key] = orig_meta[key]
 

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -165,6 +165,7 @@ class SessionCreateRequest(SessionConfigBase):
 
 class MessageRequest(BaseModel):
     message: str
+    metadata: dict | None = None
 
 
 class SessionNameUpdateRequest(BaseModel):
@@ -1284,7 +1285,7 @@ class ClaudeWebUI:
                 raise HTTPException(status_code=404, detail="Session not found")
             if state != SessionState.ACTIVE:
                 raise HTTPException(status_code=409, detail="Session is not active")
-            success = await self.coordinator.send_message(session_id, request.message)
+            success = await self.coordinator.send_message(session_id, request.message, metadata=request.metadata)
             return {"success": success}
 
         @self.app.get("/api/sessions/{session_id}/messages")


### PR DESCRIPTION
## Summary

- `InputArea.vue` builds `metadata.attachments` array at send time from uploaded file info and passes it to `wsStore.sendMessage`
- `websocket.js` `sendMessage` accepts optional `metadata` arg and includes it in the REST payload
- `web_server.py` `MessageRequest` gains an optional `metadata` field; the handler passes it through to `coordinator.send_message`
- `message_parser.py` preserves the `attachments` key in the metadata pass-through (same pattern as the existing `comm` key)
- `UserMessage.vue` uses two-tier rendering: reads chips from `message.metadata.attachments` for new messages; falls back to regex parsing of the content block for old messages

No schema migration. No new files. Old messages continue to render chips via the existing regex fallback.

## Test plan

- [ ] Send message with attachment → confirm chip rendered and `message.metadata.attachments` present
- [ ] Load old message without `metadata.attachments` → confirm chip still renders via fallback
- [ ] Send plain text message → no chips, no errors
- [ ] 798 unit tests pass (≥784 required)

Resolves #850

🤖 Generated with [Claude Code](https://claude.com/claude-code)