### PR TITLE
chore: post-refactor cleanup — stale comment and lock dict symmetry

### DIFF
--- a/src/oauth_refresh_manager.py
+++ b/src/oauth_refresh_manager.py
@@ -81,6 +81,8 @@ class OAuthRefreshManager:
             if task:
                 task.cancel()
                 coord_logger.info("Cancelled background OAuth refresh task for server %s", server_id)
+            if server_id in self._refresh_locks:
+                del self._refresh_locks[server_id]
         else:
             self._refresh_refcounts[server_id] = count - 1
 

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -241,7 +241,7 @@ class MinionCreateRequest(SessionConfig):
     system_prompt: str | None = ""
     capabilities: list[str] | None = None
     working_directory: str | None = None  # Optional custom working directory for this minion
-    permission_mode: str = "default"  # Override default from SessionConfigBase
+    permission_mode: str = "default"  # Override default from SessionConfig
 
 
 class ScheduleCreateRequest(BaseModel):


### PR DESCRIPTION
## Summary
Resolves #1005

Two trivial post-refactor cleanup fixes with no behavior changes.

## Changes Made
- **`src/web_server.py`**: Update stale comment from `SessionConfigBase` to `SessionConfig` (`SessionConfigBase` was removed in a prior refactor)
- **`src/oauth_refresh_manager.py`**: Remove `_refresh_locks[server_id]` entry in `release_refresh()` when refcount hits zero, matching the existing cleanup of `_refresh_tasks` and `_refresh_refcounts`

## Testing
- Ruff linting: passed (zero violations)
- Unit tests: 885 passed, 1 pre-existing failure unrelated to these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)