### PR TITLE
refactor: replace broad sandbox error patterns with precise match

### DIFF
--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -4053,9 +4053,9 @@ class SessionCoordinator:
                 "Docker daemon is not running": None,
                 "Docker socket permission denied": None,
                 "Nested Claude Code session detected": None,
-                # Issue #958: Sandbox unavailability — passthrough (SDK message is descriptive)
-                "Sandbox is not available": None,
-                "sandbox": None,
+                # Issue #958: Sandbox unavailable with failIfUnavailable=True — passthrough.
+                # Full error: "Error: sandbox required but unavailable: ... sandbox.failIfUnavailable is set"
+                "sandbox.failIfUnavailable is set": None,
             }
 
             # Check for known patterns and provide clearer descriptions


### PR DESCRIPTION
## Summary
- Replace two imprecise sandbox error patterns with one exact substring match
- Remove `"Sandbox is not available"` (wording mismatch, never matched actual SDK error)
- Remove `"sandbox"` (overly broad, risks silently suppressing unrelated errors)
- Add `"sandbox.failIfUnavailable is set"` matching the actual SDK error string

## Test plan
- [x] Ruff lint passes with zero violations
- [x] 184 session tests pass, no regressions
- [x] Pattern verified against known SDK error: `"Error: sandbox required but unavailable: ... sandbox.failIfUnavailable is set"`

Resolves #993

🤖 Generated with [Claude Code](https://claude.com/claude-code)