### PR TITLE
refactor: extract _apply_resource_filters() helper

### DIFF
--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -54,6 +54,54 @@ logger = logging.getLogger(__name__)
 _DOCKER_WRAPPER_PREFIX = '[claude-docker] '
 _DOCKER_ERROR_KEYWORDS = ('exited with code', 'was killed', 'crashed')
 
+# Resource format groups for filtering
+_TEXT_RESOURCE_FORMATS = {
+    "py", "js", "ts", "json", "md", "txt", "yaml", "yml",
+    "toml", "cfg", "ini", "log", "csv", "xml", "html", "css",
+    "sh", "bash", "rs", "go", "java", "c", "cpp", "h", "rb",
+    "php", "sql", "r", "swift", "kt",
+}
+
+
+def _apply_resource_filters(
+    resources: list[dict],
+    search: str | None,
+    format_filter: str | None,
+    sort: str,
+) -> list[dict]:
+    """Filter and sort a list of resource dicts. Returns a new list."""
+    result = list(resources)
+
+    if search:
+        q = search.lower()
+        result = [
+            r
+            for r in result
+            if q in (r.get("title") or "").lower() or q in (r.get("original_name") or "").lower()
+        ]
+
+    if format_filter:
+        if format_filter == "image":
+            result = [r for r in result if r.get("is_image")]
+        elif format_filter == "text":
+            result = [r for r in result if r.get("format") in _TEXT_RESOURCE_FORMATS]
+        else:
+            result = [r for r in result if r.get("format") == format_filter]
+
+    if sort == "newest":
+        result.sort(key=lambda x: x.get("timestamp", 0), reverse=True)
+    elif sort == "oldest":
+        result.sort(key=lambda x: x.get("timestamp", 0))
+    elif sort == "name-asc":
+        result.sort(key=lambda x: (x.get("title") or x.get("original_name") or "").lower())
+    elif sort == "name-desc":
+        result.sort(
+            key=lambda x: (x.get("title") or x.get("original_name") or "").lower(),
+            reverse=True,
+        )
+
+    return result
+
 
 class SessionCoordinator:
     """
@@ -822,44 +870,7 @@ class SessionCoordinator:
         if storage_manager:
             all_resources = await storage_manager.read_resources()
 
-        # Filter by search query (case-insensitive substring on title or original_name)
-        if search:
-            q = search.lower()
-            all_resources = [
-                r
-                for r in all_resources
-                if q in (r.get("title") or "").lower() or q in (r.get("original_name") or "").lower()
-            ]
-
-        # Filter by format/type
-        if format_filter:
-            if format_filter == "image":
-                all_resources = [r for r in all_resources if r.get("is_image")]
-            elif format_filter == "text":
-                text_formats = {
-                    "py", "js", "ts", "json", "md", "txt", "yaml", "yml",
-                    "toml", "cfg", "ini", "log", "csv", "xml", "html", "css",
-                    "sh", "bash", "rs", "go", "java", "c", "cpp", "h", "rb",
-                    "php", "sql", "r", "swift", "kt",
-                }
-                all_resources = [r for r in all_resources if r.get("format") in text_formats]
-            else:
-                all_resources = [r for r in all_resources if r.get("format") == format_filter]
-
-        # Sort
-        if sort == "newest":
-            all_resources.sort(key=lambda x: x.get("timestamp", 0), reverse=True)
-        elif sort == "oldest":
-            all_resources.sort(key=lambda x: x.get("timestamp", 0))
-        elif sort == "name-asc":
-            all_resources.sort(
-                key=lambda x: (x.get("title") or x.get("original_name") or "").lower()
-            )
-        elif sort == "name-desc":
-            all_resources.sort(
-                key=lambda x: (x.get("title") or x.get("original_name") or "").lower(),
-                reverse=True,
-            )
+        all_resources = _apply_resource_filters(all_resources, search, format_filter, sort)
 
         total = len(all_resources)
         sliced = all_resources[offset : offset + limit]
@@ -2643,44 +2654,7 @@ class SessionCoordinator:
             session_id, archive_id
         )
 
-        # Filter by search query
-        if search:
-            q = search.lower()
-            all_resources = [
-                r
-                for r in all_resources
-                if q in (r.get("title") or "").lower() or q in (r.get("original_name") or "").lower()
-            ]
-
-        # Filter by format/type
-        if format_filter:
-            if format_filter == "image":
-                all_resources = [r for r in all_resources if r.get("is_image")]
-            elif format_filter == "text":
-                text_formats = {
-                    "py", "js", "ts", "json", "md", "txt", "yaml", "yml",
-                    "toml", "cfg", "ini", "log", "csv", "xml", "html", "css",
-                    "sh", "bash", "rs", "go", "java", "c", "cpp", "h", "rb",
-                    "php", "sql", "r", "swift", "kt",
-                }
-                all_resources = [r for r in all_resources if r.get("format") in text_formats]
-            else:
-                all_resources = [r for r in all_resources if r.get("format") == format_filter]
-
-        # Sort
-        if sort == "newest":
-            all_resources.sort(key=lambda x: x.get("timestamp", 0), reverse=True)
-        elif sort == "oldest":
-            all_resources.sort(key=lambda x: x.get("timestamp", 0))
-        elif sort == "name-asc":
-            all_resources.sort(
-                key=lambda x: (x.get("title") or x.get("original_name") or "").lower()
-            )
-        elif sort == "name-desc":
-            all_resources.sort(
-                key=lambda x: (x.get("title") or x.get("original_name") or "").lower(),
-                reverse=True,
-            )
+        all_resources = _apply_resource_filters(all_resources, search, format_filter, sort)
 
         total = len(all_resources)
         sliced = all_resources[offset : offset + limit]

--- a/src/tests/test_apply_resource_filters.py
+++ b/src/tests/test_apply_resource_filters.py
@@ -1,0 +1,131 @@
+"""Unit tests for _apply_resource_filters() helper (issue #991)."""
+
+import pytest
+
+from ..session_coordinator import _apply_resource_filters
+
+
+# Fixture data
+@pytest.fixture
+def resources():
+    return [
+        {
+            "title": "Alpha Script",
+            "original_name": "alpha.py",
+            "format": "py",
+            "is_image": False,
+            "timestamp": 100,
+        },
+        {
+            "title": "Beta Image",
+            "original_name": "beta.png",
+            "format": "png",
+            "is_image": True,
+            "timestamp": 200,
+        },
+        {
+            "title": "Gamma Readme",
+            "original_name": "gamma.md",
+            "format": "md",
+            "is_image": False,
+            "timestamp": 50,
+        },
+        {
+            "title": None,
+            "original_name": "delta.json",
+            "format": "json",
+            "is_image": False,
+            "timestamp": 300,
+        },
+    ]
+
+
+# --- Search ---
+
+def test_search_by_title(resources):
+    result = _apply_resource_filters(resources, search="alpha", format_filter=None, sort="newest")
+    assert len(result) == 1
+    assert result[0]["original_name"] == "alpha.py"
+
+
+def test_search_by_original_name(resources):
+    result = _apply_resource_filters(resources, search="delta", format_filter=None, sort="newest")
+    assert len(result) == 1
+    assert result[0]["original_name"] == "delta.json"
+
+
+def test_search_case_insensitive(resources):
+    result = _apply_resource_filters(resources, search="GAMMA", format_filter=None, sort="newest")
+    assert len(result) == 1
+    assert result[0]["original_name"] == "gamma.md"
+
+
+def test_search_none_returns_all(resources):
+    result = _apply_resource_filters(resources, search=None, format_filter=None, sort="newest")
+    assert len(result) == 4
+
+
+def test_search_no_match(resources):
+    result = _apply_resource_filters(resources, search="zzz", format_filter=None, sort="newest")
+    assert result == []
+
+
+# --- Format filter ---
+
+def test_format_filter_image(resources):
+    result = _apply_resource_filters(resources, search=None, format_filter="image", sort="newest")
+    assert all(r["is_image"] for r in result)
+    assert len(result) == 1
+    assert result[0]["original_name"] == "beta.png"
+
+
+def test_format_filter_text(resources):
+    result = _apply_resource_filters(resources, search=None, format_filter="text", sort="newest")
+    formats = {r["format"] for r in result}
+    assert formats <= {"py", "md", "json"}
+    assert len(result) == 3
+
+
+def test_format_filter_exact(resources):
+    result = _apply_resource_filters(resources, search=None, format_filter="md", sort="newest")
+    assert len(result) == 1
+    assert result[0]["original_name"] == "gamma.md"
+
+
+def test_format_filter_exact_no_match(resources):
+    result = _apply_resource_filters(resources, search=None, format_filter="svg", sort="newest")
+    assert result == []
+
+
+# --- Sort modes ---
+
+def test_sort_newest(resources):
+    result = _apply_resource_filters(resources, search=None, format_filter=None, sort="newest")
+    timestamps = [r["timestamp"] for r in result]
+    assert timestamps == sorted(timestamps, reverse=True)
+
+
+def test_sort_oldest(resources):
+    result = _apply_resource_filters(resources, search=None, format_filter=None, sort="oldest")
+    timestamps = [r["timestamp"] for r in result]
+    assert timestamps == sorted(timestamps)
+
+
+def test_sort_name_asc(resources):
+    result = _apply_resource_filters(resources, search=None, format_filter=None, sort="name-asc")
+    names = [(r.get("title") or r.get("original_name") or "").lower() for r in result]
+    assert names == sorted(names)
+
+
+def test_sort_name_desc(resources):
+    result = _apply_resource_filters(resources, search=None, format_filter=None, sort="name-desc")
+    names = [(r.get("title") or r.get("original_name") or "").lower() for r in result]
+    assert names == sorted(names, reverse=True)
+
+
+# --- Immutability ---
+
+def test_does_not_mutate_input(resources):
+    original_order = [r["original_name"] for r in resources]
+    _apply_resource_filters(resources, search=None, format_filter=None, sort="name-asc")
+    assert [r["original_name"] for r in resources] == original_order


### PR DESCRIPTION
## Summary
Resolves #991

Consolidates the duplicated ~38-line filter/sort block that existed identically in `get_session_resources()` and `get_archive_resources()` into a single reusable helper.

## Changes Made
- Add `_TEXT_RESOURCE_FORMATS` module-level constant (set of text file extensions)
- Add `_apply_resource_filters(resources, search, format_filter, sort)` module-level helper covering search, image/text/exact format filtering, and all four sort modes
- Replace inline blocks in both methods with a single one-liner call
- Add 14 unit tests in `src/tests/test_apply_resource_filters.py`

## Testing
- 14 new unit tests covering all filter/sort branches pass
- Existing integration tests (`test_api_resources`, `test_api_archives`) pass — 37 total

🤖 Generated with [Claude Code](https://claude.com/claude-code)