### PR TITLE
fix: allow OAuth token refresh by removing :ro from credentials mount

### DIFF
--- a/src/docker/claude-docker
+++ b/src/docker/claude-docker
@@ -144,7 +144,7 @@ docker run \
     --name "$CONTAINER_NAME" \
     -v "$WORKSPACE:$WORKSPACE" \
     -w "$WORKSPACE" \
-    -v "$HOME/.claude/.credentials.json:$DOCKER_HOME/.claude/.credentials.json:ro" \
+    -v "$HOME/.claude/.credentials.json:$DOCKER_HOME/.claude/.credentials.json" \
     -v "$HOME/.claude/settings.json:$DOCKER_HOME/.claude/settings.json:ro" \
     -e "CLAUDE_CODE_DISABLE_AUTO_UPDATE=1" \
     $ENV_FLAGS \


### PR DESCRIPTION
## Summary
Resolves #970

Remove the read-only flag from the `.credentials.json` volume mount in the `claude-docker` wrapper script. With `:ro`, the Claude CLI inside the container cannot write refreshed OAuth tokens back to disk, causing authentication failures in long-running sessions.

## Changes Made
- `src/docker/claude-docker` line 147: removed `:ro` from `.credentials.json` volume mount
- The `settings.json` mount on line 148 retains `:ro` (settings should not be writable from inside the container)

## Testing
- Run `claude-docker` with an OAuth-authenticated account
- Confirm `.credentials.json` is writable inside the container: `touch ~/.claude/.credentials.json` should succeed
- Confirm `settings.json` remains read-only inside the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)