### PR TITLE
refactor: extract shared exit code regex list into _EXIT_CODE_PATTERNS constant

### DIFF
--- a/src/claude_sdk.py
+++ b/src/claude_sdk.py
@@ -1586,6 +1586,15 @@ class ClaudeSDK:
     # Exit codes that represent container setup/config errors (not runtime failures)
     _SETUP_EXIT_CODES: frozenset[int] = frozenset({126, 127})
 
+    # Regex patterns for extracting exit codes from error messages (used in Phase 1.5 and Phase 2)
+    _EXIT_CODE_PATTERNS: list[str] = [
+        r"exit code[:\s]+(\d+)",
+        r"exited with code\s+(\d+)",
+        r"exit status\s+(\d+)",
+        r"returned non-zero exit status\s+(\d+)",
+        r"Command failed with exit code\s+(\d+)",
+    ]
+
     def _parse_container_exit_code(
         self, error_msg: str, stderr_buffer: list[str]
     ) -> str | None:
@@ -1625,14 +1634,7 @@ class ClaudeSDK:
             and not stderr_buffer
             and self._session_health_checks.get("total_queries_sent", 0) == 0
         ):
-            stale_patterns = [
-                r"exit code[:\s]+(\d+)",
-                r"exited with code\s+(\d+)",
-                r"exit status\s+(\d+)",
-                r"returned non-zero exit status\s+(\d+)",
-                r"Command failed with exit code\s+(\d+)",
-            ]
-            for pattern in stale_patterns:
+            for pattern in self._EXIT_CODE_PATTERNS:
                 match = re.search(pattern, combined, re.IGNORECASE)
                 if match and int(match.group(1)) == 1:
                     return (
@@ -1643,14 +1645,7 @@ class ClaudeSDK:
 
         # Phase 2: Extract exit code from error message
         exit_code = None
-        patterns = [
-            r"exit code[:\s]+(\d+)",
-            r"exited with code\s+(\d+)",
-            r"exit status\s+(\d+)",
-            r"returned non-zero exit status\s+(\d+)",
-            r"Command failed with exit code\s+(\d+)",
-        ]
-        for pattern in patterns:
+        for pattern in self._EXIT_CODE_PATTERNS:
             match = re.search(pattern, combined, re.IGNORECASE)
             if match:
                 exit_code = int(match.group(1))


### PR DESCRIPTION
## Summary
Resolves #1023

Extract the duplicated 5-element exit code regex list into a single class-level constant `_EXIT_CODE_PATTERNS`, keeping it consistent with the existing pattern of class-level constants (`_EXIT_CODE_MAP`, `_CRASH_EXIT_CODES`, etc.).

## Changes Made
- Add `_EXIT_CODE_PATTERNS` class constant to `ClaudeSDK` (placed after `_SETUP_EXIT_CODES`)
- Replace Phase 1.5 `stale_patterns` local list + reference with `self._EXIT_CODE_PATTERNS`
- Replace Phase 2 `patterns` local list + reference with `self._EXIT_CODE_PATTERNS`

## Testing
- `uv run ruff check --fix src/claude_sdk.py` — zero violations
- `uv run pytest src/tests/ -v` — no regressions (no existing tests target this code path)
- Visual verification that constant contents match original lists character-for-character

🤖 Generated with [Claude Code](https://claude.com/claude-code)