### PR TITLE
refactor: consolidate SessionConfig/SessionConfigBase into single Pydantic model

### DIFF
--- a/src/session_config.py
+++ b/src/session_config.py
@@ -9,13 +9,10 @@ direct function parameters.
 Issue #713: Reduce parameter sprawl across session creation APIs.
 """
 
-from dataclasses import dataclass
-
 from pydantic import BaseModel
 
 
-@dataclass
-class SessionConfig:
+class SessionConfig(BaseModel):
     """Bundled configuration for session/minion/template creation.
 
     Groups configuration toggle parameters that were previously threaded
@@ -69,73 +66,3 @@ class SessionConfig:
     strict_mcp_config: bool = False  # Pass --strict-mcp-config to disable local .mcp.json
     bare_mode: bool = False  # Pass --bare to skip hooks, LSP, plugin sync, skill walks
     env_scrub_enabled: bool = False  # Issue #957: Strip credentials from subprocess envs
-
-
-class SessionConfigBase(BaseModel):
-    """Shared Pydantic base for session/minion/template request models.
-
-    All request models that create sessions, minions, or templates inherit
-    from this base to avoid duplicating the common config fields.
-    """
-
-    permission_mode: str = "acceptEdits"
-    system_prompt: str | None = None
-    override_system_prompt: bool = False
-    allowed_tools: list[str] | None = None
-    disallowed_tools: list[str] | None = None
-    model: str | None = None
-    cli_path: str | None = None
-    additional_directories: list[str] | None = None
-    setting_sources: list[str] | None = None
-    sandbox_enabled: bool = False
-    sandbox_config: dict | None = None
-    docker_enabled: bool = False
-    docker_image: str | None = None
-    docker_extra_mounts: list[str] | None = None
-    docker_home_directory: str | None = None
-    thinking_mode: str | None = None
-    thinking_budget_tokens: int | None = None
-    effort: str | None = None
-    history_distillation_enabled: bool = True
-    auto_memory_mode: str = "claude"
-    auto_memory_directory: str | None = None  # Custom directory for native auto-memory (issue #906)
-    skill_creating_enabled: bool = False
-    mcp_server_ids: list[str] | None = None
-    enable_claudeai_mcp_servers: bool = True
-    strict_mcp_config: bool = False
-    bare_mode: bool = False
-    env_scrub_enabled: bool = False  # Issue #957: Strip credentials from subprocess envs
-
-    def to_session_config(self, **overrides) -> SessionConfig:
-        """Convert to SessionConfig dataclass, with optional field overrides."""
-        data = {
-            "permission_mode": self.permission_mode,
-            "system_prompt": self.system_prompt,
-            "override_system_prompt": self.override_system_prompt,
-            "allowed_tools": self.allowed_tools,
-            "disallowed_tools": self.disallowed_tools,
-            "model": self.model,
-            "cli_path": self.cli_path,
-            "additional_directories": self.additional_directories,
-            "setting_sources": self.setting_sources,
-            "sandbox_enabled": self.sandbox_enabled,
-            "sandbox_config": self.sandbox_config,
-            "docker_enabled": self.docker_enabled,
-            "docker_image": self.docker_image,
-            "docker_extra_mounts": self.docker_extra_mounts,
-            "docker_home_directory": self.docker_home_directory,
-            "thinking_mode": self.thinking_mode,
-            "thinking_budget_tokens": self.thinking_budget_tokens,
-            "effort": self.effort,
-            "history_distillation_enabled": self.history_distillation_enabled,
-            "auto_memory_mode": self.auto_memory_mode,
-            "auto_memory_directory": self.auto_memory_directory,
-            "skill_creating_enabled": self.skill_creating_enabled,
-            "mcp_server_ids": self.mcp_server_ids,
-            "enable_claudeai_mcp_servers": self.enable_claudeai_mcp_servers,
-            "strict_mcp_config": self.strict_mcp_config,
-            "bare_mode": self.bare_mode,
-            "env_scrub_enabled": self.env_scrub_enabled,
-        }
-        data.update(overrides)
-        return SessionConfig(**data)

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -585,35 +585,7 @@ class SessionCoordinator:
             # Issue #349: All sessions are minions (is_minion field removed)
 
             # Build a config copy with resolved working directory for session manager
-            sm_config = SessionConfig(
-                permission_mode=config.permission_mode,
-                system_prompt=config.system_prompt,
-                override_system_prompt=config.override_system_prompt,
-                allowed_tools=config.allowed_tools,
-                disallowed_tools=config.disallowed_tools,
-                model=config.model,
-                working_directory=effective_working_directory,
-                additional_directories=config.additional_directories,
-                cli_path=config.cli_path,
-                setting_sources=config.setting_sources,
-                sandbox_enabled=config.sandbox_enabled,
-                sandbox_config=config.sandbox_config,
-                docker_enabled=config.docker_enabled,
-                docker_image=config.docker_image,
-                docker_extra_mounts=config.docker_extra_mounts,
-                thinking_mode=config.thinking_mode,
-                thinking_budget_tokens=config.thinking_budget_tokens,
-                effort=config.effort,
-                history_distillation_enabled=config.history_distillation_enabled,
-                auto_memory_mode=config.auto_memory_mode,
-                auto_memory_directory=config.auto_memory_directory,
-                skill_creating_enabled=config.skill_creating_enabled,
-                mcp_server_ids=config.mcp_server_ids,
-                enable_claudeai_mcp_servers=config.enable_claudeai_mcp_servers,
-                strict_mcp_config=config.strict_mcp_config,
-                bare_mode=config.bare_mode,
-                env_scrub_enabled=config.env_scrub_enabled,
-            )
+            sm_config = config.model_copy(update={"working_directory": effective_working_directory})
 
             # Create session through session manager
             # Store raw system_prompt (guide will be prepended later in start_session)
@@ -706,23 +678,7 @@ class SessionCoordinator:
 
             # Create SDK instance (uses factory for testability — issue #559)
             # Build SDK config from session config with resolved tools and prompt
-            sdk_config = SessionConfig(
-                permission_mode=sm_config.permission_mode,
-                system_prompt=escaped_system_prompt,
-                override_system_prompt=sm_config.override_system_prompt,
-                allowed_tools=all_tools,
-                disallowed_tools=sm_config.disallowed_tools,
-                model=sm_config.model,
-                sandbox_enabled=sm_config.sandbox_enabled,
-                sandbox_config=sm_config.sandbox_config,
-                thinking_mode=sm_config.thinking_mode,
-                thinking_budget_tokens=sm_config.thinking_budget_tokens,
-                effort=sm_config.effort,
-                enable_claudeai_mcp_servers=sm_config.enable_claudeai_mcp_servers,
-                strict_mcp_config=sm_config.strict_mcp_config,
-                bare_mode=sm_config.bare_mode,
-                env_scrub_enabled=sm_config.env_scrub_enabled,
-            )
+            sdk_config = sm_config.model_copy(update={"system_prompt": escaped_system_prompt, "allowed_tools": all_tools})
             # Issue #707: Build PreToolUse handler for internal tool access control
             permission_handler = self._build_permission_handler(
                 session_dir, config.history_distillation_enabled, config.auto_memory_mode,

--- a/src/tests/test_overseer_controller.py
+++ b/src/tests/test_overseer_controller.py
@@ -24,6 +24,26 @@ def _make_session(session_id, name, project_id="legion-1", parent_id=None, child
     s.state = SessionState.ACTIVE
     s.working_directory = "/tmp/test"
     s.role = "worker"
+    # Attributes inherited by child minion SessionConfig construction
+    s.thinking_mode = None
+    s.thinking_budget_tokens = None
+    s.effort = None
+    s.setting_sources = None
+    s.additional_directories = []
+    s.sandbox_config = None
+    s.docker_enabled = False
+    s.docker_image = None
+    s.docker_extra_mounts = []
+    s.docker_home_directory = None
+    s.history_distillation_enabled = True
+    s.auto_memory_mode = "claude"
+    s.auto_memory_directory = None
+    s.skill_creating_enabled = False
+    s.mcp_server_ids = []
+    s.enable_claudeai_mcp_servers = True
+    s.strict_mcp_config = False
+    s.bare_mode = False
+    s.env_scrub_enabled = False
     return s
 
 

--- a/src/tests/test_template_manager.py
+++ b/src/tests/test_template_manager.py
@@ -522,12 +522,11 @@ class TestSignatureParity:
         We verify that every template field is covered by either a direct
         create_template() parameter or a SessionConfig field.
         """
-        import dataclasses
         import inspect
 
         sig = inspect.signature(TemplateManager.create_template)
         create_params = set(sig.parameters.keys()) - {"self"}
-        session_config_fields = {f.name for f in dataclasses.fields(SessionConfig)}
+        session_config_fields = set(SessionConfig.model_fields.keys())
         template_fields = self._get_template_field_names()
 
         # Fields covered by direct params OR SessionConfig

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -38,7 +38,7 @@ from .message_parser import MessageParser, MessageProcessor
 from .models.permission_mode import PermissionMode
 from .permission_resolver import resolve_effective_permissions
 from .permission_service import PermissionService
-from .session_config import SessionConfigBase
+from .session_config import SessionConfig
 from .session_coordinator import SessionCoordinator
 from .session_manager import SessionState
 from .skill_manager import SkillManager
@@ -159,7 +159,7 @@ class ProjectReorderRequest(BaseModel):
     project_ids: list[str]
 
 
-class SessionCreateRequest(SessionConfigBase):
+class SessionCreateRequest(SessionConfig):
     project_id: str
     name: str | None = None
 
@@ -235,7 +235,7 @@ class CommSendRequest(BaseModel):
     comm_type: str = "task"
 
 
-class MinionCreateRequest(SessionConfigBase):
+class MinionCreateRequest(SessionConfig):
     name: str
     role: str | None = ""
     system_prompt: str | None = ""
@@ -271,7 +271,7 @@ class ScheduleUpdateRequest(BaseModel):
 
 
 
-class TemplateCreateRequest(SessionConfigBase):
+class TemplateCreateRequest(SessionConfig):
     name: str
     role: str | None = None
     system_prompt: str | None = None
@@ -1058,7 +1058,7 @@ class ClaudeWebUI:
                 request.additional_directories, None
             )
 
-            config = request.to_session_config(additional_directories=validated_dirs)
+            config = request.model_copy(update={"additional_directories": validated_dirs})
             session_id = await self.coordinator.create_session(
                 session_id=session_id,
                 project_id=request.project_id,
@@ -2354,10 +2354,7 @@ class ClaudeWebUI:
             )
 
             # Create minion via OverseerController
-            config = request.to_session_config(
-                system_prompt=request.system_prompt,
-                working_directory=str(working_dir),
-            )
+            config = request.model_copy(update={"working_directory": str(working_dir)})
             minion_id = await self.coordinator.legion_system.overseer_controller.create_minion_for_user(
                 legion_id=legion_id,
                 name=request.name,
@@ -3182,7 +3179,7 @@ class ClaudeWebUI:
         @handle_exceptions("create template", value_error_status=400)
         async def create_template(request: TemplateCreateRequest):
             """Create new template"""
-            config = request.to_session_config()
+            config = request
             return await self.service.create_template(
                 name=request.name,
                 config=config,


### PR DESCRIPTION
## Summary
Resolves #992

Consolidates `SessionConfig` (dataclass) and `SessionConfigBase` (Pydantic BaseModel) into a single Pydantic `BaseModel`. Previously, adding a new config field required editing three places. Now it requires one.

## Changes Made
- **`src/session_config.py`**: Convert `SessionConfig` from `@dataclass` to `BaseModel`; delete `SessionConfigBase` and `to_session_config()` entirely
- **`src/web_server.py`**: Request classes (`SessionCreateRequest`, `MinionCreateRequest`, `TemplateCreateRequest`) now inherit `SessionConfig` directly; three `to_session_config()` call sites replaced with `model_copy()` or direct pass-through
- **`src/session_coordinator.py`**: 30-line manual `SessionConfig` copy construction replaced with `config.model_copy(update={...})`; `sdk_config` construction simplified similarly
- **`src/tests/test_template_manager.py`**: Use `SessionConfig.model_fields` instead of `dataclasses.fields(SessionConfig)`
- **`src/tests/test_overseer_controller.py`**: Add properly-typed defaults to mock `SessionInfo` so Pydantic validation passes when constructing `SessionConfig` from parent session attributes

## Testing
- `uv run ruff check --fix` — zero violations
- `uv run pytest src/tests/` — 854 passed, 0 new failures (1 pre-existing unrelated failure in `test_legion_mcp_tools`)
- Net: ~101 lines removed, ~31 added

🤖 Generated with [Claude Code](https://claude.com/claude-code)