### PR TITLE
fix: simplify review fixes from PRs #1031 #1032 #1036

### DIFF
--- a/frontend/src/components/configuration/QuickSettingsPanel.vue
+++ b/frontend/src/components/configuration/QuickSettingsPanel.vue
@@ -114,9 +114,6 @@
           @click="setPermissionMode('bypassPermissions')"
         >Bypass</button>
       </div>
-      <div v-if="permDisabled" class="form-text text-warning" style="text-transform: none; letter-spacing: normal;">
-        Session must be active to change permission mode.
-      </div>
     </div>
 
     <!-- Role -->

--- a/frontend/src/stores/websocket.js
+++ b/frontend/src/stores/websocket.js
@@ -230,7 +230,7 @@ export const useWebSocketStore = defineStore('websocket', () => {
         })
       }, 2000)
     } catch (err) {
-      if (err.response?.status === 409) {
+      if (err.status === 409) {
         console.warn('Message rejected: session is not active (permission pending?)')
       } else {
         console.error('Failed to send message:', err)

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -1755,7 +1755,7 @@ class SessionCoordinator:
                 return False
 
             # For non-running sessions, just persist to disk — the mode will be applied at startup
-            if session_info.state in [SessionState.CREATED, SessionState.TERMINATED, SessionState.ERROR]:
+            if session_info.state in [SessionState.CREATED, SessionState.PAUSED, SessionState.TERMINATED, SessionState.ERROR]:
                 await self.session_manager.update_permission_mode(session_id, mode)
                 coord_logger.info(f"Permission mode persisted to '{mode}' for stopped session {session_id}")
                 return True
@@ -1767,7 +1767,7 @@ class SessionCoordinator:
                 return False
 
             # Only allow live permission mode change for active sessions
-            if session_info.state not in [SessionState.ACTIVE]:
+            if session_info.state != SessionState.ACTIVE:
                 logger.warning(f"Session {session_id} not in active state (state: {session_info.state})")
                 return False
 
@@ -3526,7 +3526,7 @@ class SessionCoordinator:
                         logger.exception(f"Failed to set processing state for session {session_id}")
 
                 # Reset processing state on interrupt_success
-                if parsed_message.type.value == 'system' and parsed_message.metadata.get('subtype') == 'interrupt_success':
+                elif parsed_message.type.value == 'system' and parsed_message.metadata.get('subtype') == 'interrupt_success':
                     try:
                         await self.session_manager.update_processing_state(session_id, False)
                         coord_logger.info(f"Reset processing state for session {session_id} after interrupt")


### PR DESCRIPTION
## Summary

- **websocket.js**: Fix 409 detection — `err.response?.status` → `err.status`. The `APIError` class exposes `.status` directly; the permission-pending console hint was never firing.
- **session_coordinator**: Add `SessionState.PAUSED` to the persist-only branch of `set_permission_mode()`. PAUSED sessions (awaiting a permission prompt) silently returned `False`, so changing permission mode during an active prompt was rejected without feedback.
- **session_coordinator**: `not in [SessionState.ACTIVE]` → `!= SessionState.ACTIVE` (single-element list → direct comparison).
- **session_coordinator**: `interrupt_success` branch changed from `if` to `elif` — no functional overlap with `result`/`assistant` types, but the `if` implied possible double-execution and was misleading.
- **QuickSettingsPanel.vue**: Remove dead `v-if="permDisabled"` warning block. `permDisabled` is always `false` after #1031; the stale text ("Session must be active to change permission mode") contradicted the PR's intent.

## Test plan

- [ ] Verify permission mode change on a paused session (active permission prompt) now persists correctly and returns 200
- [ ] Verify 409 console warning fires when a message is sent to a non-active session
- [ ] Verify QuickSettingsPanel no longer shows the stale warning text in any session state
- [ ] Run `uv run pytest src/tests/ -v` — all existing tests should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)