### PR TITLE
fix: transition ERROR→TERMINATED before reset to allow clean session recovery

### DIFF
--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -1922,6 +1922,13 @@ class SessionCoordinator:
                 await asyncio.sleep(0.5)
                 del self._active_sdks[session_id]
 
+            # Issue #1019: If session is in ERROR state (no active SDK to disconnect),
+            # transition to TERMINATED so start_session() will accept it.
+            _pre_reset_info = await self.session_manager.get_session_info(session_id)
+            if _pre_reset_info and _pre_reset_info.state == SessionState.ERROR:
+                await self.session_manager.update_session_state(session_id, SessionState.TERMINATED)
+                coord_logger.info(f"Transitioned errored session {session_id} to TERMINATED for reset")
+
             # Clear Claude Code session ID from state (prevents resume)
             session_info = await self.session_manager.get_session_info(session_id)
             if session_info:

--- a/src/tests/test_session_coordinator.py
+++ b/src/tests/test_session_coordinator.py
@@ -531,6 +531,27 @@ class TestSessionCoordinator:
         assert storage_manager.session_dir.exists()
         assert storage_manager.messages_file.exists()
 
+    @pytest.mark.asyncio
+    async def test_issue_1019_reset_errored_session_succeeds(self, temp_coordinator, sample_session_config):
+        """reset_session() on an ERROR-state session (no active SDK) transitions to TERMINATED then starts fresh."""
+        coordinator = temp_coordinator
+        session_id = await coordinator.create_session(**sample_session_config)
+
+        # Force session into ERROR state (simulates a failed start)
+        await coordinator.session_manager.update_session_state(session_id, SessionState.ERROR, "simulated error")
+        session_info = await coordinator.session_manager.get_session_info(session_id)
+        assert session_info.state == SessionState.ERROR
+
+        # No active SDK (as happens with errored sessions)
+        assert session_id not in coordinator._active_sdks
+
+        # Mock start_session to succeed without actually launching SDK
+        with patch.object(coordinator, "start_session", return_value=True) as mock_start:
+            success = await coordinator.reset_session(session_id)
+
+        assert success is True
+        mock_start.assert_called_once_with(session_id, None)
+
 
 class TestDeleteSessionScheduleCancellation:
     """Tests for schedule cancellation when deleting sessions (Issue #671)."""


### PR DESCRIPTION
## Summary
Resolves #1019

Sessions in `ERROR` state (e.g. after a failed start) could not be reset via the UI. `reset_session()` skipped the SDK disconnect block (no active SDK), leaving the session in `ERROR` state. When `start_session()` was called, it rejected the transition because `ERROR` was not in its allowed source states, returning `False` and showing an error to the user. Meanwhile, archive, message clear, and resource clear had already executed — partial side effects with no recovery.

## Changes Made
- `src/session_coordinator.py`: After the SDK disconnect block in `reset_session()`, check if the session is still in `ERROR` state and transition it to `TERMINATED` before proceeding with destructive operations. This mirrors what `terminate_session()` already does from ERROR state.
- `src/tests/test_session_coordinator.py`: Added `test_issue_1019_reset_errored_session_succeeds` regression test verifying that `reset_session()` succeeds when the session is in ERROR state with no active SDK.

## Testing
- Regression test passes: `test_issue_1019_reset_errored_session_succeeds`
- Full test suite: 886 passed, 1 pre-existing unrelated failure
- Ruff linting: zero violations on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)