### PR TITLE
fix: enforce sandbox.failIfUnavailable=True to prevent silent fallback

### DIFF
--- a/src/claude_sdk.py
+++ b/src/claude_sdk.py
@@ -887,12 +887,14 @@ class ClaudeSDK:
             options_kwargs["cli_path"] = self.cli_path
             sdk_logger.info(f"Using custom CLI path for session {self.session_id}: {self.cli_path}")
 
-        # Add sandbox configuration (issue #319)
+        # Add sandbox configuration (issue #319, #958)
         if self.sandbox_enabled:
-            sandbox_settings = {"enabled": True}
+            sandbox_settings = {"enabled": True, "failIfUnavailable": True}
             # Merge custom sandbox config if provided
             if self.sandbox_config:
                 sandbox_settings.update(self.sandbox_config)
+            # Issue #958: Enforce failIfUnavailable after merge to prevent silent fallback
+            sandbox_settings["failIfUnavailable"] = True
             options_kwargs["sandbox"] = sandbox_settings
             sdk_logger.info(f"Sandbox enabled for session {self.session_id}: {sandbox_settings}")
 

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -3834,6 +3834,9 @@ class SessionCoordinator:
                 "Docker daemon is not running": None,
                 "Docker socket permission denied": None,
                 "Nested Claude Code session detected": None,
+                # Issue #958: Sandbox unavailability — passthrough (SDK message is descriptive)
+                "Sandbox is not available": None,
+                "sandbox": None,
             }
 
             # Check for known patterns and provide clearer descriptions


### PR DESCRIPTION
## Summary
- Sets `failIfUnavailable=True` in sandbox settings after user config merge in `claude_sdk.py`, preventing any override
- Adds sandbox error patterns to `_extract_claude_cli_error` in `session_coordinator.py` for clear user-facing messages
- Prevents silent fallback to unsandboxed execution when sandbox runtime is unavailable

## Test plan
- [ ] Enable sandbox on a session where sandbox runtime is unavailable
- [ ] Start the session — verify it transitions to `ERROR` state (not `ACTIVE`)
- [ ] Verify user sees a clear error message about sandbox unavailability
- [ ] Verify no tool execution occurs in unsandboxed mode
- [ ] Verify sessions with sandbox disabled are unaffected

Resolves #958

🤖 Generated with [Claude Code](https://claude.com/claude-code)