### PR TITLE
fix: show actionable error when session restart fails due to stale resume ID

### DIFF
--- a/src/claude_sdk.py
+++ b/src/claude_sdk.py
@@ -1617,6 +1617,30 @@ class ClaudeSDK:
                     parts.append("Recent stderr:\n" + "\n".join(recent_stderr))
                 return "\n".join(parts)
 
+        # Phase 1.5: Detect stale resume ID (issue #1017)
+        # When --resume points to a CLI session that no longer exists, the CLI exits
+        # immediately with code 1, empty stderr, and zero queries sent.
+        if (
+            self.resume_session_id is not None
+            and not stderr_buffer
+            and self._session_health_checks.get("total_queries_sent", 0) == 0
+        ):
+            stale_patterns = [
+                r"exit code[:\s]+(\d+)",
+                r"exited with code\s+(\d+)",
+                r"exit status\s+(\d+)",
+                r"returned non-zero exit status\s+(\d+)",
+                r"Command failed with exit code\s+(\d+)",
+            ]
+            for pattern in stale_patterns:
+                match = re.search(pattern, combined, re.IGNORECASE)
+                if match and int(match.group(1)) == 1:
+                    return (
+                        "Process exited with error: The stored session ID is no longer valid "
+                        "(the Claude Code conversation history may have been cleared or expired).\n\n"
+                        "Recovery: Use **Reset Session** instead of Restart to start a fresh conversation."
+                    )
+
         # Phase 2: Extract exit code from error message
         exit_code = None
         patterns = [


### PR DESCRIPTION
## Summary
Resolves #1017

When a session's stored `claude_code_session_id` refers to a CLI session that no longer exists, clicking Restart causes the CLI to exit immediately with code 1 and empty stderr — an opaque failure that gives the user no guidance.

## Changes Made
- Added Phase 1.5 heuristic in `ClaudeSDK._parse_container_exit_code()` (`src/claude_sdk.py`)
- Detects the four-signal combination: exit code 1 + empty stderr + non-null `resume_session_id` + zero queries sent
- Returns a clear message: "The stored session ID is no longer valid... Use **Reset Session** instead of Restart"
- The message passes through the existing `"Process exited with error"` passthrough pattern in `_extract_claude_cli_error()` — no coordinator changes needed

## Testing
- Manual: create session → edit `state.json` to set a bogus `claude_code_session_id` → click Restart → verify error message directs user to Reset Session
- Normal restart with valid resume ID is unaffected (succeeds before reaching the error path)
- Exit-code-1 failures with stderr output are excluded by the empty-stderr condition

🤖 Generated with [Claude Code](https://claude.com/claude-code)