### PR TITLE
fix: attachment chips not rendering in received comm messages

### DIFF
--- a/src/legion/comm_router.py
+++ b/src/legion/comm_router.py
@@ -369,7 +369,7 @@ class CommRouter:
                             attachment_lines.append(f"- {att['name']}: [delivery failed]")
 
                 if attachment_lines:
-                    formatted_message += "\n\n---\nAttached files (use Read tool to access):\n"
+                    formatted_message += "\n\n---\nAttached files (use Read tool to access, or embed via markdown URL):\n"
                     formatted_message += "\n".join(attachment_lines)
 
             formatted_message += f"\n\n---\nAlways send messages to {from_name} using the `send_comm` tool."
@@ -384,6 +384,18 @@ class CommRouter:
                     "comm_type": comm.comm_type.value if hasattr(comm.comm_type, 'value') else str(comm.comm_type),
                 }
             }
+
+            # Add processed attachment metadata for frontend chip rendering (issue #939)
+            delivered_attachments = [a for a in comm.attachments if a.get("stored_path")]
+            if delivered_attachments:
+                comm_metadata["attachments"] = [
+                    {
+                        "filename": a["name"],
+                        "stored_path": a.get("stored_path", ""),
+                        "resource_id": a.get("resource_id"),
+                    }
+                    for a in delivered_attachments
+                ]
 
             # Handle interrupt priority (issue #748)
             if comm.interrupt_priority == InterruptPriority.HALT:

--- a/src/tests/test_comm_router.py
+++ b/src/tests/test_comm_router.py
@@ -341,3 +341,52 @@ class TestCommRouter:
             await comm_router._persist_comm(comm)
             # Should append to destination minion's log
             mock_append.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_issue_939_attachment_metadata_in_comm(self, comm_router, tmp_path):
+        """Regression test: _send_to_minion must include attachment metadata in comm_metadata
+        so the frontend can render attachment chips on received comms."""
+        # Point data_dir to tmp_path so attachment directory creation succeeds
+        comm_router.system.session_coordinator.data_dir = tmp_path
+
+        # Create a real source file for the attachment delivery code to copy
+        source_file = tmp_path / "report.txt"
+        source_file.write_bytes(b"test file content")
+
+        # Mock async session methods called during attachment delivery
+        comm_router.system.session_coordinator.register_uploaded_resource = AsyncMock(
+            return_value={"resource_id": "res-abc123"}
+        )
+        comm_router.system.session_coordinator.register_uploaded_file = AsyncMock()
+
+        comm = Comm(
+            comm_id=str(uuid.uuid4()),
+            from_user=True,
+            to_minion_id="test-minion-123",
+            content="Here is a file",
+            comm_type=CommType.TASK,
+            attachments=[
+                {
+                    "name": "report.txt",
+                    "size": 1024,
+                    "source_path": str(source_file),
+                }
+            ],
+        )
+
+        result = await comm_router._send_to_minion(comm)
+        assert result is True
+
+        # Verify send_message was called with metadata containing attachments
+        send_message_mock = comm_router.system.session_coordinator.send_message
+        send_message_mock.assert_called_once()
+        call_kwargs = send_message_mock.call_args
+        metadata = call_kwargs.kwargs.get("metadata")
+
+        assert metadata is not None, "send_message must be called with metadata"
+        assert "attachments" in metadata, "metadata must contain 'attachments' key for frontend chip rendering"
+        attachments = metadata["attachments"]
+        assert len(attachments) == 1
+        assert attachments[0]["filename"] == "report.txt"
+        assert attachments[0]["stored_path"] != "", "stored_path must be set after delivery"
+        assert attachments[0]["resource_id"] == "res-abc123"


### PR DESCRIPTION
## Summary
Resolves #939

When a minion received a comm with file attachments, the `comm_metadata` dict passed to `send_message()` was missing the `attachments` field. The `UserMessage.vue` component reads `message.metadata.attachments` (Tier 1) to render attachment chips — without this key, chips were not rendered and users saw only raw file path text in the message body.

## Changes Made
- `src/legion/comm_router.py`: After the attachment delivery loop in `_send_to_minion()`, populate `comm_metadata["attachments"]` with delivered attachment metadata (filename, stored_path, resource_id) so the frontend can render chips
- `src/legion/comm_router.py`: Update attachment separator string to mention markdown URL embedding as an alternative access method
- `src/tests/test_comm_router.py`: Add regression test `test_issue_939_attachment_metadata_in_comm` verifying that `send_message()` receives `metadata` with an `attachments` list of correct shape when a comm has processed attachments

## Testing
- All 13 `test_comm_router.py` tests pass
- `uv run ruff check` reports zero violations on changed files
- Visual verification via browser: compared before (no chips, raw text) vs after (chip rendered) using injected test messages

## Screenshots

### Before (bug): raw file path text, no chip
Top message — `metadata.attachments` absent → `UserMessage.vue` falls back to regex parsing, raw path shown

### After (fix): attachment chip rendered
Bottom message — `metadata.attachments` populated → `UserMessage.vue` Tier 1 path renders chip

![Before/After comparison](/api/sessions/ed7991f2-ca96-423f-be03-70e467c6a33b/resources/e4651594-cdd6-4cdc-a69f-08001a6b7147)

🤖 Generated with [Claude Code](https://claude.com/claude-code)