### PR TITLE
fix: prevent _pending_results leaks that stuck is_processing true

### DIFF
--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -1780,10 +1780,12 @@ class SessionCoordinator:
             # The SDK should echo the user message back through the stream
             result = await sdk.send_message(message, metadata=metadata)
 
-            # If message sending failed, reset processing state
+            # If message sending failed, decrement counter and conditionally reset processing
             if not result:
-                await self.session_manager.update_processing_state(session_id, False)
                 self._pending_results[session_id] = max(0, self._pending_results.get(session_id, 0) - 1)
+                # Issue #1002: Only reset is_processing if no other queries are in flight
+                if self._pending_results.get(session_id, 0) == 0:
+                    await self.session_manager.update_processing_state(session_id, False)
 
             return result
 
@@ -1791,10 +1793,12 @@ class SessionCoordinator:
             logger.exception(f"Failed to send message to session {session_id}")
             # Reset processing state on error
             try:
-                await self.session_manager.update_processing_state(session_id, False)
                 # Decrement the counter that was incremented before the exception so
                 # it doesn't leave is_processing permanently stuck true.
                 self._pending_results[session_id] = max(0, self._pending_results.get(session_id, 0) - 1)
+                # Issue #1002: Only reset is_processing if no other queries are in flight
+                if self._pending_results.get(session_id, 0) == 0:
+                    await self.session_manager.update_processing_state(session_id, False)
             except Exception:
                 pass  # Don't fail on state update error
             return False
@@ -3657,7 +3661,11 @@ class SessionCoordinator:
 
                 # Also reset processing state on interrupt_success
                 if parsed_message.type.value == 'system' and parsed_message.metadata.get('subtype') == 'interrupt_success':
-                    # Only reset if no queries pending (PIVOT sends a new message after interrupt)
+                    # Issue #1002: The interrupted query won't produce a ResultMessage,
+                    # so decrement _pending_results to account for it.
+                    if self._pending_results.get(session_id, 0) > 0:
+                        self._pending_results[session_id] = self._pending_results[session_id] - 1
+                    # Only reset is_processing if no queries pending (PIVOT sends a new message after interrupt)
                     if self._pending_results.get(session_id, 0) == 0:
                         try:
                             await self.session_manager.update_processing_state(session_id, False)
@@ -3716,6 +3724,9 @@ class SessionCoordinator:
                 # Reset processing state on any error
                 try:
                     await self.session_manager.update_processing_state(session_id, False)
+                    # Issue #1002: Reset pending results counter to prevent phantom counts
+                    # from leaving is_processing stuck true on subsequent messages.
+                    self._pending_results[session_id] = 0
                     # logger.info(f"Reset processing state for session {session_id} after error: {error_type}")
                 except Exception:
                     logger.exception(f"Failed to reset processing state for session {session_id}")

--- a/src/tests/test_session_coordinator.py
+++ b/src/tests/test_session_coordinator.py
@@ -677,6 +677,150 @@ class TestIssue811IsProcessingStuck:
         )
 
 
+class TestIssue1002IsProcessingStuckDuringProcessing:
+    """Regression tests for issue #1002 — is_processing stuck true after
+    message sent during active processing."""
+
+    @pytest.mark.asyncio
+    async def test_issue_1002_error_callback_resets_pending_results(
+        self, temp_coordinator, sample_session_config
+    ):
+        """Error callback must reset _pending_results to 0 so phantom counts
+        don't prevent is_processing from clearing on future messages."""
+        coordinator = temp_coordinator
+        session_id = await coordinator.create_session(**sample_session_config)
+        await coordinator.session_manager.update_session_state(session_id, SessionState.ACTIVE)
+
+        # Simulate 2 messages in flight
+        coordinator._pending_results[session_id] = 2
+        await coordinator.session_manager.update_processing_state(session_id, True)
+
+        # Fire the error callback (as SDK would on client.query() failure)
+        error_cb = coordinator._create_error_callback(session_id)
+        await error_cb("message_processing_error", RuntimeError("query failed"))
+
+        assert coordinator._pending_results.get(session_id, 0) == 0
+        session_info = await coordinator.session_manager.get_session_info(session_id)
+        assert session_info.is_processing is False
+
+    @pytest.mark.asyncio
+    async def test_issue_1002_send_message_failure_preserves_is_processing_when_pending(
+        self, temp_coordinator, sample_session_config
+    ):
+        """When send_message() fails but other queries are still in flight,
+        is_processing must remain True."""
+        coordinator = temp_coordinator
+        session_id = await coordinator.create_session(**sample_session_config)
+        await coordinator.session_manager.update_session_state(session_id, SessionState.ACTIVE)
+
+        # Simulate 1 message already in flight
+        coordinator._pending_results[session_id] = 1
+        await coordinator.session_manager.update_processing_state(session_id, True)
+
+        # Second message fails at SDK level
+        mock_sdk = AsyncMock()
+        mock_sdk.send_message.return_value = False
+        coordinator._active_sdks[session_id] = mock_sdk
+
+        result = await coordinator.send_message(session_id, "Second message")
+
+        assert result is False
+        # Counter was incremented to 2 then decremented to 1
+        assert coordinator._pending_results.get(session_id, 0) == 1
+        # is_processing must stay True because first message is still in flight
+        session_info = await coordinator.session_manager.get_session_info(session_id)
+        assert session_info.is_processing is True
+
+    @pytest.mark.asyncio
+    async def test_issue_1002_send_message_exception_preserves_is_processing_when_pending(
+        self, temp_coordinator, sample_session_config
+    ):
+        """When send_message() throws but other queries are in flight,
+        is_processing must remain True."""
+        coordinator = temp_coordinator
+        session_id = await coordinator.create_session(**sample_session_config)
+        await coordinator.session_manager.update_session_state(session_id, SessionState.ACTIVE)
+
+        coordinator._pending_results[session_id] = 1
+        await coordinator.session_manager.update_processing_state(session_id, True)
+
+        mock_sdk = AsyncMock()
+        mock_sdk.send_message.side_effect = RuntimeError("SDK blew up")
+        coordinator._active_sdks[session_id] = mock_sdk
+
+        result = await coordinator.send_message(session_id, "Boom!")
+
+        assert result is False
+        assert coordinator._pending_results.get(session_id, 0) == 1
+        session_info = await coordinator.session_manager.get_session_info(session_id)
+        assert session_info.is_processing is True
+
+    @pytest.mark.asyncio
+    async def test_issue_1002_interrupt_success_decrements_pending_results(
+        self, temp_coordinator, sample_session_config
+    ):
+        """interrupt_success must decrement _pending_results for the interrupted
+        query that won't produce a ResultMessage."""
+        coordinator = temp_coordinator
+        session_id = await coordinator.create_session(**sample_session_config)
+        await coordinator.session_manager.update_session_state(session_id, SessionState.ACTIVE)
+
+        coordinator._pending_results[session_id] = 1
+        await coordinator.session_manager.update_processing_state(session_id, True)
+
+        # Simulate interrupt_success message arriving via the message callback
+        callback = coordinator._create_message_callback(session_id)
+        await callback({
+            "type": "system",
+            "content": "Session interrupted successfully",
+            "subtype": "interrupt_success",
+            "session_id": session_id,
+            "timestamp": 1234567890.0,
+        })
+
+        assert coordinator._pending_results.get(session_id, 0) == 0
+        session_info = await coordinator.session_manager.get_session_info(session_id)
+        assert session_info.is_processing is False
+
+    @pytest.mark.asyncio
+    async def test_issue_1002_pivot_interrupt_then_send_keeps_counter_accurate(
+        self, temp_coordinator, sample_session_config
+    ):
+        """PIVOT: interrupt decrements for interrupted query, then send_message
+        increments for new query — counter must reflect exactly 1 in-flight."""
+        coordinator = temp_coordinator
+        session_id = await coordinator.create_session(**sample_session_config)
+        await coordinator.session_manager.update_session_state(session_id, SessionState.ACTIVE)
+
+        # 1 message in flight
+        coordinator._pending_results[session_id] = 1
+        await coordinator.session_manager.update_processing_state(session_id, True)
+
+        # Simulate interrupt_success
+        callback = coordinator._create_message_callback(session_id)
+        await callback({
+            "type": "system",
+            "content": "Session interrupted successfully",
+            "subtype": "interrupt_success",
+            "session_id": session_id,
+            "timestamp": 1234567890.0,
+        })
+
+        assert coordinator._pending_results.get(session_id, 0) == 0
+
+        # PIVOT sends new message
+        mock_sdk = AsyncMock()
+        mock_sdk.send_message.return_value = True
+        coordinator._active_sdks[session_id] = mock_sdk
+
+        result = await coordinator.send_message(session_id, "New direction")
+
+        assert result is True
+        assert coordinator._pending_results.get(session_id, 0) == 1
+        session_info = await coordinator.session_manager.get_session_info(session_id)
+        assert session_info.is_processing is True
+
+
 class TestIssue819DockerHistoryMount:
     """Regression tests for issue #819 — history/ dir must be mounted in Docker sessions."""
 


### PR DESCRIPTION
## Summary
Resolves #1002

Three leak paths in `SessionCoordinator._pending_results` could leave `is_processing` permanently stuck `True` after a message was sent while another message was already being processed.

## Changes Made

- **Error callback** (`_create_error_callback`): Reset `_pending_results[session_id] = 0` alongside the `is_processing = False` reset. When the SDK fires an error callback, all in-flight queries are dead — no further `ResultMessage` will arrive. Without this reset, phantom counts leave `is_processing` stuck on future messages.

- **`send_message()` failure paths** (both `if not result` and `except` branches): Decrement first, then only reset `is_processing` if `_pending_results` reaches 0. Previously, `is_processing` was unconditionally cleared even when other queries were still in flight.

- **`interrupt_success` handler** (`_create_message_callback`): Decrement `_pending_results` for the interrupted query that will never produce a `ResultMessage`. The PIVOT case remains correct: the subsequent `send_message()` re-increments the counter, keeping the net count accurate.

## Testing

- Added `TestIssue1002IsProcessingStuckDuringProcessing` with 5 regression tests:
  1. Error callback resets `_pending_results` to 0
  2. `send_message()` failure preserves `is_processing=True` when other queries pending
  3. `send_message()` exception preserves `is_processing=True` when other queries pending
  4. `interrupt_success` decrements `_pending_results` and clears `is_processing`
  5. PIVOT sequence (interrupt + new send) keeps counter accurate at 1

- All 5 new tests pass; existing issue #811 regression tests unaffected
- Full test suite: 885 passed, 1 pre-existing failure in unrelated `test_legion_mcp_tools.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)