### PR TITLE
fix: block message input during pending permission prompt

### DIFF
--- a/frontend/src/components/messages/InputArea.vue
+++ b/frontend/src/components/messages/InputArea.vue
@@ -103,7 +103,7 @@
       <button
         v-else-if="isProcessing && hasContent"
         class="btn btn-info"
-        :disabled="!isConnected || isStarting || isUploading"
+        :disabled="!isConnected || isStarting || isUploading || isPaused"
         title="Send while processing (doesn't interrupt)"
         @click="sendMessage"
       >
@@ -114,7 +114,7 @@
       <button
         v-else
         class="btn btn-primary"
-        :disabled="!hasContent || !isConnected || isStarting || isUploading"
+        :disabled="!hasContent || !isConnected || isStarting || isUploading || isPaused"
         @click="sendMessage"
       >
         {{ isUploading ? 'Uploading...' : 'Send' }}
@@ -183,6 +183,7 @@ const inputText = computed({
 const isProcessing = computed(() => sessionStore.currentSession?.is_processing || false)
 const isConnected = computed(() => wsStore.sessionConnected)
 const isStarting = computed(() => sessionStore.currentSession?.state === 'starting')
+const isPaused = computed(() => sessionStore.currentSession?.state === 'paused')
 const currentSessionId = computed(() => sessionStore.currentSessionId)
 
 // Check if input has content (text or valid attachments)
@@ -192,6 +193,9 @@ const hasContent = computed(() => !!inputText.value.trim() || attachments.value.
 const isMobile = computed(() => windowWidth.value < 768)
 
 const inputPlaceholder = computed(() => {
+  if (isPaused.value) {
+    return 'Respond to the permission prompt first...'
+  }
   if (isStarting.value) {
     return 'Session is starting...'
   }
@@ -531,6 +535,8 @@ async function uploadAllFiles() {
  * Send message with attachments
  */
 async function sendMessage() {
+  if (isPaused.value) return
+
   // Intercept /clear command before normal send path
   if (inputText.value.trim() === '/clear') {
     await executeClearCommand()

--- a/frontend/src/stores/websocket.js
+++ b/frontend/src/stores/websocket.js
@@ -230,7 +230,11 @@ export const useWebSocketStore = defineStore('websocket', () => {
         })
       }, 2000)
     } catch (err) {
-      console.error('Failed to send message:', err)
+      if (err.response?.status === 409) {
+        console.warn('Message rejected: session is not active (permission pending?)')
+      } else {
+        console.error('Failed to send message:', err)
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
Resolves #1034

Block the message input area when a session is PAUSED (pending permission prompt), preventing messages from being silently lost with an HTTP 409 error.

## Changes Made
- Add `isPaused` computed property in `InputArea.vue` (checks `session.state === 'paused'`)
- Update `inputPlaceholder` to show "Respond to the permission prompt first..." when paused
- Disable Send and Queue buttons while `isPaused` is true
- Add early-return guard in `sendMessage()` when paused
- Improve 409 error logging in `websocket.js` with a targeted `console.warn`

## Testing
- Start a session in `default` permission mode
- Trigger a permission prompt (e.g., invoke an Edit tool)
- Verify: Send button is disabled and placeholder text shows "Respond to the permission prompt first..."
- Verify: Typed text is preserved in the input field
- Approve or deny the permission — verify input re-enables immediately and typed text remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)