### PR TITLE
fix: sum all input token types for context window % (#926)

### DIFF
--- a/src/web_server.py
+++ b/src/web_server.py
@@ -3294,7 +3294,11 @@ class ClaudeWebUI:
                 if msg_type_str == "result" and session_id in self.session_queues:
                     metadata = getattr(parsed_message, 'metadata', {}) or {}
                     usage = metadata.get("usage") or {}
-                    input_tokens = usage.get("input_tokens")
+                    input_tokens = (
+                        (usage.get("input_tokens") or 0) +
+                        (usage.get("cache_read_input_tokens") or 0) +
+                        (usage.get("cache_creation_input_tokens") or 0)
+                    ) or None
                     if input_tokens is not None:
                         model = self._session_models.get(session_id, "")
                         context_window = get_context_window(model)


### PR DESCRIPTION
## Summary
Resolves #926

The context window percentage was calculated using only `input_tokens`, ignoring `cache_read_input_tokens` and `cache_creation_input_tokens`. This caused the displayed percentage to be lower than actual usage when cached tokens were involved.

## Changes Made
- `src/web_server.py`: Sum all three input token fields (`input_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`) before calculating context window percentage

## Testing
- Ruff: zero violations (`uv run ruff check src/web_server.py`)
- Pytest: 827 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)