### PR TITLE
feat: add 8 Chrome DevTools MCP browser automation skills (#566)

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,111 @@
+# Claude Code WebUI — Browser Automation Skills
+
+Composable Chrome DevTools MCP skills for UI testing of the Claude Code WebUI.
+
+## Skills
+
+| Skill | Purpose |
+|-------|---------|
+| `ui-navigate` | Navigate to the app, verify connection, select project/session |
+| `ui-project-create` | Create a new project via the creation modal |
+| `ui-project-delete` | Delete a project via the edit modal |
+| `ui-session-create` | Create a new session within the selected project |
+| `ui-session-reset` | Reset a session via the manage modal |
+| `ui-send-message` | Send a message and optionally wait for idle |
+| `ui-permission-respond` | Detect and respond to permission prompts |
+| `ui-verify-snapshot` | Assert expected content, report pass/fail |
+
+## Design Principles
+
+1. **No fixed sleeps** — all wait steps use `mcp__chrome_devtools__wait_for` polling
+2. **Long-poll aware** — connection is HTTP long-poll (`/api/poll/ui`, `/api/poll/session/{id}`), not WebSocket. Connection check uses `.header-indicator.connected`
+3. **Idempotent** — handle "already in desired state" without error
+4. **Clear errors** — specific failure messages with current UI state context
+5. **Composable** — no side effects that break subsequent skills
+6. **Mock-SDK compatible** — works against `--mock-sdk --fixtures-dir <dir>` servers
+
+## Key UI Selectors Reference
+
+### Connection State
+- `.header-indicator.connected` — long-poll active
+- `.header-indicator.disconnected` — connection lost
+
+### Session Chip States
+- `.agent-chip.active` — currently selected session
+- `.ac-status-sq.active` — session idle (green)
+- `.ac-status-sq.active-processing` — session responding (purple)
+- `.ac-status-sq.paused` — awaiting permission (amber)
+- `.ac-status-sq.error` — error state (red)
+- `.ac-alert.permission` — permission badge (`?`)
+
+### Message Input
+- `#message-input` — message textarea
+- `.input-container .btn.btn-primary` — Send button (text: "Send")
+- `.input-container .btn.btn-warning` — Stop button (text: "Stop")
+- `.input-container .btn.btn-info` — Queue button (text: "Queue")
+
+### Modals
+- `#createProjectModal` — create project modal
+- `#editProjectModal` — edit/delete project modal
+- `#manageSessionModal` — manage/reset/delete session modal
+
+### Permission Prompt
+- `.permission-section` — permission prompt container
+- `.btn-timeline.btn-approve` — Approve & Apply suggestions
+- `.btn-timeline.btn-approve-outline` — Approve Only
+- `.btn-timeline.btn-deny` — Deny
+
+## Composition Patterns
+
+### Basic test flow
+```
+1. /ui-navigate url=http://localhost:8000 project="My Project" session="main"
+2. /ui-send-message message="Hello" wait_for_idle=true
+3. /ui-verify-snapshot expected="Hello" screenshot=true
+```
+
+### Create and test a new project
+```
+1. /ui-navigate url=http://localhost:8000
+2. /ui-project-create name="Test Project" directory="/tmp/test"
+3. /ui-navigate project="Test Project"
+4. /ui-session-create name="test-session"
+5. /ui-send-message message="echo hello"
+6. /ui-verify-snapshot expected="hello"
+7. /ui-project-delete name="Test Project"
+```
+
+### Handle permission during message
+```
+1. /ui-navigate project="My Project" session="main"
+2. /ui-send-message message="Edit /etc/hosts" wait_for_idle=false
+3. /ui-permission-respond action=deny
+4. /ui-verify-snapshot expected=".agent-chip.active .ac-status-sq.active"
+```
+
+### Reset and verify reconnect
+```
+1. /ui-navigate project="My Project" session="main"
+2. /ui-session-reset
+3. /ui-verify-snapshot expected="#message-input:not([disabled])"
+```
+
+## Running Against Mock SDK
+
+Start the server with mock SDK:
+```bash
+uv run python main.py --port 8000 --mock-sdk --fixtures-dir path/to/fixtures
+```
+
+Then run skills normally. The session name passed to `ui-navigate` resolves to a fixture directory name, so mock responses are deterministic.
+
+## Timeout Reference
+
+| Operation | Default Timeout |
+|-----------|----------------|
+| App shell load | 15s |
+| Connection established | 20s |
+| Modal open/close | 5–10s |
+| Session active after reset | 30s |
+| Message response (wait_for_idle) | 120s |
+| Permission prompt appears | 30s |

--- a/.claude/skills/ui-navigate/SKILL.md
+++ b/.claude/skills/ui-navigate/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: ui-navigate
+description: Navigate to the Claude Code WebUI application, verify it loads, and optionally select a project and/or session by name. Use when starting any UI test, opening the app, verifying the app is loaded, switching projects, or selecting sessions.
+allowed-tools:
+  - mcp__chrome_devtools__navigate_page
+  - mcp__chrome_devtools__list_pages
+  - mcp__chrome_devtools__new_page
+  - mcp__chrome_devtools__take_snapshot
+  - mcp__chrome_devtools__wait_for
+  - mcp__chrome_devtools__evaluate_script
+  - mcp__chrome_devtools__click
+  - mcp__chrome_devtools__take_screenshot
+---
+
+# ui-navigate
+
+Navigate to the WebUI app, verify it loads, and optionally select a project and/or session.
+
+## Inputs
+
+- `url` (optional, default: `http://localhost:8000`) — App URL to navigate to
+- `project` (optional) — Project name to select after loading
+- `session` (optional) — Session name to select after selecting the project
+
+## Steps
+
+### 1. Open the App
+
+Check if a page is already open at the target URL. If not, navigate to it:
+
+```
+navigate_page(url=<url>)
+```
+
+### 2. Wait for Main Layout
+
+Poll until the main layout is rendered. Do NOT use a fixed sleep.
+
+Poll for `.app-shell` to be present in the DOM:
+```
+wait_for(selector=".app-shell", timeout=15000)
+```
+
+If timeout: report "App shell not found — server may not be running at <url>".
+
+### 3. Wait for Connection
+
+Poll for the connection indicator to show "Connected". The app uses HTTP long-poll (NOT WebSocket). Check for `.header-indicator.connected`.
+
+```
+wait_for(selector=".header-indicator.connected", timeout=20000)
+```
+
+If timeout: check for `.header-indicator.disconnected` — report "App loaded but not connected. Long-poll connection failed. Check that backend is running."
+
+If connected: the `.header-indicator` element contains text "Connected" and has the `.connected` CSS class.
+
+### 4. Select Project (optional)
+
+If `project` argument is provided:
+
+a. Poll for the project pill bar:
+```
+wait_for(selector=".project-pill-bar", timeout=5000)
+```
+
+b. Find the project pill with matching text. Use `evaluate_script` to find the pill by name:
+```javascript
+// Find project pill containing the target text
+const pills = document.querySelectorAll('.project-pill-bar .project-pill, .project-pill-bar [role="button"]');
+const target = Array.from(pills).find(p => p.textContent.trim().includes('<project name>'));
+target?.click();
+```
+
+c. If not found: take a snapshot and report "Project '<name>' not found in project pill bar. Available: <list>".
+
+d. Wait for the agent strip to update:
+```
+wait_for(selector=".agent-strip", timeout=5000)
+```
+
+### 5. Select Session (optional)
+
+If `session` argument is provided (requires project to be selected first):
+
+a. Poll for session chips to appear:
+```
+wait_for(selector=".agent-chip", timeout=5000)
+```
+
+b. Find the chip with the target session name using `evaluate_script`:
+```javascript
+const chips = document.querySelectorAll('.agent-chip');
+const target = Array.from(chips).find(c => {
+  const name = c.querySelector('.ac-name');
+  return name && name.textContent.trim().includes('<session name>');
+});
+target?.click();
+```
+
+c. If not found: take a snapshot and report "Session '<name>' not found. Available: <list of .ac-name texts>".
+
+d. Wait for the selected chip to gain the `.active` class:
+```
+wait_for(selector=".agent-chip.active", timeout=5000)
+```
+
+### 6. Verify
+
+Take a snapshot to confirm the current state. Report:
+- URL loaded
+- Connection: Connected / Disconnected
+- Project selected (if requested): name
+- Session selected (if requested): name and state
+
+## Connection State Values
+
+The `.header-indicator` element:
+- `.connected` — long-poll active, app working normally
+- `.disconnected` — connection lost, app cannot receive updates
+
+The session chip `.ac-status-sq` classes indicate session state:
+- `.active` (green) — idle, ready
+- `.active-processing` (purple) — responding
+- `.paused` (amber) — awaiting permission
+- `.error` (red) — error state
+
+## Error Handling
+
+- **Server not running**: `wait_for` times out on `.app-shell`. Report the URL and suggest starting the server.
+- **Long-poll not connected**: `.header-indicator` does not get `.connected` class. Check backend health endpoint.
+- **Project not found**: take snapshot, list available projects from `.project-pill-bar`.
+- **Session not found**: take snapshot, list available sessions from `.agent-chip .ac-name` texts.
+
+## Mock-SDK Compatibility
+
+Skills work identically against `--mock-sdk` servers. The `session` name passed to `ui-navigate` corresponds to a fixture directory name when the server is started with `--mock-sdk --fixtures-dir <dir>`.

--- a/.claude/skills/ui-permission-respond/SKILL.md
+++ b/.claude/skills/ui-permission-respond/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: ui-permission-respond
+description: Detect and respond to a permission prompt in the Claude Code WebUI. Use when approving or denying tool permissions, handling permission modals, responding to Claude asking for approval, or unblocking a paused session.
+allowed-tools:
+  - mcp__chrome_devtools__wait_for
+  - mcp__chrome_devtools__click
+  - mcp__chrome_devtools__evaluate_script
+  - mcp__chrome_devtools__take_snapshot
+  - mcp__chrome_devtools__take_screenshot
+---
+
+# ui-permission-respond
+
+Detect and respond to a permission prompt in the active session.
+
+## Inputs
+
+- `action` (required) — `allow` or `deny`
+- `timeout` (optional, default: 30000) — Milliseconds to wait for permission prompt to appear
+
+## Prerequisites
+
+A session must be selected and in a state where it's awaiting permission. The session chip will show an amber dot (`.ac-status-sq.paused`) and/or a `?` badge (`.ac-alert.permission`).
+
+## Steps
+
+### 1. Wait for Permission State
+
+Poll for the session to enter paused/permission state. Do NOT use a fixed sleep.
+
+Check for amber status indicator:
+```
+wait_for(selector=".agent-chip.active .ac-status-sq.paused", timeout=<timeout>)
+```
+
+Alternative: check for the permission alert badge:
+```
+wait_for(selector=".agent-chip.active .ac-alert.permission", timeout=<timeout>)
+```
+
+If timeout: take a snapshot and report "No permission prompt detected within <timeout>ms. Session may already be idle or processing."
+
+### 2. Locate the Permission Section
+
+The permission prompt appears inside the activity timeline in the session view. Find the permission section:
+
+```
+wait_for(selector=".permission-section", timeout=5000)
+```
+
+If `.permission-section` is not visible, check if the timeline needs to be scrolled or the tool node needs to be expanded:
+```javascript
+// Check for permission-related content
+const perm = document.querySelector('.permission-section, .detail-banner-warning');
+perm?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+```
+
+### 3. Take a Snapshot for Verification
+
+Before responding, take a snapshot to confirm the permission prompt is present and note what tool is requesting permission.
+
+```
+take_snapshot()
+```
+
+Look for:
+- `.detail-banner.detail-banner-warning` with text "Permission Required"
+- The tool name in the permission description
+- Any suggested permission updates in `.suggestions-section`
+
+### 4. Respond to the Permission
+
+**To ALLOW:**
+
+If there are suggestions and you want to approve with suggestions applied:
+```
+click(selector=".btn-timeline.btn-approve")
+```
+Button text: "Approve & Apply (N/M)" where N/M indicates suggestion counts.
+
+If you want to approve without applying suggestions:
+```
+click(selector=".btn-timeline.btn-approve-outline")
+```
+Button text: "Approve Only"
+
+**To DENY:**
+```
+click(selector=".btn-timeline.btn-deny")
+```
+Button text: "Deny"
+
+### 5. Wait for Permission Modal to Dismiss
+
+After responding, wait for the permission section to be replaced and the session to resume:
+
+Poll for the session to leave paused state:
+```
+wait_for(selector=".agent-chip.active .ac-status-sq.active-processing, .agent-chip.active .ac-status-sq.active", timeout=10000)
+```
+
+The session should:
+- On **allow**: return to `.active-processing` (purple) as Claude continues
+- On **deny**: return to `.active` (green) as Claude handles the denial and stops the tool
+
+### 6. Verify Permission Dismissed
+
+Take a snapshot to confirm:
+- The permission `?` badge is gone from the session chip: no `.ac-alert.permission`
+- The session is back in active state
+- If allowed: the tool continues execution
+
+```javascript
+// Confirm no permission badge
+const badge = document.querySelector('.agent-chip.active .ac-alert.permission');
+!badge // should be null
+```
+
+## AskUserQuestion Handling
+
+For `AskUserQuestion` tool (different from standard permission):
+- Banner text: "Claude is asking for your input"
+- Class: `.detail-banner-info`
+- Response: Fill the answer input and click "Submit Answers" (`.btn-timeline.btn-primary`)
+- Skip: "Skip" button (`.btn-timeline.btn-secondary`)
+
+This skill handles standard permission prompts. For AskUserQuestion, use `ui-send-message` or handle manually.
+
+## Error Handling
+
+- **No permission prompt within timeout**: Session may already have moved on. Take a snapshot to check current state.
+- **Approve button not found**: The permission section may be collapsed inside a timeline node. Try clicking the timeline node to expand it.
+- **Session stuck in paused state after response**: Take a screenshot. Check browser console for errors.
+- **Multiple permission prompts**: This skill handles one at a time. After each allow/deny, check if another permission follows before proceeding.
+
+## Notes
+
+- The `.btn-approve` button (with suggestions) is preferred when suggestions are available, as it applies permission rules that prevent future prompts.
+- If `action=allow` and `.btn-approve` is not present (no suggestions), use `.btn-approve-outline` instead.
+- After a session reset, any in-flight permission requests are cancelled (shown as "Permission Request Cancelled").

--- a/.claude/skills/ui-project-create/SKILL.md
+++ b/.claude/skills/ui-project-create/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: ui-project-create
+description: Create a new project in the Claude Code WebUI via the UI. Use when creating a project, adding a project, opening the new project modal, or testing project creation flow.
+allowed-tools:
+  - mcp__chrome_devtools__wait_for
+  - mcp__chrome_devtools__click
+  - mcp__chrome_devtools__fill
+  - mcp__chrome_devtools__type_text
+  - mcp__chrome_devtools__take_snapshot
+  - mcp__chrome_devtools__evaluate_script
+  - mcp__chrome_devtools__take_screenshot
+---
+
+# ui-project-create
+
+Create a new project via the WebUI project creation modal.
+
+## Inputs
+
+- `name` (required) — Project display name
+- `directory` (required) — Working directory path for the project
+
+## Prerequisites
+
+The app must be loaded and connected. Run `ui-navigate` first if needed.
+
+## Steps
+
+### 1. Open the Create Project Modal
+
+Click the "+" add button in the project pill bar:
+```
+wait_for(selector=".project-pill-bar", timeout=5000)
+click(selector=".pill-add-btn")
+```
+
+Wait for the modal to appear:
+```
+wait_for(selector="#createProjectModal.show, #createProjectModal[aria-modal='true']", timeout=5000)
+```
+
+Alternative selector if Bootstrap modal uses display style:
+```javascript
+// Check modal is visible
+const modal = document.querySelector('#createProjectModal');
+modal && (modal.classList.contains('show') || window.getComputedStyle(modal).display !== 'none')
+```
+
+If modal doesn't open within 5s: take a screenshot and report "Create project modal did not open. Check `.pill-add-btn` is clickable."
+
+### 2. Fill the Project Name
+
+Wait for the name field and fill it:
+```
+wait_for(selector="#projectName", timeout=3000)
+fill(selector="#projectName", value=<name>)
+```
+
+### 3. Fill the Working Directory
+
+Fill the directory field:
+```
+fill(selector="#workingDirectory", value=<directory>)
+```
+
+### 4. Submit the Form
+
+Verify the submit button is enabled (not disabled):
+```
+wait_for(selector="#createProjectModal .btn.btn-primary:not([disabled])", timeout=3000)
+```
+
+Click the "Create Project" button:
+```
+click(selector="#createProjectModal .btn.btn-primary")
+```
+
+The button text changes to "Creating..." while loading. Do NOT click again.
+
+### 5. Wait for Modal to Close
+
+Poll for the modal to dismiss, indicating success:
+```
+wait_for(selector="#createProjectModal:not(.show)", timeout=10000)
+```
+
+Alternative check — wait for modal to have aria-hidden:
+```javascript
+const modal = document.querySelector('#createProjectModal');
+!modal || !modal.classList.contains('show')
+```
+
+If the modal does not close within 10s:
+- Check for an error alert: `.alert.alert-danger[role="alert"]`
+- Take a snapshot and report the error text
+
+### 6. Verify Project Appears in Sidebar
+
+Wait for the new project pill to appear in the project pill bar:
+```javascript
+// Poll for pill with matching text
+const pills = document.querySelectorAll('.project-pill-bar .project-pill, .project-pill-bar [role="button"]');
+Array.from(pills).some(p => p.textContent.trim().includes('<name>'))
+```
+
+Use `wait_for` with the evaluate approach or take a snapshot and verify manually.
+
+If the project pill does not appear within 5s: take a snapshot and report "Project created but not visible in pill bar. May need page refresh."
+
+## Error Handling
+
+- **Submit button stays disabled**: The form may have validation errors. Check that `#projectName` and `#workingDirectory` are both filled.
+- **Error alert shown**: Read `.alert.alert-danger` text and report it (e.g., "Directory does not exist", "Name already taken").
+- **Modal closes but project missing**: Take a full snapshot of the pill bar. The project may have been created with a truncated name.
+
+## Notes
+
+- The modal also has a "Create session" checkbox (`#createSession`). This skill leaves it at its default value. If you want to create an initial session simultaneously, click the checkbox before submitting.
+- The directory field accepts any string — the server validates existence. For mock-sdk testing, use a valid directory that exists on the server.

--- a/.claude/skills/ui-project-delete/SKILL.md
+++ b/.claude/skills/ui-project-delete/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: ui-project-delete
+description: Delete a project via the Claude Code WebUI. Use when deleting a project, removing a project, testing project deletion, or cleaning up test projects.
+allowed-tools:
+  - mcp__chrome_devtools__wait_for
+  - mcp__chrome_devtools__click
+  - mcp__chrome_devtools__evaluate_script
+  - mcp__chrome_devtools__take_snapshot
+  - mcp__chrome_devtools__take_screenshot
+---
+
+# ui-project-delete
+
+Delete a project via the WebUI project edit modal.
+
+## Inputs
+
+- `name` (required) — Name of the project to delete
+
+## Prerequisites
+
+The app must be loaded and connected. Run `ui-navigate` first if needed.
+
+## Steps
+
+### 1. Select the Target Project
+
+Find and click the project pill for the target project:
+```javascript
+// Find project pill by name
+const pills = document.querySelectorAll('.project-pill-bar .project-pill, .project-pill-bar [role="button"]');
+const target = Array.from(pills).find(p => p.textContent.trim().includes('<name>'));
+if (target) target.click();
+```
+
+Use `evaluate_script` to run this. If `target` is null: take a snapshot and report "Project '<name>' not found in project pill bar."
+
+### 2. Open the Project Edit Modal
+
+After selecting the project, find the edit button. In the pill bar, look for an edit/settings icon button associated with the selected project pill:
+
+```javascript
+// Look for edit button in the active/selected project area
+const editBtn = document.querySelector('.project-pill.active .pill-edit-btn, .project-pill-bar .btn-edit, [aria-label*="Edit project"], [aria-label*="edit"]');
+editBtn?.click();
+```
+
+If no edit button is visible via direct click, check if hovering over the selected pill reveals it:
+```
+// Try clicking the gear/edit icon in pill bar
+click(selector=".project-pill.active .pill-options-btn")
+```
+
+Wait for the edit modal to open:
+```
+wait_for(selector="#editProjectModal.show, #editProjectModal[aria-modal='true']", timeout=5000)
+```
+
+If modal does not open within 5s: take a screenshot to identify the correct edit button selector, then report the issue.
+
+### 3. Initiate Delete
+
+Scroll to the danger zone section and click the delete button. Look for a button with class `.btn-outline-danger` or text matching "Delete":
+
+```
+wait_for(selector="#editProjectModal .danger-zone .btn-outline-danger", timeout=3000)
+click(selector="#editProjectModal .danger-zone .btn-outline-danger")
+```
+
+This reveals a confirmation prompt (`.alert.alert-warning`).
+
+### 4. Confirm Deletion
+
+Wait for the confirmation alert to appear, then click the "Yes, Delete Permanently" button:
+
+```
+wait_for(selector="#editProjectModal .btn.btn-danger", timeout=3000)
+click(selector="#editProjectModal .btn.btn-danger")
+```
+
+The button shows text "Yes, Delete Permanently" (or "Deleting..." while in progress). Do NOT click again while it shows "Deleting...".
+
+### 5. Wait for Modal to Close
+
+Poll for the modal to dismiss:
+```
+wait_for(selector="#editProjectModal:not(.show)", timeout=10000)
+```
+
+If modal stays open after 10s: take a snapshot, check for error messages, and report.
+
+### 6. Verify Project Removed from Pill Bar
+
+Check that the project pill is gone:
+```javascript
+const pills = document.querySelectorAll('.project-pill-bar .project-pill, .project-pill-bar [role="button"]');
+!Array.from(pills).some(p => p.textContent.trim().includes('<name>'))
+```
+
+If still present after 5s: take a snapshot and report "Project pill still visible after deletion. May be a display refresh issue."
+
+## Error Handling
+
+- **Project not found**: No pill matches the name. Check spelling. Take a snapshot to list available projects.
+- **Edit modal doesn't open**: The edit button selector may vary. Take a screenshot to identify the correct trigger element.
+- **Delete button not visible**: The danger zone section may need scrolling. Use `evaluate_script` to scroll: `document.querySelector('.danger-zone')?.scrollIntoView()`.
+- **Confirmation shows error**: Read `.alert.alert-danger` text and report. The project may have active sessions preventing deletion.
+
+## Notes
+
+- This skill handles the two-step delete confirmation (click delete → click confirm).
+- If the project has active sessions, deletion may fail. Terminate sessions first using `ui-session-reset` or by stopping sessions manually.
+- The Cancel button (`.btn-secondary` text "Cancel") dismisses the confirmation without deleting.

--- a/.claude/skills/ui-send-message/SKILL.md
+++ b/.claude/skills/ui-send-message/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: ui-send-message
+description: Send a message in the active session of the Claude Code WebUI. Use when typing and sending a message to Claude, submitting a prompt, interacting with an active session, or waiting for the assistant to finish responding.
+allowed-tools:
+  - mcp__chrome_devtools__wait_for
+  - mcp__chrome_devtools__click
+  - mcp__chrome_devtools__type_text
+  - mcp__chrome_devtools__press_key
+  - mcp__chrome_devtools__take_snapshot
+  - mcp__chrome_devtools__evaluate_script
+  - mcp__chrome_devtools__take_screenshot
+---
+
+# ui-send-message
+
+Send a message in the active session and optionally wait for the assistant to finish responding.
+
+## Inputs
+
+- `message` (required) — Text to send
+- `wait_for_idle` (optional, default: `true`) — Wait for the assistant to finish before returning
+
+## Prerequisites
+
+A session must be active and selected. Run `ui-navigate` with the appropriate `project` and `session` arguments first if needed.
+
+## Steps
+
+### 1. Verify Session is Ready
+
+Check that the active session chip exists and is NOT in processing state:
+```
+wait_for(selector=".agent-chip.active", timeout=5000)
+```
+
+Check the input area is enabled. Wait for the textarea to not be disabled:
+```
+wait_for(selector="#message-input:not([disabled])", timeout=10000)
+```
+
+If the input is still disabled after 10s: take a snapshot and report "Input area is disabled. Session may be processing, disconnected, or starting."
+
+### 2. Click the Input Area
+
+```
+click(selector="#message-input")
+```
+
+### 3. Type the Message
+
+Use `type_text` to enter the message content. This appends to whatever is in the field:
+```
+type_text(text=<message>)
+```
+
+If the input needs to be cleared first, use `evaluate_script`:
+```javascript
+const input = document.querySelector('#message-input');
+input.value = '';
+input.dispatchEvent(new Event('input', { bubbles: true }));
+```
+
+### 4. Send the Message
+
+Press Enter to send (preferred method — matches normal user behavior):
+```
+press_key(key="Enter")
+```
+
+Alternative: click the Send button:
+```
+click(selector=".input-container .btn.btn-primary")
+```
+
+Note: The Send button shows text "Send" when idle, and is replaced by "Stop" when processing. Only click the Send button if it shows "Send" text.
+
+### 5. Wait for Processing to Start
+
+After sending, wait briefly for the session to enter processing state (purple dot):
+```
+wait_for(selector=".agent-chip.active .ac-status-sq.active-processing", timeout=5000)
+```
+
+If the processing indicator never appears within 5s, the message may have been sent to a queued session or the session started very fast. Continue to the idle check regardless.
+
+### 6. Wait for Idle (if wait_for_idle is true)
+
+Poll for the session to return to idle state (green dot, not processing). Do NOT use a fixed sleep.
+
+```
+wait_for(selector=".agent-chip.active .ac-status-sq.active:not(.active-processing)", timeout=120000)
+```
+
+Wait up to 120 seconds for the assistant to finish. If timeout: take a screenshot, take a snapshot, and report "Session did not return to idle within 120s. May still be processing. Check for permission prompts (`.ac-alert.permission`)."
+
+**Permission detection during wait**: If the session enters `.paused` state while waiting:
+```
+// Check for paused state (amber dot)
+.agent-chip.active .ac-status-sq.paused
+// or permission alert badge
+.agent-chip.active .ac-alert.permission
+```
+
+If paused, report "Session is paused awaiting permission. Use `ui-permission-respond` to handle the permission request before continuing."
+
+### 7. Confirm Response Received
+
+Take a snapshot to verify a response appeared in the message area:
+```
+wait_for(selector=".messages-area", timeout=5000)
+```
+
+Use `evaluate_script` to check the last message:
+```javascript
+const msgs = document.querySelectorAll('.messages-area .message-item');
+const last = msgs[msgs.length - 1];
+last?.textContent?.trim().substring(0, 100)
+```
+
+## Idle State Detection
+
+The session is idle (ready for next message) when:
+- `.agent-chip.active .ac-status-sq.active` exists (green dot)
+- AND `.agent-chip.active .ac-status-sq.active-processing` does NOT exist
+
+Use `evaluate_script` for explicit check:
+```javascript
+const chip = document.querySelector('.agent-chip.active');
+const sq = chip?.querySelector('.ac-status-sq');
+sq?.classList.contains('active') && !sq?.classList.contains('active-processing')
+```
+
+## Error Handling
+
+- **Input disabled**: Session may be in `starting` or `terminating` state. Wait or run `ui-navigate` to select a valid active session.
+- **Message not sent**: Verify `#message-input` received the text. Check for validation errors.
+- **Session stuck in processing**: After 120s take a screenshot. Check for permission modal in the activity timeline.
+- **Permission required**: Pause and invoke `ui-permission-respond` with appropriate `action`.
+
+## Queue vs Send
+
+If the session is processing when you call this skill and you want to queue the message rather than wait:
+- Click the "Queue" button (`.btn.btn-info` with text "Queue") instead of Send
+- Queued messages are delivered automatically when the session returns to idle

--- a/.claude/skills/ui-session-create/SKILL.md
+++ b/.claude/skills/ui-session-create/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: ui-session-create
+description: Create a new session within the currently selected project in the Claude Code WebUI. Use when adding a new session, creating an agent, testing session creation, or setting up a new conversation.
+allowed-tools:
+  - mcp__chrome_devtools__wait_for
+  - mcp__chrome_devtools__click
+  - mcp__chrome_devtools__fill
+  - mcp__chrome_devtools__type_text
+  - mcp__chrome_devtools__evaluate_script
+  - mcp__chrome_devtools__take_snapshot
+  - mcp__chrome_devtools__take_screenshot
+---
+
+# ui-session-create
+
+Create a new session within the currently selected project.
+
+## Inputs
+
+- `name` (optional) — Session name. If omitted, the server assigns a default name.
+
+## Prerequisites
+
+A project must be selected (visible in the project pill bar with the agent strip showing). Run `ui-navigate` with the `project` argument first.
+
+## Steps
+
+### 1. Find the "Add Agent" Button
+
+Wait for the agent strip to be visible:
+```
+wait_for(selector=".agent-strip", timeout=5000)
+```
+
+Click the add-session button (dashed "+" button at the right end of the agent strip):
+```
+wait_for(selector=".strip-add-btn", timeout=3000)
+click(selector=".strip-add-btn")
+```
+
+### 2. Handle Session Name Input (if required)
+
+The UI may show a prompt for the session name, or it may create the session immediately and route to it. Check which behavior applies:
+
+a. **If a name input dialog appears** (modal or inline prompt):
+```javascript
+// Check for any visible input that appeared after clicking
+const newInput = document.querySelector('[placeholder*="session"], [placeholder*="name"], [placeholder*="agent"]');
+if (newInput) newInput.value = '<name>';
+```
+
+b. **If session is created immediately** (no name prompt): the new chip will appear in the agent strip. If `name` was provided, skip to the rename step or accept the default name.
+
+### 3. Wait for the New Session Chip to Appear
+
+Poll for a new session chip to appear in the agent strip:
+```
+wait_for(selector=".agent-chip", timeout=10000)
+```
+
+Use `evaluate_script` to count chips before and after to detect the new one:
+```javascript
+document.querySelectorAll('.agent-chip').length
+```
+
+### 4. Verify Session is Created and Starting
+
+The new session should appear with `.ac-status-sq.created` or `.ac-status-sq.starting` state initially.
+
+Wait for the new chip to become active (selected):
+```
+wait_for(selector=".agent-chip.active", timeout=5000)
+```
+
+Read the session name from the active chip:
+```javascript
+document.querySelector('.agent-chip.active .ac-name')?.textContent?.trim()
+```
+
+### 5. Wait for Session to be Ready (Optional but Recommended)
+
+If the session transitions through `starting` state, wait for it to reach `active`:
+```
+wait_for(selector=".agent-chip.active .ac-status-sq.active, .agent-chip.active .ac-status-sq.created", timeout=15000)
+```
+
+For a freshly created session that has not been started, the state will be `created` (gray dot).
+
+## Idempotency
+
+If a session with the given name already exists, this skill creates a second session with the same name (the UI allows duplicate names). To avoid this, first check with `ui-navigate` or `ui-verify-snapshot` whether the session already exists.
+
+## Error Handling
+
+- **Add button not found**: Agent strip may not be visible. Ensure a project is selected. Take a screenshot.
+- **No new chip appears after 10s**: Server may have returned an error. Check browser console messages with `list_console_messages`.
+- **Session stuck in `starting` state**: The server may be launching the SDK. Wait up to 30s before reporting.
+- **Session enters `error` state**: Red dot (`.ac-status-sq.error`). Take a snapshot and check console for errors.
+
+## Notes
+
+- In mock-sdk mode (`--mock-sdk`), sessions are created with a fixture-based name. The session name corresponds to the fixture directory used.
+- The new session starts in `created` state and remains idle until a message is sent or it is manually started.

--- a/.claude/skills/ui-session-reset/SKILL.md
+++ b/.claude/skills/ui-session-reset/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: ui-session-reset
+description: Reset a session via the manage modal in the Claude Code WebUI. Use when resetting a session, clearing session history, restarting a Claude Code conversation, or waiting for session reconnect after reset.
+allowed-tools:
+  - mcp__chrome_devtools__wait_for
+  - mcp__chrome_devtools__click
+  - mcp__chrome_devtools__evaluate_script
+  - mcp__chrome_devtools__take_snapshot
+  - mcp__chrome_devtools__take_screenshot
+---
+
+# ui-session-reset
+
+Reset the currently active session via the manage modal.
+
+## Prerequisites
+
+A session must be selected and active. Run `ui-navigate` with `project` and `session` arguments first if needed.
+
+## Steps
+
+### 1. Open the Session Manage Modal
+
+Find and click the manage/settings button for the active session. This is typically accessible via a button in the session info bar or by right-clicking the session chip.
+
+Check for a manage button in the session view:
+```javascript
+// Look for manage or settings button in session info bar
+const manageBtn = document.querySelector(
+  '.session-info-bar .btn[aria-label*="manage"], ' +
+  '.session-info-bar .btn[aria-label*="settings"], ' +
+  '[aria-label*="Manage session"], ' +
+  '.session-manage-btn'
+);
+manageBtn?.click();
+```
+
+Alternatively, look for a clickable element that opens `#manageSessionModal`:
+```javascript
+document.querySelector('[data-bs-target="#manageSessionModal"]')?.click()
+```
+
+Wait for the modal to appear:
+```
+wait_for(selector="#manageSessionModal.show, #manageSessionModal[aria-modal='true']", timeout=5000)
+```
+
+If modal does not open: take a screenshot to identify the manage trigger element.
+
+### 2. Click "Reset Session"
+
+Inside the manage modal, click the Reset Session button:
+```
+wait_for(selector="#manageSessionModal .btn-outline-warning", timeout=3000)
+click(selector="#manageSessionModal .btn-outline-warning")
+```
+
+The button has text "Reset Session". This reveals a confirmation view.
+
+### 3. Confirm the Reset
+
+Wait for the confirmation prompt to appear, then click the confirm button:
+```
+wait_for(selector="#manageSessionModal .btn.btn-warning", timeout=3000)
+click(selector="#manageSessionModal .btn.btn-warning")
+```
+
+The confirm button has text "Confirm Reset". Do NOT click Cancel (`.btn-secondary` with text "Cancel").
+
+### 4. Wait for Modal to Close
+
+```
+wait_for(selector="#manageSessionModal:not(.show)", timeout=10000)
+```
+
+If modal does not close: take a snapshot and report any error messages.
+
+### 5. Wait for Session to Reconnect
+
+After reset, the session goes through `starting` → `active` states. Poll for the session to be active and idle (not processing). Do NOT use a fixed sleep.
+
+Wait for the active chip to show green (idle) state:
+```
+wait_for(selector=".agent-chip.active .ac-status-sq.active", timeout=30000)
+```
+
+While waiting, also check that the session is not in error state:
+```javascript
+const sq = document.querySelector('.agent-chip.active .ac-status-sq');
+sq?.classList.contains('error') // if true, report error
+```
+
+If a "Claude Code Launched" system message appears in the message list, that is the canonical signal that the session has reconnected:
+```javascript
+const msgs = document.querySelectorAll('.messages-area .message-item');
+Array.from(msgs).some(m => m.textContent.includes('Claude Code Launched') || m.textContent.includes('launched'))
+```
+
+### 6. Verify Reset Complete
+
+Take a snapshot and confirm:
+- Session chip shows green/active state
+- No error indicators
+- Input area is enabled and not disabled
+
+```
+wait_for(selector="#message-input:not([disabled])", timeout=10000)
+```
+
+## Error Handling
+
+- **Manage modal doesn't open**: The trigger button may have a different selector. Take a screenshot and look for a gear icon or "manage" text near the session.
+- **Reset button not found**: The modal may show a different view. Check for spinner or loading state.
+- **Session enters error state after reset**: Red dot (`.ac-status-sq.error`). Report the error and suggest checking server logs.
+- **Session never becomes active after 30s**: Session may be stuck in `starting`. Check browser console messages.
+
+## Notes
+
+- Reset clears the session's SDK conversation history and restarts the Claude Code process.
+- The session messages in the UI are preserved (not deleted) — only the SDK conversation context is reset.
+- After reset, the next message sent will start a fresh conversation.
+- In mock-sdk mode, reset causes the mock SDK to reinitialize with the same fixture.

--- a/.claude/skills/ui-verify-snapshot/SKILL.md
+++ b/.claude/skills/ui-verify-snapshot/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: ui-verify-snapshot
+description: Take a snapshot of the Claude Code WebUI and verify expected content is present. Use when asserting UI state, checking that text or elements are visible, verifying a test condition, taking a screenshot for review, or reporting pass/fail on UI expectations.
+allowed-tools:
+  - mcp__chrome_devtools__take_snapshot
+  - mcp__chrome_devtools__take_screenshot
+  - mcp__chrome_devtools__evaluate_script
+  - mcp__chrome_devtools__wait_for
+---
+
+# ui-verify-snapshot
+
+Take an accessibility snapshot and verify expected content is present. Report pass/fail with details.
+
+## Inputs
+
+- `expected` (required) — Text string or CSS selector to verify is present
+- `screenshot` (optional, default: `true`) — Whether to also take a screenshot
+
+## Steps
+
+### 1. Take Screenshot (if enabled)
+
+If `screenshot=true`:
+```
+take_screenshot()
+```
+
+This captures the visual state for review.
+
+### 2. Take Accessibility Snapshot
+
+```
+take_snapshot()
+```
+
+The snapshot returns the full accessibility tree and visible text content of the page.
+
+### 3. Evaluate Expected Content
+
+Determine the type of `expected`:
+
+**If `expected` looks like a CSS selector** (starts with `.`, `#`, `[`, or is a tag name):
+```javascript
+// Check for element presence
+const el = document.querySelector('<expected>');
+el !== null  // true = found, false = not found
+```
+
+Use `evaluate_script` to run this check. Report:
+- PASS: "Element '<expected>' found — `<tagName>`, text: `<element.textContent.trim().substring(0, 100)>`"
+- FAIL: "Element '<expected>' NOT found. Page title: `<document.title>`. URL: `<location.href>`"
+
+**If `expected` is plain text** (not a selector):
+Check for the text in the snapshot or via DOM:
+```javascript
+// Check body text content
+document.body.textContent.includes('<expected>')
+```
+
+Report:
+- PASS: "Text '<expected>' found on page."
+- FAIL: "Text '<expected>' NOT found on page."
+
+### 4. Additional Context on Failure
+
+If verification fails, gather additional context:
+
+```javascript
+// Current URL
+location.href
+
+// Page title
+document.title
+
+// Connection state
+document.querySelector('.header-indicator')?.className
+
+// Active session info
+{
+  chip: document.querySelector('.agent-chip.active')?.textContent?.trim(),
+  state: document.querySelector('.agent-chip.active .ac-status-sq')?.className,
+  permission: !!document.querySelector('.agent-chip.active .ac-alert.permission')
+}
+```
+
+Report all of this in the failure output.
+
+### 5. Report Result
+
+Output a clear pass/fail result:
+
+**PASS format:**
+```
+✓ PASS: [expected content] is present.
+  - Element: <selector or text>
+  - Page: <URL>
+  - Session state: <state class>
+```
+
+**FAIL format:**
+```
+✗ FAIL: [expected content] is NOT present.
+  - Expected: <expected>
+  - Page: <URL>
+  - Page title: <title>
+  - Connection: <header-indicator class>
+  - Active session: <chip text / state>
+  - Suggestion: <what to check>
+```
+
+## Common Verification Patterns
+
+### Check app is loaded and connected
+```
+expected: ".header-indicator.connected"
+```
+
+### Check project is visible
+```
+expected: "My Project"  (text in pill bar)
+```
+
+### Check session is idle (ready for input)
+```
+expected: ".agent-chip.active .ac-status-sq.active"
+```
+
+### Check session is processing
+```
+expected: ".agent-chip.active .ac-status-sq.active-processing"
+```
+
+### Check session has permission prompt
+```
+expected: ".agent-chip.active .ac-alert.permission"
+```
+
+### Check message text appeared
+```
+expected: "Hello, world"  (text in messages area)
+```
+
+### Check input is enabled
+```
+expected: "#message-input:not([disabled])"
+```
+
+### Check modal is open
+```
+expected: "#createProjectModal.show"
+```
+
+## Error Handling
+
+- If `take_snapshot` fails: report "Snapshot failed — page may be in a transient state" and try again once.
+- If `evaluate_script` throws: report the JavaScript error and fall back to text search in the snapshot.
+- If `expected` is ambiguous (could be text or selector): try as selector first, then as text.
+
+## Composability
+
+This skill is designed to be the final step in test flows. Typical composition:
+1. `ui-navigate` → navigate and connect
+2. `ui-project-create` → create project
+3. `ui-verify-snapshot` with `expected: "My New Project"` → confirm success
+
+Always use this skill to assert final state rather than relying on previous skills' output alone.


### PR DESCRIPTION
## Summary

Closes #566. Adds 8 composable Chrome DevTools MCP skills for UI testing of the Claude Code WebUI.

- **ui-navigate** — Navigate to app, verify HTTP long-poll connection (`.header-indicator.connected`), optionally select project and session by name
- **ui-send-message** — Type and send a message in the active session; polls for `.ac-status-sq.active-processing` then `.ac-status-sq.active` to detect idle (no fixed sleeps)
- **ui-project-create** — Opens `#createProjectModal`, fills name + directory, submits, verifies project pill appears in pill bar
- **ui-project-delete** — Selects project, opens `#editProjectModal`, two-step delete (danger zone → "Yes, Delete Permanently"), verifies pill removed
- **ui-session-create** — Clicks `.strip-add-btn`, waits for new `.agent-chip` to appear in agent strip
- **ui-session-reset** — Opens `#manageSessionModal`, clicks Reset Session → Confirm Reset, polls until session returns to active state
- **ui-permission-respond** — Detects `.ac-status-sq.paused` / `.ac-alert.permission`, clicks allow (`.btn-timeline.btn-approve`) or deny (`.btn-timeline.btn-deny`)
- **ui-verify-snapshot** — Takes accessibility snapshot + screenshot, asserts text or CSS selector present, reports pass/fail with full context on failure

Also adds `.claude/skills/README.md` with selector reference, composition patterns, and timeout table.

## Design decisions

- **No WebSocket references anywhere** — connection checked via `.header-indicator.connected` (long-poll indicator)
- **Never fixed sleeps** — every wait step uses `mcp__chrome_devtools__wait_for` with a timeout
- **Mock-SDK compatible** — session names map to fixture dirs; no live SDK dependency in skill logic
- **Composable** — each skill leaves the UI in a clean state for the next skill

## Test plan

- [ ] Run `ui-navigate` against a live server on port 8000 — verifies connected indicator
- [ ] Run `ui-project-create` then `ui-verify-snapshot expected="<project name>"` — confirms project appears
- [ ] Run `ui-send-message` and wait for idle — verifies green dot returns
- [ ] Run `ui-permission-respond action=deny` after triggering a permission — verifies session resumes
- [ ] Run full composition: navigate → create project → create session → send message → verify response → delete project

🤖 Generated with [Claude Code](https://claude.com/claude-code)