### PR TITLE
feat: allow permission mode changes on stopped sessions

### DIFF
--- a/frontend/src/components/configuration/QuickSettingsPanel.vue
+++ b/frontend/src/components/configuration/QuickSettingsPanel.vue
@@ -253,9 +253,7 @@ const isSessionActive = computed(() => {
   return props.session?.state === 'active' || props.session?.state === 'starting'
 })
 
-const permDisabled = computed(() => {
-  return isEditSession.value && !isSessionActive.value
-})
+const permDisabled = computed(() => false)
 
 const canUseBypassPermissions = computed(() => {
   return props.session?.initial_permission_mode === 'bypassPermissions'

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -1765,19 +1765,25 @@ class SessionCoordinator:
                 logger.error(f"Invalid permission mode: {mode}")
                 return False
 
-            # Check if SDK exists and is active
-            sdk = self._active_sdks.get(session_id)
-            if not sdk:
-                logger.warning(f"No active SDK found for session {session_id} - cannot set permission mode")
-                return False
-
             # Check session state
             session_info = await self.session_manager.get_session_info(session_id)
             if not session_info:
                 logger.warning(f"Session {session_id} not found - cannot set permission mode")
                 return False
 
-            # Only allow permission mode change for active sessions
+            # For non-running sessions, just persist to disk — the mode will be applied at startup
+            if session_info.state in [SessionState.CREATED, SessionState.TERMINATED, SessionState.ERROR]:
+                await self.session_manager.update_permission_mode(session_id, mode)
+                coord_logger.info(f"Permission mode persisted to '{mode}' for stopped session {session_id}")
+                return True
+
+            # Check if SDK exists for live update
+            sdk = self._active_sdks.get(session_id)
+            if not sdk:
+                logger.warning(f"No active SDK found for session {session_id} - cannot set permission mode")
+                return False
+
+            # Only allow live permission mode change for active sessions
             if session_info.state not in [SessionState.ACTIVE]:
                 logger.warning(f"Session {session_id} not in active state (state: {session_info.state})")
                 return False

--- a/src/tests/integration/test_api_sessions_lifecycle.py
+++ b/src/tests/integration/test_api_sessions_lifecycle.py
@@ -89,7 +89,7 @@ class TestDisconnectSession:
 
 class TestPermissionMode:
     async def test_set_permission_mode_on_created_session(self, api_integration_env):
-        """Setting permission mode on a non-active session returns 400."""
+        """Setting permission mode on a non-active (created) session persists the mode."""
         client = api_integration_env["client"]
         session = await _create_named_session(api_integration_env, "single_turn")
         sid = session["session_id"]
@@ -98,8 +98,12 @@ class TestPermissionMode:
             f"/api/sessions/{sid}/permission-mode",
             json={"mode": "bypassPermissions"},
         )
-        # Session must be active to change permission mode
-        assert resp.status_code == 400
+        # Non-running sessions can have their permission mode changed (persisted to disk)
+        assert resp.status_code == 200
+        # Verify the mode is reflected in the session state
+        session_resp = await client.get(f"/api/sessions/{sid}")
+        assert session_resp.status_code == 200
+        assert session_resp.json()["session"]["current_permission_mode"] == "bypassPermissions"
 
     async def test_set_permission_mode_invalid(self, api_integration_env):
         client = api_integration_env["client"]


### PR DESCRIPTION
## Summary
Resolves #1030

Allow users to configure a session's permission mode before starting it. The chosen mode is persisted to disk and applied automatically when the session is started via `ClaudeAgentOptions`.

## Changes Made
- **Backend** (`src/session_coordinator.py`): `set_permission_mode()` now handles CREATED, TERMINATED, and ERROR sessions by persisting the mode to disk without requiring an active SDK. Live mid-session mode changes for ACTIVE sessions are unchanged.
- **Frontend** (`frontend/src/components/configuration/QuickSettingsPanel.vue`): Removed the gate that disabled permission mode buttons when the session was not active/starting. Users can now select any permission mode in the edit modal regardless of session state.
- **Test** (`src/tests/integration/test_api_sessions_lifecycle.py`): Updated integration test to assert the new correct behavior (200 response + mode persisted) for permission mode changes on created sessions.

## Testing
- Unit/integration tests pass (885 passed; 1 pre-existing unrelated failure in `test_legion_mcp_tools`)
- Backend: `http://localhost:8030/?token=test`
- Frontend: `http://localhost:5030/?token=test`

Manual test scenarios:
1. Create a session → open edit modal → change permission mode → start session → verify session starts in selected mode
2. Terminate a session → open edit modal → change permission mode → restart → verify new mode applied
3. Change permission mode on an active session → verify live SDK update still works (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)