### PR TITLE
refactor: define named SessionState group constants to replace inline literals

### DIFF
--- a/src/claude_sdk.py
+++ b/src/claude_sdk.py
@@ -80,6 +80,12 @@ class SessionState(Enum):
     TERMINATED = "terminated"
 
 
+# Named SessionState groupings — update these when adding new states
+SDK_ACTIVE_STATES: frozenset[SessionState] = frozenset({
+    SessionState.RUNNING, SessionState.PROCESSING,
+})
+
+
 class SDKErrorDetectionHandler(logging.Handler):
     """Custom log handler to detect immediate SDK CLI failures."""
 
@@ -411,7 +417,7 @@ class ClaudeSDK:
                 return False
 
             # Check if we're in a state that can be interrupted
-            if self.info.state not in [SessionState.RUNNING, SessionState.PROCESSING]:
+            if self.info.state not in SDK_ACTIVE_STATES:
                 sdk_logger.debug(f"Session {self.session_id} not in interruptible state: {self.info.state}")
                 return False
 
@@ -468,7 +474,7 @@ class ClaudeSDK:
                 return False
 
             # Check if we're in a valid state
-            if self.info.state not in [SessionState.RUNNING, SessionState.PROCESSING]:
+            if self.info.state not in SDK_ACTIVE_STATES:
                 logger.warning(f"Session {self.session_id} not in valid state for permission mode change: {self.info.state}")
                 return False
 
@@ -494,7 +500,7 @@ class ClaudeSDK:
                 logger.warning(f"No active SDK client for session {self.session_id} - cannot get MCP status")
                 return {"servers": []}
 
-            if self.info.state not in [SessionState.RUNNING, SessionState.PROCESSING]:
+            if self.info.state not in SDK_ACTIVE_STATES:
                 logger.warning(f"Session {self.session_id} not in valid state for MCP status: {self.info.state}")
                 return {"servers": []}
 
@@ -510,7 +516,7 @@ class ClaudeSDK:
             if not self._sdk_client:
                 logger.warning(f"No active SDK client for session {self.session_id}")
                 return {}
-            if self.info.state not in [SessionState.RUNNING, SessionState.PROCESSING]:
+            if self.info.state not in SDK_ACTIVE_STATES:
                 return {}
             result = await self._sdk_client.get_context_usage()
             return dict(result)
@@ -523,7 +529,7 @@ class ClaudeSDK:
         if not self._sdk_client:
             raise RuntimeError(f"No active SDK client for session {self.session_id}")
 
-        if self.info.state not in [SessionState.RUNNING, SessionState.PROCESSING]:
+        if self.info.state not in SDK_ACTIVE_STATES:
             raise RuntimeError(f"Session not in valid state for MCP toggle: {self.info.state}")
 
         await self._sdk_client.toggle_mcp_server(name, enabled)
@@ -533,7 +539,7 @@ class ClaudeSDK:
         if not self._sdk_client:
             raise RuntimeError(f"No active SDK client for session {self.session_id}")
 
-        if self.info.state not in [SessionState.RUNNING, SessionState.PROCESSING]:
+        if self.info.state not in SDK_ACTIVE_STATES:
             raise RuntimeError(f"Session not in valid state for MCP reconnect: {self.info.state}")
 
         await self._sdk_client.reconnect_mcp_server(name)
@@ -1424,7 +1430,7 @@ class ClaudeSDK:
 
     def is_running(self) -> bool:
         """Check if the session is currently running."""
-        return self.info.state in [SessionState.RUNNING, SessionState.PROCESSING]
+        return self.info.state in SDK_ACTIVE_STATES
 
     async def wait_until_ready(self, timeout: float = 60.0) -> bool:
         """Wait until SDK is ready to accept messages. Returns False on timeout."""
@@ -1475,7 +1481,7 @@ class ClaudeSDK:
             health_status["context_manager_active"] and
             health_status["client_object_valid"] and
             not health_status["shutdown_event_set"] and
-            self.info.state in [SessionState.RUNNING, SessionState.PROCESSING]
+            self.info.state in SDK_ACTIVE_STATES
         )
 
         health_status["overall_health"] = "healthy" if is_healthy else "unhealthy"

--- a/src/mock_sdk.py
+++ b/src/mock_sdk.py
@@ -21,7 +21,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
-from .claude_sdk import SessionInfo, SessionState
+from .claude_sdk import SDK_ACTIVE_STATES, SessionInfo, SessionState
 
 logger = logging.getLogger(__name__)
 
@@ -797,7 +797,7 @@ class MockClaudeSDK:
 
     def is_running(self) -> bool:
         """Check if mock session is running."""
-        return self.info.state in (SessionState.RUNNING, SessionState.PROCESSING)
+        return self.info.state in SDK_ACTIVE_STATES
 
     async def _safe_callback(self, callback, *args):
         """Safely execute a callback."""

--- a/src/queue_processor.py
+++ b/src/queue_processor.py
@@ -11,7 +11,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from .logging_config import get_logger
-from .session_manager import SessionState
+from .session_manager import AUTO_START_STATES, SessionState
 
 if TYPE_CHECKING:
     from .session_coordinator import SessionCoordinator
@@ -142,7 +142,7 @@ class QueueProcessor:
                     break
 
                 # Auto-start session if needed
-                if session_info.state in (SessionState.CREATED, SessionState.TERMINATED):
+                if session_info.state in AUTO_START_STATES:
                     queue_proc_logger.info(f"Auto-starting session {session_id} for queue processing")
                     # Register WebSocket message callback so messages are broadcast to frontend
                     self._ensure_message_callback(session_id)

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -42,7 +42,7 @@ from .project_manager import ProjectInfo, ProjectManager
 from .queue_manager import QueueManager
 from .queue_processor import QueueProcessor
 from .session_config import SessionConfig
-from .session_manager import SessionManager, SessionState
+from .session_manager import STOPPED_STATES, SessionManager, SessionState
 from .task_utils import task_done_log_exception
 from .timestamp_utils import get_unix_timestamp
 
@@ -1755,7 +1755,7 @@ class SessionCoordinator:
                 return False
 
             # For non-running sessions, just persist to disk — the mode will be applied at startup
-            if session_info.state in [SessionState.CREATED, SessionState.PAUSED, SessionState.TERMINATED, SessionState.ERROR]:
+            if session_info.state in STOPPED_STATES:
                 await self.session_manager.update_permission_mode(session_id, mode)
                 coord_logger.info(f"Permission mode persisted to '{mode}' for stopped session {session_id}")
                 return True

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -68,6 +68,22 @@ class SessionState(Enum):
     ERROR = "error"
 
 
+# Named SessionState groupings — update these when adding new states
+STOPPED_STATES: frozenset[SessionState] = frozenset({
+    SessionState.CREATED, SessionState.PAUSED,
+    SessionState.TERMINATED, SessionState.ERROR,
+})
+STARTABLE_STATES: frozenset[SessionState] = frozenset({
+    SessionState.CREATED, SessionState.PAUSED, SessionState.TERMINATED,
+})
+RUNNABLE_STATES: frozenset[SessionState] = frozenset({
+    SessionState.ACTIVE, SessionState.STARTING,
+})
+AUTO_START_STATES: frozenset[SessionState] = frozenset({
+    SessionState.CREATED, SessionState.TERMINATED,
+})
+
+
 @dataclass
 class SessionInfo:
     """Session metadata and state information (all sessions are minions - issue #349)"""
@@ -291,7 +307,7 @@ class SessionManager:
                             original_processing = session_info.is_processing
                             state_changed = False
 
-                            if session_info.state in [SessionState.ACTIVE, SessionState.STARTING]:
+                            if session_info.state in RUNNABLE_STATES:
                                 session_info.state = SessionState.CREATED
                                 session_info.updated_at = datetime.now(UTC)
                                 state_changed = True
@@ -450,7 +466,7 @@ class SessionManager:
                     logger.error(f"Session {session_id} not found")
                     return False
 
-                if session.state not in [SessionState.CREATED, SessionState.PAUSED, SessionState.TERMINATED]:
+                if session.state not in STARTABLE_STATES:
                     session_logger.warning(f"Cannot start session {session_id} in state {session.state}")
                     return False
 


### PR DESCRIPTION
## Summary
Resolves #1042

Define named `frozenset` constants for repeated `SessionState` membership groups, replacing 13 inline literals across 5 files with descriptive named constants.

## Changes Made
- `src/session_manager.py`: Define `STOPPED_STATES`, `STARTABLE_STATES`, `RUNNABLE_STATES`, `AUTO_START_STATES` adjacent to `SessionState` enum; replace 2 inline literals
- `src/claude_sdk.py`: Define `SDK_ACTIVE_STATES` adjacent to its `SessionState` enum; replace 8 inline literals
- `src/session_coordinator.py`: Import `STOPPED_STATES`, replace 1 inline literal
- `src/queue_processor.py`: Import `AUTO_START_STATES`, replace 1 inline literal
- `src/mock_sdk.py`: Import `SDK_ACTIVE_STATES`, replace 1 inline literal

## Testing
- `uv run ruff check src/` — zero violations
- `uv run pytest src/tests/ -v` — 885 passed, 1 pre-existing failure unrelated to this change (`test_issue_824_tmp_path_translated_for_docker_session` — MagicMock await issue present on main before this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)