### PR TITLE
fix: reload page after auth token submission

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -142,8 +142,7 @@ onMounted(async () => {
 })
 
 async function onAuthenticated() {
-  showAuthPrompt.value = false
-  initializeApp()
+  window.location.reload()
 }
 
 async function initializeApp() {


### PR DESCRIPTION
## Summary
Resolves #974

After a user enters a valid auth token, the app now performs a full page reload instead of calling `initializeApp()` in-place. This ensures all Vue components mount cleanly in an already-authenticated context.

## Changes Made
- `frontend/src/App.vue`: Replace `onAuthenticated()` body with `window.location.reload()`

## Testing
- Started backend with `--force-auth --token test`
- Navigated to app without token → AuthPrompt appeared
- Entered token and clicked Authenticate → page reloaded, app loaded cleanly with "Connected" status, no stale state
- Unit tests: 851 passed, 1 pre-existing failure unrelated to this change

## Screenshots

**AuthPrompt overlay (unauthenticated)**
![Auth Prompt](/api/sessions/2fcbdf5e-8527-4a99-83b3-b9ebd5ae78a2/resources/266041be-4569-4821-b322-424d284ef084)

**App loaded cleanly after reload**
![After Auth](/api/sessions/2fcbdf5e-8527-4a99-83b3-b9ebd5ae78a2/resources/8c661e24-f507-413a-9e2b-cd79e9a9dd34)

🤖 Generated with [Claude Code](https://claude.com/claude-code)