### PR TITLE
refactor: extract OAuthRefreshManager from SessionCoordinator

### DIFF
--- a/src/oauth_refresh_manager.py
+++ b/src/oauth_refresh_manager.py
@@ -1,0 +1,153 @@
+"""
+OAuthRefreshManager — Issue #989
+
+Encapsulates the per-server OAuth token refresh lifecycle that was previously
+embedded in SessionCoordinator:
+  - Per-server asyncio locks (prevent concurrent refresh calls)
+  - Background refresh tasks (one per server_id, shared across sessions)
+  - Reference counts (task cancelled when last session releases)
+  - Broadcast callback (notifies the UI after a successful background refresh)
+"""
+
+import asyncio
+import logging
+from collections.abc import Callable
+
+from .logging_config import get_logger
+from .task_utils import task_done_log_exception
+
+logger = logging.getLogger(__name__)
+coord_logger = get_logger("coordinator")
+
+
+class OAuthRefreshManager:
+    """Manages background OAuth token refresh tasks for MCP servers.
+
+    Issue #976: Tokens are application-scoped — one background refresh task per
+    server_id, shared across all sessions that use the same MCP server config.
+    """
+
+    # Refresh token this many seconds before the stored expiry.
+    REFRESH_BUFFER_SECONDS = 300
+
+    def __init__(self, oauth_manager) -> None:
+        """
+        Args:
+            oauth_manager: OAuthFlowManager instance used for token storage/refresh.
+        """
+        self._oauth_manager = oauth_manager
+        self._refresh_locks: dict[str, asyncio.Lock] = {}
+        self._refresh_tasks: dict[str, asyncio.Task] = {}
+        self._refresh_refcounts: dict[str, int] = {}
+        self._broadcast_callback: Callable[[str], None] | None = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def set_broadcast_callback(self, callback: Callable[[str], None]) -> None:
+        """Set the callback for broadcasting mcp_oauth_refreshed events to the UI.
+
+        Issue #976: Called by web_server after server init.
+        The callback receives server_id and appends an event to the UI poll queue.
+        """
+        self._broadcast_callback = callback
+
+    def ensure_refresh(self, server_id: str) -> None:
+        """Increment the ref count for server_id and start a refresh task if needed.
+
+        Issue #976: Tokens are application-scoped — one background task per server_id
+        shared across all sessions that use the same MCP server config.
+        """
+        self._refresh_refcounts[server_id] = self._refresh_refcounts.get(server_id, 0) + 1
+        if server_id not in self._refresh_tasks:
+            task = asyncio.create_task(
+                self._refresh_loop(server_id),
+                name=f"oauth-refresh-{server_id}",
+            )
+            task.add_done_callback(task_done_log_exception)
+            self._refresh_tasks[server_id] = task
+            coord_logger.info("Started background OAuth refresh task for server %s", server_id)
+
+    def release_refresh(self, server_id: str) -> None:
+        """Decrement the ref count for server_id and cancel the task when it hits zero.
+
+        Issue #976: Called when a session terminates or resets.
+        """
+        count = self._refresh_refcounts.get(server_id, 0)
+        if count <= 1:
+            self._refresh_refcounts.pop(server_id, None)
+            task = self._refresh_tasks.pop(server_id, None)
+            if task:
+                task.cancel()
+                coord_logger.info("Cancelled background OAuth refresh task for server %s", server_id)
+        else:
+            self._refresh_refcounts[server_id] = count - 1
+
+    async def refresh_token(self, server_id: str):
+        """Refresh the OAuth token for a server with per-server locking.
+
+        Issue #976: Prevents duplicate concurrent refresh requests for the same server.
+        Returns the new OAuthToken on success, or None on failure.
+        """
+        if server_id not in self._refresh_locks:
+            self._refresh_locks[server_id] = asyncio.Lock()
+        async with self._refresh_locks[server_id]:
+            return await self._oauth_manager.refresh_token(server_id)
+
+    # ------------------------------------------------------------------
+    # Private
+    # ------------------------------------------------------------------
+
+    async def _refresh_loop(self, server_id: str) -> None:
+        """Background task: refresh an OAuth token before it expires.
+
+        Issue #976: App-level task (one per server_id). Wakes up
+        REFRESH_BUFFER_SECONDS before the stored expiry and performs a token
+        refresh. Broadcasts mcp_oauth_refreshed on success so the UI status
+        indicator stays accurate. Repeats until cancelled or refresh token
+        is revoked.
+        """
+        import time as _time
+
+        while True:
+            try:
+                store = self._oauth_manager.get_token_store(server_id)
+                expiry = await store.get_token_expiry()
+                if expiry is None:
+                    # No expiry recorded — wait a fixed interval and recheck
+                    await asyncio.sleep(300)
+                    continue
+
+                sleep_seconds = (expiry - _time.time()) - self.REFRESH_BUFFER_SECONDS
+                if sleep_seconds > 0:
+                    await asyncio.sleep(sleep_seconds)
+
+                # Attempt refresh
+                new_token = await self.refresh_token(server_id)
+                if new_token:
+                    logger.info(
+                        "Background OAuth refresh succeeded for MCP server %s", server_id
+                    )
+                    if self._broadcast_callback:
+                        try:
+                            self._broadcast_callback(server_id)
+                        except Exception:
+                            logger.exception(
+                                "Error broadcasting mcp_oauth_refreshed for %s", server_id
+                            )
+                else:
+                    logger.warning(
+                        "Background OAuth refresh failed for MCP server %s. "
+                        "Session restart will re-authenticate if a valid token is available.",
+                        server_id,
+                    )
+                    # Token cleared by refresh_token() on revocation — stop looping
+                    break
+            except asyncio.CancelledError:
+                break
+            except Exception:
+                logger.exception(
+                    "Unexpected error in OAuth refresh loop for server %s", server_id
+                )
+                await asyncio.sleep(60)  # Back off before retrying

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -37,6 +37,7 @@ from .models.messages import (
     legacy_to_stored,
 )
 from .models.permission_mode import PermissionMode
+from .oauth_refresh_manager import OAuthRefreshManager
 from .project_manager import ProjectInfo, ProjectManager
 from .queue_manager import QueueManager
 from .queue_processor import QueueProcessor
@@ -139,15 +140,8 @@ class SessionCoordinator:
         self._active_sdks: dict[str, ClaudeSDK] = {}
         self._storage_managers: dict[str, DataStorageManager] = {}
 
-        # Issue #976: Per-server refresh locks (prevent concurrent refresh calls)
-        self._oauth_refresh_locks: dict[str, asyncio.Lock] = {}
-        # Issue #976: App-level background refresh tasks keyed by server_id (not session_id).
-        # Tokens are application-scoped — one task per server_id, shared across sessions.
-        self._oauth_refresh_tasks: dict[str, asyncio.Task] = {}
-        # Issue #976: Reference counts per server_id — task cancelled when count hits zero.
-        self._oauth_refresh_refcounts: dict[str, int] = {}
-        # Issue #976: Callback for broadcasting mcp_oauth_refreshed UI events
-        self._oauth_refresh_broadcast_callback: Callable[[str], None] | None = None
+        # Issue #976/#989: OAuth token refresh lifecycle (extracted to OAuthRefreshManager)
+        self.oauth_refresh_manager = OAuthRefreshManager(self.oauth_manager)
 
         # Event callbacks
         self._message_callbacks: dict[str, list[Callable]] = {}
@@ -239,9 +233,6 @@ class SessionCoordinator:
         """Set custom SDK factory for testing (e.g., MockClaudeSDK)."""
         self._sdk_factory = factory
 
-    # Issue #976: Refresh the stored token ≥5 min before expiry (or on expiry).
-    _OAUTH_REFRESH_BUFFER_SECONDS = 300
-
     async def _get_mcp_sdk_config(self, mcp_cfg) -> dict:
         """Return SDK config for an MCP server, injecting OAuth Bearer token when applicable.
 
@@ -265,7 +256,7 @@ class SessionCoordinator:
                     now = _time.time()
 
                     # Issue #976: Attempt refresh if token is expired or expiring soon
-                    if expiry is not None and expiry < (now + self._OAUTH_REFRESH_BUFFER_SECONDS):
+                    if expiry is not None and expiry < (now + OAuthRefreshManager.REFRESH_BUFFER_SECONDS):
                         seconds_until_expiry = expiry - now
                         if seconds_until_expiry < 0:
                             logger.warning(
@@ -279,7 +270,7 @@ class SessionCoordinator:
                                 mcp_cfg.id,
                                 seconds_until_expiry,
                             )
-                        new_token = await self._refresh_oauth_token(mcp_cfg.id)
+                        new_token = await self.oauth_refresh_manager.refresh_token(mcp_cfg.id)
                         if new_token:
                             token = new_token
                         else:
@@ -314,106 +305,6 @@ class SessionCoordinator:
                 "[MCP config] server=%s oauth=False config=%s", mcp_cfg.id, config
             )
         return config
-
-    async def _refresh_oauth_token(self, server_id: str):
-        """Refresh the OAuth token for a server with per-server locking.
-
-        Issue #976: Prevents duplicate concurrent refresh requests for the same server.
-        Returns the new OAuthToken on success, or None on failure.
-        """
-        if server_id not in self._oauth_refresh_locks:
-            self._oauth_refresh_locks[server_id] = asyncio.Lock()
-        async with self._oauth_refresh_locks[server_id]:
-            return await self.oauth_manager.refresh_token(server_id)
-
-    async def _oauth_refresh_loop(self, server_id: str) -> None:
-        """Background task: refresh an OAuth token before it expires.
-
-        Issue #976: App-level task (one per server_id). Wakes up
-        _OAUTH_REFRESH_BUFFER_SECONDS before the stored expiry and performs a token
-        refresh. Broadcasts mcp_oauth_refreshed on success so the UI status indicator
-        stays accurate. Repeats until cancelled or refresh token is revoked.
-        """
-        import time as _time
-
-        while True:
-            try:
-                store = self.oauth_manager.get_token_store(server_id)
-                expiry = await store.get_token_expiry()
-                if expiry is None:
-                    # No expiry recorded — wait a fixed interval and recheck
-                    await asyncio.sleep(300)
-                    continue
-
-                sleep_seconds = (expiry - _time.time()) - self._OAUTH_REFRESH_BUFFER_SECONDS
-                if sleep_seconds > 0:
-                    await asyncio.sleep(sleep_seconds)
-
-                # Attempt refresh
-                new_token = await self._refresh_oauth_token(server_id)
-                if new_token:
-                    logger.info(
-                        "Background OAuth refresh succeeded for MCP server %s", server_id
-                    )
-                    if self._oauth_refresh_broadcast_callback:
-                        try:
-                            self._oauth_refresh_broadcast_callback(server_id)
-                        except Exception:
-                            logger.exception("Error broadcasting mcp_oauth_refreshed for %s", server_id)
-                else:
-                    logger.warning(
-                        "Background OAuth refresh failed for MCP server %s. "
-                        "Session restart will re-authenticate if a valid token is available.",
-                        server_id,
-                    )
-                    # Token cleared by refresh_token() on revocation — stop looping
-                    break
-            except asyncio.CancelledError:
-                break
-            except Exception:
-                logger.exception(
-                    "Unexpected error in OAuth refresh loop for server %s", server_id
-                )
-                await asyncio.sleep(60)  # Back off before retrying
-
-    def _ensure_oauth_refresh(self, server_id: str) -> None:
-        """Increment the ref count for server_id and start a refresh task if needed.
-
-        Issue #976: Tokens are application-scoped — one background task per server_id
-        shared across all sessions that use the same MCP server config.
-        """
-        self._oauth_refresh_refcounts[server_id] = self._oauth_refresh_refcounts.get(server_id, 0) + 1
-        if server_id not in self._oauth_refresh_tasks:
-            task = asyncio.create_task(
-                self._oauth_refresh_loop(server_id),
-                name=f"oauth-refresh-{server_id}",
-            )
-            task.add_done_callback(task_done_log_exception)
-            self._oauth_refresh_tasks[server_id] = task
-            coord_logger.info("Started background OAuth refresh task for server %s", server_id)
-
-    def _release_oauth_refresh(self, server_id: str) -> None:
-        """Decrement the ref count for server_id and cancel the task when it hits zero.
-
-        Issue #976: Called when a session terminates or resets.
-        """
-        count = self._oauth_refresh_refcounts.get(server_id, 0)
-        if count <= 1:
-            self._oauth_refresh_refcounts.pop(server_id, None)
-            task = self._oauth_refresh_tasks.pop(server_id, None)
-            if task:
-                task.cancel()
-                coord_logger.info("Cancelled background OAuth refresh task for server %s", server_id)
-        else:
-            self._oauth_refresh_refcounts[server_id] = count - 1
-
-    def set_oauth_refresh_broadcast_callback(self, callback: Callable[[str], None]) -> None:
-        """Set the callback for broadcasting mcp_oauth_refreshed events to the UI.
-
-        Issue #976: Called by web_server after server init.
-        The callback receives server_id and appends an event to the UI poll queue.
-        """
-        self._oauth_refresh_broadcast_callback = callback
 
     async def initialize(self):
         """Initialize the session coordinator"""
@@ -1364,7 +1255,7 @@ class SessionCoordinator:
                 selected_configs = self.mcp_config_manager.get_configs_by_ids(session_info.mcp_server_ids)
                 for mcp_cfg in selected_configs:
                     if mcp_cfg.oauth_enabled:
-                        self._ensure_oauth_refresh(mcp_cfg.id)
+                        self.oauth_refresh_manager.ensure_refresh(mcp_cfg.id)
 
             coord_logger.info(f"Session {session_id} SDK task started - state will update to ACTIVE when SDK is ready")
             return True
@@ -1410,7 +1301,7 @@ class SessionCoordinator:
                 _term_configs = self.mcp_config_manager.get_configs_by_ids(_term_info.mcp_server_ids)
                 for _cfg in _term_configs:
                     if _cfg.oauth_enabled:
-                        self._release_oauth_refresh(_cfg.id)
+                        self.oauth_refresh_manager.release_refresh(_cfg.id)
 
             # Issue #500: Stop queue processor before termination
             self.queue_processor.stop(session_id)
@@ -2107,7 +1998,7 @@ class SessionCoordinator:
                 _reset_configs = self.mcp_config_manager.get_configs_by_ids(_reset_info.mcp_server_ids)
                 for _cfg in _reset_configs:
                     if _cfg.oauth_enabled:
-                        self._release_oauth_refresh(_cfg.id)
+                        self.oauth_refresh_manager.release_refresh(_cfg.id)
 
             # Issue #500: Stop queue processor and mark any in-flight item as failed
             # Skip when called from the processor itself to avoid self-cancellation

--- a/src/tests/test_issue_976_oauth_refresh.py
+++ b/src/tests/test_issue_976_oauth_refresh.py
@@ -9,7 +9,7 @@ Covers:
 - SessionCoordinator._get_mcp_sdk_config() proactive refresh before expiry
 - SessionCoordinator._get_mcp_sdk_config() reactive refresh on expired token
 - SessionCoordinator._get_mcp_sdk_config() fallback when refresh fails
-- SessionCoordinator._ensure_oauth_refresh / _release_oauth_refresh ref counting
+- OAuthRefreshManager.ensure_refresh / release_refresh ref counting (issue #989)
 """
 
 import json
@@ -357,61 +357,65 @@ async def test_get_mcp_sdk_config_fallback_when_refresh_fails(tmp_path: Path):
 
 
 # ---------------------------------------------------------------------------
-# Step 4: _ensure_oauth_refresh / _release_oauth_refresh reference counting
+# Step 4: OAuthRefreshManager.ensure_refresh / release_refresh ref counting
+# (issue #989: extracted from SessionCoordinator)
 # ---------------------------------------------------------------------------
 
 
+def _make_manager(tmp_path):
+    """Build an OAuthRefreshManager backed by a real OAuthFlowManager."""
+    from src.oauth_manager import OAuthFlowManager
+    from src.oauth_refresh_manager import OAuthRefreshManager
+
+    oauth_mgr = OAuthFlowManager(tmp_path)
+    return OAuthRefreshManager(oauth_mgr)
+
+
 def test_ensure_oauth_refresh_creates_task_once(tmp_path):
-    """_ensure_oauth_refresh() creates a single task and increments ref count."""
+    """ensure_refresh() creates a single task and increments ref count."""
     import asyncio
 
-    from src.session_coordinator import SessionCoordinator
-
-    coordinator = SessionCoordinator(data_dir=tmp_path)
+    manager = _make_manager(tmp_path)
 
     loop = asyncio.new_event_loop()
     try:
-        loop.run_until_complete(_run_ensure_release(coordinator))
+        loop.run_until_complete(_run_ensure_release(manager))
     finally:
         loop.close()
 
 
-async def _run_ensure_release(coordinator):
-    from src.session_coordinator import SessionCoordinator  # noqa: F401
+async def _run_ensure_release(manager):
+    manager.ensure_refresh("srv1")
+    manager.ensure_refresh("srv1")  # second session, same server
 
-    coordinator._ensure_oauth_refresh("srv1")
-    coordinator._ensure_oauth_refresh("srv1")  # second session, same server
-
-    assert coordinator._oauth_refresh_refcounts["srv1"] == 2
-    assert "srv1" in coordinator._oauth_refresh_tasks
-    task_id = id(coordinator._oauth_refresh_tasks["srv1"])
+    assert manager._refresh_refcounts["srv1"] == 2
+    assert "srv1" in manager._refresh_tasks
+    task_id = id(manager._refresh_tasks["srv1"])
 
     # Second ensure does NOT replace the existing task
-    coordinator._ensure_oauth_refresh("srv1")
-    assert coordinator._oauth_refresh_refcounts["srv1"] == 3
-    assert id(coordinator._oauth_refresh_tasks["srv1"]) == task_id
+    manager.ensure_refresh("srv1")
+    assert manager._refresh_refcounts["srv1"] == 3
+    assert id(manager._refresh_tasks["srv1"]) == task_id
 
     # Releasing twice — task should still be alive
-    coordinator._release_oauth_refresh("srv1")
-    coordinator._release_oauth_refresh("srv1")
-    assert coordinator._oauth_refresh_refcounts.get("srv1") == 1
-    assert "srv1" in coordinator._oauth_refresh_tasks
+    manager.release_refresh("srv1")
+    manager.release_refresh("srv1")
+    assert manager._refresh_refcounts.get("srv1") == 1
+    assert "srv1" in manager._refresh_tasks
 
     # Final release — task cancelled and removed
-    coordinator._release_oauth_refresh("srv1")
-    assert "srv1" not in coordinator._oauth_refresh_refcounts
-    assert "srv1" not in coordinator._oauth_refresh_tasks
+    manager.release_refresh("srv1")
+    assert "srv1" not in manager._refresh_refcounts
+    assert "srv1" not in manager._refresh_tasks
 
 
 def test_release_below_zero_is_safe(tmp_path):
-    """_release_oauth_refresh() does not error when called with no matching task."""
+    """release_refresh() does not error when called with no matching task."""
     import asyncio
 
-    from src.session_coordinator import SessionCoordinator
-
-    coordinator = SessionCoordinator(data_dir=tmp_path)
+    manager = _make_manager(tmp_path)
 
     async def _run():
-        coordinator._release_oauth_refresh("nonexistent")
+        manager.release_refresh("nonexistent")
 
     asyncio.run(_run())

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -452,9 +452,9 @@ class ClaudeWebUI:
         self.coordinator.set_resource_broadcast_callback(self._broadcast_resource_registered)
         logger.info("Resource broadcast callback injected into SessionCoordinator")
 
-        # Issue #976: Inject OAuth refresh broadcast callback into SessionCoordinator
-        self.coordinator.set_oauth_refresh_broadcast_callback(self._broadcast_mcp_oauth_refreshed)
-        logger.info("OAuth refresh broadcast callback injected into SessionCoordinator")
+        # Issue #976/#989: Inject OAuth refresh broadcast callback into OAuthRefreshManager
+        self.coordinator.oauth_refresh_manager.set_broadcast_callback(self._broadcast_mcp_oauth_refreshed)
+        logger.info("OAuth refresh broadcast callback injected into OAuthRefreshManager")
 
         # Setup static files (Vue 3 production build)
         static_dir = Path(__file__).parent.parent / "frontend" / "dist"


### PR DESCRIPTION
## Summary
Resolves #989

Extracts OAuth token refresh lifecycle into a dedicated `OAuthRefreshManager` class, removing ~150 lines from `SessionCoordinator` and making the refresh logic independently testable.

## Changes Made
- **New**: `src/oauth_refresh_manager.py` — `OAuthRefreshManager` class with `ensure_refresh()`, `release_refresh()`, `refresh_token()`, `set_broadcast_callback()`, `_refresh_loop()`
- **`src/session_coordinator.py`**: Remove 4 dicts, 1 class constant, 5 methods; add `self.oauth_refresh_manager = OAuthRefreshManager(self.oauth_manager)`; update 3 call sites
- **`src/web_server.py`**: Change `coordinator.set_oauth_refresh_broadcast_callback(...)` → `coordinator.oauth_refresh_manager.set_broadcast_callback(...)`
- **`src/tests/test_issue_976_oauth_refresh.py`**: Update ref-counting tests to instantiate `OAuthRefreshManager` directly instead of `SessionCoordinator`

## Testing
- All 15 existing OAuth refresh tests pass (`uv run pytest src/tests/test_issue_976_oauth_refresh.py -v`)
- Ruff linting: zero violations on modified files
- No behavior change — pure structural refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)