### PR TITLE
fix: resolve minion spawn comm race condition

### DIFF
--- a/src/claude_sdk.py
+++ b/src/claude_sdk.py
@@ -233,6 +233,7 @@ class ClaudeSDK:
 
         # Control
         self._shutdown_event = asyncio.Event()
+        self._ready_event = asyncio.Event()
 
         # Claude Code's actual session ID (captured from init message)
         self._claude_code_session_id: str | None = None
@@ -306,6 +307,7 @@ class ClaudeSDK:
 
             # Reset shutdown event to ensure clean start (fixes resumed session disconnect loops)
             self._shutdown_event.clear()
+            self._ready_event.clear()
 
             self.info.state = SessionState.STARTING
             self.info.start_time = time.time()
@@ -598,6 +600,7 @@ class ClaudeSDK:
 
                 # NOW the SDK is truly ready - change session state to RUNNING
                 self.info.state = SessionState.RUNNING
+                self._ready_event.set()  # Signal readiness to waiting comm_router callers
                 sdk_logger.info(f"Session {self.session_id} state changed to RUNNING")
 
                 # Also notify session manager that SDK is ready
@@ -769,6 +772,7 @@ class ClaudeSDK:
                 logger.exception("Health check failed during fatal error handling")
 
             self.info.state = SessionState.FAILED
+            self._ready_event.set()  # Unblock any waiters even on fatal failure
             # Include buffered stderr in error message (issue #517)
             error_msg = str(e)
             # Issue #781: Parse container exit codes for actionable error reporting
@@ -1416,6 +1420,14 @@ class ClaudeSDK:
     def is_running(self) -> bool:
         """Check if the session is currently running."""
         return self.info.state in [SessionState.RUNNING, SessionState.PROCESSING]
+
+    async def wait_until_ready(self, timeout: float = 60.0) -> bool:
+        """Wait until SDK is ready to accept messages. Returns False on timeout."""
+        try:
+            await asyncio.wait_for(self._ready_event.wait(), timeout=timeout)
+            return True
+        except TimeoutError:
+            return False
 
     def _perform_session_health_check(self, client: ClaudeSDKClient | None = None) -> dict[str, Any]:
         """

--- a/src/legion/comm_router.py
+++ b/src/legion/comm_router.py
@@ -10,7 +10,6 @@ Responsibilities:
 - Parse #minion-name tags for explicit references
 """
 
-import asyncio
 import json
 import re
 import uuid
@@ -224,7 +223,26 @@ class CommRouter:
 
             # Auto-start minion if not active
             from src.session_manager import SessionState
-            if target_minion.state not in [SessionState.ACTIVE, SessionState.STARTING]:
+            if target_minion.state == SessionState.STARTING:
+                # Session is starting but SDK may not be ready yet — wait for readiness
+                legion_logger.info(
+                    f"Target minion {comm.to_minion_id} is STARTING - waiting for SDK readiness"
+                )
+                ready = await self.system.session_coordinator.wait_for_session_ready(
+                    comm.to_minion_id, timeout=60.0
+                )
+                if not ready:
+                    legion_logger.error(
+                        f"Minion {comm.to_minion_id} did not become ready within timeout"
+                    )
+                    if comm.from_minion_id:
+                        await self._send_system_error_comm(
+                            to_minion_id=comm.from_minion_id,
+                            error_message="Failed to deliver message: Minion did not become ready within 60 seconds",
+                            original_comm_id=comm.comm_id
+                        )
+                    return False
+            elif target_minion.state not in [SessionState.ACTIVE]:
                 legion_logger.info(f"Target minion {comm.to_minion_id} is in {target_minion.state} state - auto-starting")
 
                 # Register WebSocket message callback before starting
@@ -260,29 +278,21 @@ class CommRouter:
                         )
                     return False
 
-                # Wait for session to become active (with timeout)
-                max_wait = 30  # 30 seconds timeout
-                wait_interval = 0.5
-                elapsed = 0
-
-                while elapsed < max_wait:
+                # Wait for session to become ready (event-based, no polling)
+                ready = await self.system.session_coordinator.wait_for_session_ready(
+                    comm.to_minion_id, timeout=30.0
+                )
+                if not ready:
                     session_info = await self.system.session_coordinator.session_manager.get_session_info(comm.to_minion_id)
-                    if session_info and session_info.state == SessionState.ACTIVE:
-                        legion_logger.info(f"Minion {comm.to_minion_id} is now active after {elapsed}s")
-                        break
-
-                    await asyncio.sleep(wait_interval)
-                    elapsed += wait_interval
-                else:
-                    legion_logger.warning(f"Minion {comm.to_minion_id} did not become active within {max_wait}s - sending error to sender")
-                    # Send timeout error comm back to sender
+                    legion_logger.warning(f"Minion {comm.to_minion_id} did not become ready within 30s - sending error to sender")
                     if comm.from_minion_id:
                         await self._send_system_error_comm(
                             to_minion_id=comm.from_minion_id,
-                            error_message=f"Failed to deliver message: Target minion did not start within {max_wait} seconds (state: {session_info.state if session_info else 'unknown'})",
+                            error_message=f"Failed to deliver message: Target minion did not start within 30 seconds (state: {session_info.state if session_info else 'unknown'})",
                             original_comm_id=comm.comm_id
                         )
                     return False
+                legion_logger.info(f"Minion {comm.to_minion_id} is now ready")
 
             # Get sender name for formatting
             # Use "Minion #user" to signal that replies should use send_comm MCP tool
@@ -424,11 +434,22 @@ class CommRouter:
                 # Fall through to send_message below
 
             # Send message to target minion via SessionCoordinator (PIVOT and NORMAL)
-            await self.system.session_coordinator.send_message(
+            success = await self.system.session_coordinator.send_message(
                 session_id=comm.to_minion_id,
                 message=formatted_message,
                 metadata=comm_metadata
             )
+            if not success:
+                legion_logger.error(
+                    f"Failed to deliver comm {comm.comm_id} to minion {comm.to_minion_id} - send_message returned False"
+                )
+                if comm.from_minion_id:
+                    await self._send_system_error_comm(
+                        to_minion_id=comm.from_minion_id,
+                        error_message="Failed to deliver message: SDK rejected the message",
+                        original_comm_id=comm.comm_id
+                    )
+                return False
 
             legion_logger.info(f"Delivered comm {comm.comm_id} from {from_name} to minion {comm.to_minion_id}")
             return True

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -1206,8 +1206,7 @@ class SessionCoordinator:
             # else:
             #     logger.info(f"NOT calling _send_client_launched_message for session {session_id} because sdk_was_created = False")
 
-            coord_logger.info(f"Session {session_id} started")
-            await self._notify_state_change(session_id, SessionState.ACTIVE)
+            coord_logger.info(f"Session {session_id} SDK task started - state will update to ACTIVE when SDK is ready")
             return True
 
         except Exception as e:
@@ -1695,6 +1694,15 @@ class SessionCoordinator:
         """
         descendants = await self._get_all_descendants(session_id)
         return len(descendants)
+
+    async def wait_for_session_ready(self, session_id: str, timeout: float = 60.0) -> bool:
+        """Wait until session's SDK is ready to accept messages."""
+        sdk = self._active_sdks.get(session_id)
+        if not sdk:
+            return False
+        if sdk.is_running():
+            return True
+        return await sdk.wait_until_ready(timeout=timeout)
 
     async def send_message(self, session_id: str, message: str, metadata: dict | None = None) -> bool:
         """Send a message through the integrated pipeline"""


### PR DESCRIPTION
## Summary
Resolves #978

Fix three-part timing race that caused initial comms sent to newly spawned minions to be silently dropped. The root cause was that `spawn_minion` returns before the SDK background task reaches `RUNNING` state, and `comm_router` was neither waiting for readiness nor checking whether `send_message()` actually succeeded.

## Changes Made

- **`src/claude_sdk.py`**: Add `_ready_event` (asyncio.Event) signaled when SDK reaches RUNNING; set on fatal failure paths so waiters never hang. Add `wait_until_ready(timeout)` public method.
- **`src/session_coordinator.py`**: Add `wait_for_session_ready()` delegating to SDK event. Remove premature `ACTIVE` state broadcast in `start_session()` — `mark_session_active()` in `_message_processing_loop` already fires the UI notification via session_manager callbacks.
- **`src/legion/comm_router.py`**: Add STARTING state readiness wait in `_send_to_minion()` before message delivery. Fix unchecked `send_message()` return value (was logging false success). Replace polling loop in auto-start path with event-based wait.

## Testing

- 851 unit tests pass (1 pre-existing failure unrelated to these changes)
- Backend health endpoint verified
- Failure paths tested: pre-existing `test_issue_824` failure confirmed unchanged before and after patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)