### PR TITLE
fix: update_sdk_generated_name returns True when name unchanged

### DIFF
--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -689,7 +689,7 @@ class SessionManager:
                 if not session:
                     return False
                 if session.sdk_generated_name == sdk_name:
-                    return False  # No change
+                    return True  # No change needed — idempotent success
                 session.sdk_generated_name = sdk_name
                 session.updated_at = datetime.now(UTC)
                 await self._persist_session_state(session_id)


### PR DESCRIPTION
## Summary
Resolves #1041

`update_sdk_generated_name()` returned `False` on the no-change path, inconsistent with other update methods that return `True` for idempotent no-ops.

## Changes Made
- `src/session_manager.py`: Changed `return False` to `return True` when `sdk_generated_name` already equals the requested value

## Testing
- `uv run ruff check src/session_manager.py` — no violations
- `uv run pytest src/tests/ -v -k session_manager` — 23 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)