### PR TITLE
feat: proxy container for agent network isolation and traffic inspection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,6 @@ test_data_*/
 
 # Workstrees
 worktrees/
+
+# Proxy CA certificates (private key must not be committed)
+src/docker/proxy/certs/

--- a/src/docker/proxy/Corefile
+++ b/src/docker/proxy/Corefile
@@ -1,0 +1,36 @@
+# Allowlisted domains — forward to upstream
+api.github.com {
+    forward . 8.8.8.8 8.8.4.4
+    log
+}
+
+github.com {
+    forward . 8.8.8.8 8.8.4.4
+    log
+}
+
+registry.npmjs.org {
+    forward . 8.8.8.8 8.8.4.4
+    log
+}
+
+pypi.org {
+    forward . 8.8.8.8 8.8.4.4
+    log
+}
+
+files.pythonhosted.org {
+    forward . 8.8.8.8 8.8.4.4
+    log
+}
+
+# Default: deny everything else
+. {
+    template IN A {
+        rcode NXDOMAIN
+    }
+    template IN AAAA {
+        rcode NXDOMAIN
+    }
+    log
+}

--- a/src/docker/proxy/Dockerfile
+++ b/src/docker/proxy/Dockerfile
@@ -42,8 +42,10 @@ COPY addon.py /etc/proxy/addon.py
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-# CA cert output directory (mounted as volume at runtime)
-VOLUME /root/.mitmproxy
+# CA cert output directory — outside /root/ so uid 9999 can traverse to it.
+# /root/ is mode 700; any path under it is unreachable by non-root users.
+RUN mkdir -p /var/lib/mitmproxy && chown 9999:9999 /var/lib/mitmproxy
+VOLUME /var/lib/mitmproxy
 
 # mitmdump: transparent HTTP/HTTPS (single port handles both)
 EXPOSE 8080

--- a/src/docker/proxy/Dockerfile
+++ b/src/docker/proxy/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     iptables \
     iproute2 \
     util-linux \
+    libcap2-bin \
     curl \
     jq \
     ca-certificates \
@@ -21,11 +22,18 @@ RUN pipx install mitmproxy
 # to exclude mitmdump's upstream connections from TPROXY re-interception loop.
 RUN useradd -r -u 9999 -s /bin/false mitmproxy
 
+# Dedicated non-root user for CoreDNS; UID 9998 exempted in UDP default-deny
+# so CoreDNS can make upstream UDP DNS queries (e.g. to 8.8.8.8).
+# setcap grants cap_net_bind_service on the binary so it can bind :53 as
+# a non-root user without needing ambient capabilities at runtime.
+RUN useradd -r -u 9998 -s /bin/false coredns
+
 # Install CoreDNS
 ARG COREDNS_VERSION=1.12.1
 RUN curl -fsSL "https://github.com/coredns/coredns/releases/download/v${COREDNS_VERSION}/coredns_${COREDNS_VERSION}_linux_amd64.tgz" \
     | tar -xz -C /usr/local/bin/ \
-    && chmod +x /usr/local/bin/coredns
+    && chmod +x /usr/local/bin/coredns \
+    && setcap cap_net_bind_service=+ep /usr/local/bin/coredns
 
 # Copy configuration
 COPY allowlist.json /etc/proxy/allowlist.json

--- a/src/docker/proxy/Dockerfile
+++ b/src/docker/proxy/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     iproute2 \
     util-linux \
     libcap2-bin \
+    procps \
     curl \
     jq \
     ca-certificates \

--- a/src/docker/proxy/Dockerfile
+++ b/src/docker/proxy/Dockerfile
@@ -1,0 +1,38 @@
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    python3-pip \
+    pipx \
+    iptables \
+    curl \
+    jq \
+    ca-certificates \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install mitmproxy via pipx (isolated, no system conflicts)
+RUN pipx install mitmproxy && pipx ensurepath
+ENV PATH="/root/.local/bin:${PATH}"
+
+# Install CoreDNS
+ARG COREDNS_VERSION=1.12.1
+RUN curl -fsSL "https://github.com/coredns/coredns/releases/download/v${COREDNS_VERSION}/coredns_${COREDNS_VERSION}_linux_amd64.tgz" \
+    | tar -xz -C /usr/local/bin/ \
+    && chmod +x /usr/local/bin/coredns
+
+# Copy configuration
+COPY allowlist.json /etc/proxy/allowlist.json
+COPY Corefile /etc/coredns/Corefile
+COPY addon.py /etc/proxy/addon.py
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# CA cert output directory (mounted as volume at runtime)
+VOLUME /root/.mitmproxy
+
+# mitmdump: transparent HTTP/HTTPS (single port handles both)
+EXPOSE 8080
+# CoreDNS
+EXPOSE 53/udp 53/tcp
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/src/docker/proxy/Dockerfile
+++ b/src/docker/proxy/Dockerfile
@@ -5,14 +5,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-pip \
     pipx \
     iptables \
+    iproute2 \
+    util-linux \
     curl \
     jq \
     ca-certificates \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install mitmproxy via pipx (isolated, no system conflicts)
-RUN pipx install mitmproxy && pipx ensurepath
-ENV PATH="/root/.local/bin:${PATH}"
+# Install mitmproxy system-wide so uid 9999 can execute mitmdump
+ENV PIPX_HOME=/opt/pipx
+ENV PIPX_BIN_DIR=/usr/local/bin
+RUN pipx install mitmproxy
+
+# Dedicated non-root user for mitmdump; UID 9999 used in iptables owner match
+# to exclude mitmdump's upstream connections from TPROXY re-interception loop.
+RUN useradd -r -u 9999 -s /bin/false mitmproxy
 
 # Install CoreDNS
 ARG COREDNS_VERSION=1.12.1

--- a/src/docker/proxy/addon.py
+++ b/src/docker/proxy/addon.py
@@ -1,0 +1,41 @@
+import json
+import logging
+from pathlib import Path
+from mitmproxy import http, ctx
+
+ALLOWLIST_PATH = "/etc/proxy/allowlist.json"
+
+
+class DomainFilter:
+    def __init__(self):
+        self.allowed_domains: set[str] = set()
+        self.logger = logging.getLogger("proxy.filter")
+
+    def load(self, loader):
+        data = json.loads(Path(ALLOWLIST_PATH).read_text())
+        self.allowed_domains = set(data.get("domains", []))
+        ctx.log.info(f"Loaded {len(self.allowed_domains)} allowed domains")
+
+    def _is_allowed(self, host: str) -> bool:
+        # Exact match or subdomain match
+        for domain in self.allowed_domains:
+            if host == domain or host.endswith("." + domain):
+                return True
+        return False
+
+    def request(self, flow: http.HTTPFlow) -> None:
+        host = flow.request.pretty_host
+        client_ip = flow.client_conn.peername[0] if flow.client_conn.peername else "unknown"
+
+        if self._is_allowed(host):
+            ctx.log.info(f"ALLOW {client_ip} -> {host}{flow.request.path}")
+        else:
+            ctx.log.warn(f"DENY {client_ip} -> {host}{flow.request.path}")
+            flow.response = http.Response.make(
+                403,
+                json.dumps({"error": "domain_blocked", "domain": host}),
+                {"Content-Type": "application/json"},
+            )
+
+
+addons = [DomainFilter()]

--- a/src/docker/proxy/allowlist.json
+++ b/src/docker/proxy/allowlist.json
@@ -1,0 +1,9 @@
+{
+  "domains": [
+    "api.github.com",
+    "github.com",
+    "registry.npmjs.org",
+    "pypi.org",
+    "files.pythonhosted.org"
+  ]
+}

--- a/src/docker/proxy/entrypoint.sh
+++ b/src/docker/proxy/entrypoint.sh
@@ -61,8 +61,13 @@ fi
 # --- Enable IP forwarding and NAT ---
 # Required to act as a gateway: forward packets from agent-net to internet
 # (bridge-net), and masquerade the source IP so return traffic routes back.
+# ip_forward is set via --sysctl net.ipv4.ip_forward=1 at docker run time;
+# the write below is a belt-and-suspenders attempt that may be a no-op if
+# /proc/sys is read-only (which is normal for non-privileged containers).
 echo "Enabling IP forwarding and NAT..."
-echo 1 > /proc/sys/net/ipv4/ip_forward
+echo 1 > /proc/sys/net/ipv4/ip_forward 2>/dev/null || true
+IP_FWD=$(cat /proc/sys/net/ipv4/ip_forward 2>/dev/null || echo "unknown")
+echo "ip_forward = $IP_FWD"
 iptables -t nat -A POSTROUTING -j MASQUERADE
 iptables -A FORWARD -j ACCEPT
 

--- a/src/docker/proxy/entrypoint.sh
+++ b/src/docker/proxy/entrypoint.sh
@@ -103,36 +103,41 @@ iptables -t nat -A OUTPUT -p tcp --dport 443 \
 # the 2B gap (raw IP + non-HTTP/HTTPS was previously unrestricted).
 #
 # Rule order:
-#   lo ACCEPT first: covers CoreDNS TCP fallback and TPROXY re-injection
-#                    (marked 80/443 packets route to lo before filter runs).
-#   uid 9999 ACCEPT: mitmdump upstream connections exit freely to internet.
-#   dport 80/443 ACCEPT: agent HTTP/HTTPS — caught by TPROXY, never reach wire.
-#   tcp DROP: everything else (port 22, raw-IP non-HTTP, etc.) is blocked.
+#   lo ACCEPT (all protocols): agent TCP port 80/443 is REDIRECT-ed to
+#     127.0.0.1:8080 by nat OUTPUT before filter runs, so the output
+#     interface becomes lo. This rule catches all redirected agent traffic
+#     and all mitmdump→agent reply traffic.
+#   ! -o lo dport 80 ACCEPT: mitmdump upstream HTTP connections.
+#     Safe: agent port 80 is always redirected to lo first, so agent traffic
+#     never reaches this rule. Only mitmdump (excluded from nat REDIRECT via
+#     ! --uid-owner 9999) sends port 80 on the bridge interface.
+#   ! -o lo dport 443 ACCEPT: same as above for HTTPS.
+#   ! -o lo dport 53 uid 9998 ACCEPT: CoreDNS TCP upstream (DNS-over-TCP
+#     fallback to 8.8.8.8). CoreDNS port 53 TCP goes to the bridge interface
+#     (not lo). uid-owner 9998 match works for CoreDNS (verified by UDP counts).
+#   tcp DROP: everything else (agent TCP to port 22, arbitrary ports, etc.).
 #
-# To add a future protocol proxy (sshpiper uid 9998, SOCKS uid 9997, etc.),
-# insert an additional uid ACCEPT rule before the final DROP.
+# Note: -m owner --uid-owner 9999 is intentionally NOT used here because
+# iptables owner match does not reliably match PID 1 connections created by
+# exec setpriv; using ! -o lo + dport-based rules achieves the same security
+# guarantee without relying on uid matching for mitmproxy.
 echo "Configuring default-deny TCP OUTPUT..."
-# nat OUTPUT REDIRECT fires before filter OUTPUT. After REDIRECT rewrites the
-# destination to 127.0.0.1:8080, the routing decision picks lo, so filter
-# OUTPUT sees -o lo and ACCEPTs. The explicit dport 80/443 rules below are
-# therefore redundant but kept as documentation of intent.
 iptables -A OUTPUT -o lo -j ACCEPT
-iptables -A OUTPUT -p tcp -m owner --uid-owner 9999 -j ACCEPT
-iptables -A OUTPUT -p tcp --dport 80 -j ACCEPT
-iptables -A OUTPUT -p tcp --dport 443 -j ACCEPT
+iptables -A OUTPUT ! -o lo -p tcp --dport 80 -j ACCEPT
+iptables -A OUTPUT ! -o lo -p tcp --dport 443 -j ACCEPT
+iptables -A OUTPUT ! -o lo -p tcp --dport 53 -m owner --uid-owner 9998 -j ACCEPT
 iptables -A OUTPUT -p tcp -j DROP
 
 # --- Default-deny UDP OUTPUT ---
-# Same pattern as TCP: loopback always allowed, then per-service UID exemptions,
-# then drop everything else. This blocks DNS exfiltration to external resolvers
-# (e.g. nc/nslookup directly to 1.1.1.1:53) and any other UDP to raw IPs.
+# Block all UDP from non-proxy processes. This prevents DNS exfiltration via
+# direct UDP queries to external resolvers (e.g. nslookup 1.1.1.1) and any
+# other raw-IP UDP protocol bypasses.
 #
-# uid 9998 (CoreDNS) must be exempted so it can forward DNS queries upstream
-# to 8.8.8.8. uid 9999 (mitmdump) exempted for any internal UDP it may use.
+# uid 9998 (CoreDNS) exempted so it can forward UDP DNS queries upstream to
+# 8.8.8.8. All other UDP (from agents or system) is dropped.
 #
 # To add future protocol proxies: insert uid ACCEPT before the DROP.
 echo "Configuring default-deny UDP OUTPUT..."
-iptables -A OUTPUT -p udp -m owner --uid-owner 9999 -j ACCEPT
 iptables -A OUTPUT -p udp -m owner --uid-owner 9998 -j ACCEPT
 iptables -A OUTPUT -p udp -j DROP
 

--- a/src/docker/proxy/entrypoint.sh
+++ b/src/docker/proxy/entrypoint.sh
@@ -41,8 +41,12 @@ CATCHALL
 echo "Corefile generated with $(echo "$DOMAINS" | wc -w) domains"
 
 # --- Start CoreDNS in background ---
+# Run as uid 9998 so the UDP default-deny OUTPUT rule can exempt it.
+# cap_net_bind_service is set on the binary via setcap (Dockerfile), allowing
+# it to bind :53 without root.
 echo "Starting CoreDNS on :53..."
-coredns -conf "$COREFILE" -dns.port 53 &
+setpriv --reuid=9998 --regid=9998 --clear-groups -- \
+    coredns -conf "$COREFILE" -dns.port 53 &
 COREDNS_PID=$!
 
 # --- Generate CA cert if not present ---
@@ -108,6 +112,20 @@ iptables -A OUTPUT -p tcp -m owner --uid-owner 9999 -j ACCEPT
 iptables -A OUTPUT -p tcp --dport 80 -j ACCEPT
 iptables -A OUTPUT -p tcp --dport 443 -j ACCEPT
 iptables -A OUTPUT -p tcp -j DROP
+
+# --- Default-deny UDP OUTPUT ---
+# Same pattern as TCP: loopback always allowed, then per-service UID exemptions,
+# then drop everything else. This blocks DNS exfiltration to external resolvers
+# (e.g. nc/nslookup directly to 1.1.1.1:53) and any other UDP to raw IPs.
+#
+# uid 9998 (CoreDNS) must be exempted so it can forward DNS queries upstream
+# to 8.8.8.8. uid 9999 (mitmdump) exempted for any internal UDP it may use.
+#
+# To add future protocol proxies: insert uid ACCEPT before the DROP.
+echo "Configuring default-deny UDP OUTPUT..."
+iptables -A OUTPUT -p udp -m owner --uid-owner 9999 -j ACCEPT
+iptables -A OUTPUT -p udp -m owner --uid-owner 9998 -j ACCEPT
+iptables -A OUTPUT -p udp -j DROP
 
 # --- Start mitmdump in TPROXY mode as uid 9999 ---
 # setpriv drops to uid/gid 9999 while preserving CAP_NET_ADMIN in the ambient

--- a/src/docker/proxy/entrypoint.sh
+++ b/src/docker/proxy/entrypoint.sh
@@ -99,8 +99,8 @@ fi
 # source is not reachable via lo. Disabling rp_filter on lo and all interfaces
 # allows these REDIRECT-ed packets through.
 echo "Disabling rp_filter for transparent proxy..."
-sysctl -w net.ipv4.conf.all.rp_filter=0 >/dev/null 2>&1
-sysctl -w net.ipv4.conf.lo.rp_filter=0 >/dev/null 2>&1
+sysctl -w net.ipv4.conf.all.rp_filter=0 >/dev/null 2>&1 || echo "  (sysctl failed — pass --sysctl net.ipv4.conf.all.rp_filter=0 to docker run)"
+sysctl -w net.ipv4.conf.lo.rp_filter=0 >/dev/null 2>&1 || true
 
 echo "Configuring transparent proxy iptables..."
 iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-port 8080

--- a/src/docker/proxy/entrypoint.sh
+++ b/src/docker/proxy/entrypoint.sh
@@ -90,6 +90,18 @@ fi
 # connections to the real internet are never re-intercepted (loop prevention).
 # mitmproxy --mode transparent uses SO_ORIGINAL_DST to recover the original
 # destination after REDIRECT. No policy routing or IP_TRANSPARENT needed.
+# --- Disable reverse-path filtering on loopback ---
+# nat OUTPUT REDIRECT rewrites external destinations (e.g. 140.82.114.6:443) to
+# 127.0.0.1:8080, causing the packet to be re-routed through lo. The packet
+# arrives on lo with its ORIGINAL source address (the container's bridge IP,
+# e.g. 172.18.0.2), which is NOT in 127.0.0.0/8. With rp_filter=1 (strict,
+# the Fedora/RHEL default), the kernel silently drops the packet because the
+# source is not reachable via lo. Disabling rp_filter on lo and all interfaces
+# allows these REDIRECT-ed packets through.
+echo "Disabling rp_filter for transparent proxy..."
+sysctl -w net.ipv4.conf.all.rp_filter=0 >/dev/null 2>&1
+sysctl -w net.ipv4.conf.lo.rp_filter=0 >/dev/null 2>&1
+
 echo "Configuring transparent proxy iptables..."
 iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-port 8080
 iptables -t nat -A PREROUTING -p tcp --dport 443 -j REDIRECT --to-port 8080

--- a/src/docker/proxy/entrypoint.sh
+++ b/src/docker/proxy/entrypoint.sh
@@ -65,13 +65,16 @@ echo "Configuring iptables for transparent proxy..."
 iptables -t nat -A PREROUTING -i eth0 -p tcp --dport 80 -j REDIRECT --to-port 8080
 iptables -t nat -A PREROUTING -i eth0 -p tcp --dport 443 -j REDIRECT --to-port 8080
 
-# --- Start mitmdump in transparent mode ---
+# --- Start mitmdump as explicit HTTP/HTTPS proxy ---
 # mitmdump is the headless version of mitmproxy (no interactive TUI).
-# Transparent mode on a single port handles both plain HTTP and TLS — it
-# detects TLS via the ClientHello and performs MITM interception automatically.
-echo "Starting mitmdump (transparent mode) on :8080..."
+# Default (regular) mode accepts explicit HTTP CONNECT proxy requests.
+# Agent containers set http_proxy/https_proxy env vars pointing to port 8080.
+# For HTTPS, mitmdump performs MITM via CONNECT interception + cert injection.
+# The iptables rules above additionally redirect any direct port 80/443 traffic
+# (e.g., from tools that bypass proxy env vars) to port 8080.
+echo "Starting mitmdump (explicit proxy mode) on :8080..."
 echo "Addon: /etc/proxy/addon.py"
-exec mitmdump --mode transparent --showhost \
+exec mitmdump --showhost \
     --set confdir="$CERTS_DIR" \
     --listen-port 8080 \
     --ssl-insecure \

--- a/src/docker/proxy/entrypoint.sh
+++ b/src/docker/proxy/entrypoint.sh
@@ -117,30 +117,42 @@ iptables -t mangle -A PREROUTING -p tcp --dport 443 \
 # Block all TCP from non-proxy processes on ports other than 80/443, closing
 # the raw-IP gap (non-HTTP/HTTPS TCP was previously unrestricted).
 #
+# CRITICAL ordering note: filter OUTPUT runs BEFORE the fwmark policy-routing
+# reroute. When mangle OUTPUT sets fwmark 1, the packet still has its original
+# output interface (eth0). The reroute to lo only happens AFTER all OUTPUT
+# hooks complete. Therefore, fwmark-1 packets must be explicitly accepted in
+# filter OUTPUT — they will NOT match the -o lo rule.
+#
 # Rule order:
-#   1. lo ACCEPT: covers TPROXY-redirected agent traffic (mangle OUTPUT marks
-#      it → policy routing sends to lo → filter sees -o lo → ACCEPT) and all
-#      inter-process loopback communication.
-#   2. ESTABLISHED,RELATED ACCEPT: allows TCP handshakes to complete and
+#   1. lo ACCEPT: inter-process loopback communication (CoreDNS, mitmdump
+#      return traffic, etc.).
+#   2. fwmark 1 ACCEPT: TPROXY-bound agent TCP 80/443. These packets were
+#      marked by mangle OUTPUT and will be rerouted to lo after filter, then
+#      TPROXY-ed in PREROUTING. Must pass filter first since the reroute
+#      hasn't happened yet (packet still shows -o eth0 at this point).
+#   3. ESTABLISHED,RELATED ACCEPT: allows TCP handshakes to complete and
 #      return traffic for established connections.
-#   3. uid 9999 NEW ACCEPT: mitmdump upstream connections to the real internet.
+#   4. uid 9999 NEW ACCEPT: mitmdump upstream connections to the real internet.
 #      Works because mitmdump is a child process (not PID 1); xt_owner uid
 #      matching is reliable for non-PID-1 processes.
-#   4. tcp NEW DROP: everything else (agent TCP to port 22, 8443, etc.).
-#      Agent TCP to 80/443 is safe: it's already marked and routed to lo
-#      by mangle OUTPUT, so it never reaches this rule.
+#   5. tcp NEW DROP: everything else (agent TCP to port 22, 8443, etc.).
 echo "Configuring default-deny TCP OUTPUT..."
 
-# 1. Allow all loopback traffic (TPROXY-marked agent traffic + inter-process comms).
+# 1. Allow all loopback traffic (inter-process comms).
 iptables -A OUTPUT -o lo -j ACCEPT
 
-# 2. Allow established/related traffic (TCP handshake completion, return traffic).
+# 2. Allow TPROXY-marked packets (fwmark 1) to pass filter before reroute.
+# These are agent TCP 80/443 that mangle OUTPUT marked; they'll be rerouted
+# to lo and TPROXY-ed in PREROUTING after filter OUTPUT completes.
+iptables -A OUTPUT -m mark --mark 1 -j ACCEPT
+
+# 3. Allow established/related traffic (TCP handshake completion, return traffic).
 iptables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 
-# 3. Allow mitmdump (uid 9999) to initiate new upstream connections.
+# 4. Allow mitmdump (uid 9999) to initiate new upstream connections.
 iptables -A OUTPUT -p tcp -m owner --uid-owner 9999 -m conntrack --ctstate NEW -j ACCEPT
 
-# 4. Drop all other new outbound TCP (port 22, 8443, arbitrary ports, etc.).
+# 5. Drop all other new outbound TCP (port 22, 8443, arbitrary ports, etc.).
 iptables -A OUTPUT -p tcp -m conntrack --ctstate NEW -j DROP
 
 # --- Default-deny UDP OUTPUT ---

--- a/src/docker/proxy/entrypoint.sh
+++ b/src/docker/proxy/entrypoint.sh
@@ -83,14 +83,16 @@ fi
 #   Loop prevention: mitmdump runs as uid 9999; the OUTPUT MARK rule has
 #                  ! --uid-owner 9999, so mitmdump's upstream connections
 #                  to the real internet are never re-marked and never looped.
-echo "Configuring TPROXY policy routing and iptables..."
+# Policy routing re-injects marked packets via loopback so they re-enter
+# PREROUTING. REDIRECT in the NAT table then catches them for mitmdump.
+# mitmproxy --mode transparent uses SO_ORIGINAL_DST to recover the original
+# destination after REDIRECT — no IP_TRANSPARENT socket binding required.
+echo "Configuring transparent proxy routing and iptables..."
 ip rule add fwmark 1 lookup 100 2>/dev/null || true
 ip route add local 0.0.0.0/0 dev lo table 100 2>/dev/null || true
 
-iptables -t mangle -A PREROUTING -p tcp --dport 80 -j TPROXY \
-    --tproxy-mark 1 --on-port 8080
-iptables -t mangle -A PREROUTING -p tcp --dport 443 -j TPROXY \
-    --tproxy-mark 1 --on-port 8080
+iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-port 8080
+iptables -t nat -A PREROUTING -p tcp --dport 443 -j REDIRECT --to-port 8080
 
 iptables -t mangle -A OUTPUT -p tcp --dport 80 \
     -m owner ! --uid-owner 9999 -j MARK --set-mark 1
@@ -131,17 +133,15 @@ iptables -A OUTPUT -p udp -m owner --uid-owner 9999 -j ACCEPT
 iptables -A OUTPUT -p udp -m owner --uid-owner 9998 -j ACCEPT
 iptables -A OUTPUT -p udp -j DROP
 
-# --- Start mitmdump in TPROXY mode as uid 9999 ---
-# setpriv drops to uid/gid 9999 while preserving CAP_NET_ADMIN in the ambient
-# capability set. CAP_NET_ADMIN is required for the IP_TRANSPARENT socket
-# option that TPROXY mode uses to bind on behalf of the original destination.
-# --inh-caps promotes cap_net_admin into the inheritable set first; Linux
-# requires a cap to be inheritable before it can be made ambient.
-echo "Starting mitmdump (tproxy mode) on :8080..."
+# --- Start mitmdump in transparent mode as uid 9999 ---
+# setpriv drops to uid/gid 9999. CAP_NET_ADMIN is not needed for
+# transparent mode (it uses SO_ORIGINAL_DST, not IP_TRANSPARENT).
+# Running as uid 9999 is what the OUTPUT MARK rule excludes, preventing
+# mitmdump's own upstream connections from being re-intercepted.
+echo "Starting mitmdump (transparent mode) on :8080..."
 echo "Addon: /etc/proxy/addon.py"
-exec setpriv --reuid=9999 --regid=9999 --clear-groups \
-    --inh-caps +net_admin --ambient-caps +net_admin -- \
-    mitmdump --mode tproxy --showhost \
+exec setpriv --reuid=9999 --regid=9999 --clear-groups -- \
+    mitmdump --mode transparent --showhost \
     --set confdir="$CERTS_DIR" \
     --listen-port 8080 \
     --ssl-insecure \

--- a/src/docker/proxy/entrypoint.sh
+++ b/src/docker/proxy/entrypoint.sh
@@ -53,7 +53,7 @@ COREDNS_PID=$!
 # The entrypoint starts as root; transfer ownership of the certs dir to
 # uid 9999 now so mitmdump can write (init) and read (tproxy mode) it.
 # chmod 755 lets the host user traverse the directory to read the public cert.
-chown 9999:9999 "$CERTS_DIR"
+chown -R 9999:9999 "$CERTS_DIR"
 chmod 755 "$CERTS_DIR"
 if [ ! -f "$CERTS_DIR/mitmproxy-ca-cert.pem" ]; then
     echo "Generating mitmproxy CA certificate..."

--- a/src/docker/proxy/entrypoint.sh
+++ b/src/docker/proxy/entrypoint.sh
@@ -59,22 +59,24 @@ else
 fi
 
 # --- Set up iptables for transparent proxying ---
-# Both ports redirect to 8080 — mitmdump transparent mode auto-detects TLS
-# by inspecting the ClientHello on the same listener port.
+# Redirect all TCP 80/443 arriving at any interface to mitmdump on :8080.
+# No -i restriction: the proxy container connects to multiple Docker networks
+# (bridge-net for internet egress, agent-net for agent traffic) and the
+# interface name for agent-net is not predictable at build time.
+# Agent containers route through the proxy as their default gateway, so their
+# traffic arrives at the proxy's agent-net interface and is caught here.
 echo "Configuring iptables for transparent proxy..."
-iptables -t nat -A PREROUTING -i eth0 -p tcp --dport 80 -j REDIRECT --to-port 8080
-iptables -t nat -A PREROUTING -i eth0 -p tcp --dport 443 -j REDIRECT --to-port 8080
+iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-port 8080
+iptables -t nat -A PREROUTING -p tcp --dport 443 -j REDIRECT --to-port 8080
 
-# --- Start mitmdump as explicit HTTP/HTTPS proxy ---
+# --- Start mitmdump in transparent mode ---
 # mitmdump is the headless version of mitmproxy (no interactive TUI).
-# Default (regular) mode accepts explicit HTTP CONNECT proxy requests.
-# Agent containers set http_proxy/https_proxy env vars pointing to port 8080.
-# For HTTPS, mitmdump performs MITM via CONNECT interception + cert injection.
-# The iptables rules above additionally redirect any direct port 80/443 traffic
-# (e.g., from tools that bypass proxy env vars) to port 8080.
-echo "Starting mitmdump (explicit proxy mode) on :8080..."
+# Transparent mode uses SO_ORIGINAL_DST to recover the original destination
+# after iptables REDIRECT has rewritten it, enabling MITM of all TCP 80/443
+# regardless of whether the client has proxy env vars set.
+echo "Starting mitmdump (transparent mode) on :8080..."
 echo "Addon: /etc/proxy/addon.py"
-exec mitmdump --showhost \
+exec mitmdump --mode transparent --showhost \
     --set confdir="$CERTS_DIR" \
     --listen-port 8080 \
     --ssl-insecure \

--- a/src/docker/proxy/entrypoint.sh
+++ b/src/docker/proxy/entrypoint.sh
@@ -83,21 +83,20 @@ fi
 #   Loop prevention: mitmdump runs as uid 9999; the OUTPUT MARK rule has
 #                  ! --uid-owner 9999, so mitmdump's upstream connections
 #                  to the real internet are never re-marked and never looped.
-# Policy routing re-injects marked packets via loopback so they re-enter
-# PREROUTING. REDIRECT in the NAT table then catches them for mitmdump.
+# PREROUTING: intercept TCP 80/443 arriving from outside this namespace.
+# OUTPUT: intercept TCP 80/443 generated locally (agent processes sharing
+#         this network namespace via --network container:<proxy>).
+# uid 9999 (mitmdump) is excluded from OUTPUT REDIRECT so its upstream
+# connections to the real internet are never re-intercepted (loop prevention).
 # mitmproxy --mode transparent uses SO_ORIGINAL_DST to recover the original
-# destination after REDIRECT — no IP_TRANSPARENT socket binding required.
-echo "Configuring transparent proxy routing and iptables..."
-ip rule add fwmark 1 lookup 100 2>/dev/null || true
-ip route add local 0.0.0.0/0 dev lo table 100 2>/dev/null || true
-
+# destination after REDIRECT. No policy routing or IP_TRANSPARENT needed.
+echo "Configuring transparent proxy iptables..."
 iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-port 8080
 iptables -t nat -A PREROUTING -p tcp --dport 443 -j REDIRECT --to-port 8080
-
-iptables -t mangle -A OUTPUT -p tcp --dport 80 \
-    -m owner ! --uid-owner 9999 -j MARK --set-mark 1
-iptables -t mangle -A OUTPUT -p tcp --dport 443 \
-    -m owner ! --uid-owner 9999 -j MARK --set-mark 1
+iptables -t nat -A OUTPUT -p tcp --dport 80 \
+    -m owner ! --uid-owner 9999 -j REDIRECT --to-port 8080
+iptables -t nat -A OUTPUT -p tcp --dport 443 \
+    -m owner ! --uid-owner 9999 -j REDIRECT --to-port 8080
 
 # --- Default-deny TCP OUTPUT ---
 # Block all TCP from non-proxy processes on ports other than 80/443, closing
@@ -113,6 +112,10 @@ iptables -t mangle -A OUTPUT -p tcp --dport 443 \
 # To add a future protocol proxy (sshpiper uid 9998, SOCKS uid 9997, etc.),
 # insert an additional uid ACCEPT rule before the final DROP.
 echo "Configuring default-deny TCP OUTPUT..."
+# nat OUTPUT REDIRECT fires before filter OUTPUT. After REDIRECT rewrites the
+# destination to 127.0.0.1:8080, the routing decision picks lo, so filter
+# OUTPUT sees -o lo and ACCEPTs. The explicit dport 80/443 rules below are
+# therefore redundant but kept as documentation of intent.
 iptables -A OUTPUT -o lo -j ACCEPT
 iptables -A OUTPUT -p tcp -m owner --uid-owner 9999 -j ACCEPT
 iptables -A OUTPUT -p tcp --dport 80 -j ACCEPT

--- a/src/docker/proxy/entrypoint.sh
+++ b/src/docker/proxy/entrypoint.sh
@@ -50,13 +50,22 @@ setpriv --reuid=9998 --regid=9998 --clear-groups -- \
 COREDNS_PID=$!
 
 # --- Generate CA cert if not present ---
+# The entrypoint starts as root; transfer ownership of the certs dir to
+# uid 9999 now so mitmdump can write (init) and read (tproxy mode) it.
+# chmod 755 lets the host user traverse the directory to read the public cert.
+chown 9999:9999 "$CERTS_DIR"
+chmod 755 "$CERTS_DIR"
 if [ ! -f "$CERTS_DIR/mitmproxy-ca-cert.pem" ]; then
     echo "Generating mitmproxy CA certificate..."
-    mitmdump --set confdir="$CERTS_DIR" -q &
+    setpriv --reuid=9999 --regid=9999 --clear-groups -- \
+        mitmdump --set confdir="$CERTS_DIR" -q &
     MITM_INIT_PID=$!
     sleep 2
     kill "$MITM_INIT_PID" 2>/dev/null || true
     wait "$MITM_INIT_PID" 2>/dev/null || true
+    # Public cert must be readable by the host user for volume-mounting into agents.
+    # Private key (mitmproxy-ca.pem) stays 600, owned by uid 9999.
+    chmod 644 "$CERTS_DIR/mitmproxy-ca-cert.pem" 2>/dev/null || true
     echo "CA certificate generated at $CERTS_DIR/mitmproxy-ca-cert.pem"
 else
     echo "Using existing CA certificate"

--- a/src/docker/proxy/entrypoint.sh
+++ b/src/docker/proxy/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-CERTS_DIR="/root/.mitmproxy"
+CERTS_DIR="/var/lib/mitmproxy"
 ALLOWLIST="/etc/proxy/allowlist.json"
 COREFILE="/etc/coredns/Corefile"
 
@@ -50,11 +50,6 @@ setpriv --reuid=9998 --regid=9998 --clear-groups -- \
 COREDNS_PID=$!
 
 # --- Generate CA cert if not present ---
-# The entrypoint starts as root; transfer ownership of the certs dir to
-# uid 9999 now so mitmdump can write (init) and read (tproxy mode) it.
-# chmod 755 lets the host user traverse the directory to read the public cert.
-chown -R 9999:9999 "$CERTS_DIR"
-chmod 755 "$CERTS_DIR"
 if [ ! -f "$CERTS_DIR/mitmproxy-ca-cert.pem" ]; then
     echo "Generating mitmproxy CA certificate..."
     setpriv --reuid=9999 --regid=9999 --clear-groups -- \

--- a/src/docker/proxy/entrypoint.sh
+++ b/src/docker/proxy/entrypoint.sh
@@ -144,7 +144,7 @@ iptables -A OUTPUT -p udp -j DROP
 echo "Starting mitmdump (transparent mode) on :8080..."
 echo "Addon: /etc/proxy/addon.py"
 exec setpriv --reuid=9999 --regid=9999 --clear-groups -- \
-    mitmdump --mode transparent --showhost \
+    mitmdump --mode transparent --showhost -v \
     --set confdir="$CERTS_DIR" \
     --listen-port 8080 \
     --ssl-insecure \

--- a/src/docker/proxy/entrypoint.sh
+++ b/src/docker/proxy/entrypoint.sh
@@ -89,6 +89,26 @@ iptables -t mangle -A OUTPUT -p tcp --dport 80 \
 iptables -t mangle -A OUTPUT -p tcp --dport 443 \
     -m owner ! --uid-owner 9999 -j MARK --set-mark 1
 
+# --- Default-deny TCP OUTPUT ---
+# Block all TCP from non-proxy processes on ports other than 80/443, closing
+# the 2B gap (raw IP + non-HTTP/HTTPS was previously unrestricted).
+#
+# Rule order:
+#   lo ACCEPT first: covers CoreDNS TCP fallback and TPROXY re-injection
+#                    (marked 80/443 packets route to lo before filter runs).
+#   uid 9999 ACCEPT: mitmdump upstream connections exit freely to internet.
+#   dport 80/443 ACCEPT: agent HTTP/HTTPS — caught by TPROXY, never reach wire.
+#   tcp DROP: everything else (port 22, raw-IP non-HTTP, etc.) is blocked.
+#
+# To add a future protocol proxy (sshpiper uid 9998, SOCKS uid 9997, etc.),
+# insert an additional uid ACCEPT rule before the final DROP.
+echo "Configuring default-deny TCP OUTPUT..."
+iptables -A OUTPUT -o lo -j ACCEPT
+iptables -A OUTPUT -p tcp -m owner --uid-owner 9999 -j ACCEPT
+iptables -A OUTPUT -p tcp --dport 80 -j ACCEPT
+iptables -A OUTPUT -p tcp --dport 443 -j ACCEPT
+iptables -A OUTPUT -p tcp -j DROP
+
 # --- Start mitmdump in TPROXY mode as uid 9999 ---
 # setpriv drops to uid/gid 9999 while preserving CAP_NET_ADMIN in the ambient
 # capability set. CAP_NET_ADMIN is required for the IP_TRANSPARENT socket

--- a/src/docker/proxy/entrypoint.sh
+++ b/src/docker/proxy/entrypoint.sh
@@ -103,29 +103,20 @@ iptables -t nat -A OUTPUT -p tcp --dport 443 \
 # the 2B gap (raw IP + non-HTTP/HTTPS was previously unrestricted).
 #
 # Rule order:
-#   lo ACCEPT (all protocols): agent TCP port 80/443 is REDIRECT-ed to
-#     127.0.0.1:8080 by nat OUTPUT before filter runs, so the output
-#     interface becomes lo. This rule catches all redirected agent traffic
-#     and all mitmdump→agent reply traffic.
-#   ! -o lo dport 80 ACCEPT: mitmdump upstream HTTP connections.
-#     Safe: agent port 80 is always redirected to lo first, so agent traffic
-#     never reaches this rule. Only mitmdump (excluded from nat REDIRECT via
-#     ! --uid-owner 9999) sends port 80 on the bridge interface.
-#   ! -o lo dport 443 ACCEPT: same as above for HTTPS.
-#   ! -o lo dport 53 uid 9998 ACCEPT: CoreDNS TCP upstream (DNS-over-TCP
-#     fallback to 8.8.8.8). CoreDNS port 53 TCP goes to the bridge interface
-#     (not lo). uid-owner 9998 match works for CoreDNS (verified by UDP counts).
-#   tcp DROP: everything else (agent TCP to port 22, arbitrary ports, etc.).
+#   lo ACCEPT: covers redirected agent traffic (nat REDIRECT rewrites dst to
+#     127.0.0.1:8080 → routing picks lo → filter sees -o lo → ACCEPT) and
+#     all loopback communication between processes in this namespace.
+#   uid 9999 ACCEPT: mitmdump upstream connections to the real internet.
+#     Works because mitmdump is a child process (not PID 1); xt_owner uid
+#     matching is reliable for non-PID-1 processes.
+#   tcp DROP: everything else (agent TCP to non-80/443 ports, port 22, etc.).
 #
-# Note: -m owner --uid-owner 9999 is intentionally NOT used here because
-# iptables owner match does not reliably match PID 1 connections created by
-# exec setpriv; using ! -o lo + dport-based rules achieves the same security
-# guarantee without relying on uid matching for mitmproxy.
+# The dport 80/443 rules are intentionally absent: agent TCP to those ports
+# is always redirected to lo by nat OUTPUT before filter runs, so they are
+# caught by the lo ACCEPT rule and never reach the DROP.
 echo "Configuring default-deny TCP OUTPUT..."
 iptables -A OUTPUT -o lo -j ACCEPT
-iptables -A OUTPUT ! -o lo -p tcp --dport 80 -j ACCEPT
-iptables -A OUTPUT ! -o lo -p tcp --dport 443 -j ACCEPT
-iptables -A OUTPUT ! -o lo -p tcp --dport 53 -m owner --uid-owner 9998 -j ACCEPT
+iptables -A OUTPUT -p tcp -m owner --uid-owner 9999 -j ACCEPT
 iptables -A OUTPUT -p tcp -j DROP
 
 # --- Default-deny UDP OUTPUT ---
@@ -144,15 +135,31 @@ iptables -A OUTPUT -p udp -j DROP
 # --- Start mitmdump in transparent mode as uid 9999 ---
 # setpriv drops to uid/gid 9999. CAP_NET_ADMIN is not needed for
 # transparent mode (it uses SO_ORIGINAL_DST, not IP_TRANSPARENT).
-# Running as uid 9999 is what the OUTPUT MARK rule excludes, preventing
-# mitmdump's own upstream connections from being re-intercepted.
+#
+# IMPORTANT: do NOT use exec here. The iptables nat OUTPUT REDIRECT rule
+# uses "! --uid-owner 9999" to exclude mitmproxy's own upstream connections
+# from being re-intercepted. The Linux kernel's xt_owner module does not
+# reliably match uid for PID 1; if mitmdump were exec'd into PID 1, its
+# upstream connections would fail the uid match and be redirected back to
+# itself (loop). Running as a child process (non-PID-1) ensures uid 9999
+# is matched correctly by the owner module.
+#
+# PID 1 (this shell) remains as the container's init process and forwards
+# SIGTERM/SIGINT to the child processes for clean shutdown.
 echo "Starting mitmdump (transparent mode) on :8080..."
 echo "Addon: /etc/proxy/addon.py"
-exec setpriv --reuid=9999 --regid=9999 --clear-groups -- \
+setpriv --reuid=9999 --regid=9999 --clear-groups -- \
     mitmdump --mode transparent --showhost -v \
     --set confdir="$CERTS_DIR" \
     --listen-port 8080 \
     --ssl-insecure \
     -s /etc/proxy/addon.py \
     --set block_global=false \
-    --set stream_large_bodies=1m
+    --set stream_large_bodies=1m &
+MITM_PID=$!
+
+# Forward signals to child processes so Docker stop works cleanly.
+trap 'kill "$MITM_PID" "$COREDNS_PID" 2>/dev/null; wait' TERM INT
+
+echo "Proxy ready (coredns PID=$COREDNS_PID, mitmdump PID=$MITM_PID)"
+wait "$MITM_PID"

--- a/src/docker/proxy/entrypoint.sh
+++ b/src/docker/proxy/entrypoint.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CERTS_DIR="/root/.mitmproxy"
+ALLOWLIST="/etc/proxy/allowlist.json"
+COREFILE="/etc/coredns/Corefile"
+
+echo "=== Proxy Container Starting ==="
+
+# --- Generate CoreDNS config from allowlist ---
+echo "Generating Corefile from allowlist..."
+DOMAINS=$(jq -r '.domains[]' "$ALLOWLIST")
+
+cat > "$COREFILE" <<'HEADER'
+# Auto-generated from allowlist.json
+HEADER
+
+for domain in $DOMAINS; do
+    cat >> "$COREFILE" <<EOF
+
+${domain} {
+    forward . 8.8.8.8 8.8.4.4
+    log
+}
+EOF
+done
+
+cat >> "$COREFILE" <<'CATCHALL'
+
+. {
+    template IN A {
+        rcode NXDOMAIN
+    }
+    template IN AAAA {
+        rcode NXDOMAIN
+    }
+    log
+}
+CATCHALL
+
+echo "Corefile generated with $(echo "$DOMAINS" | wc -w) domains"
+
+# --- Start CoreDNS in background ---
+echo "Starting CoreDNS on :53..."
+coredns -conf "$COREFILE" -dns.port 53 &
+COREDNS_PID=$!
+
+# --- Generate CA cert if not present ---
+if [ ! -f "$CERTS_DIR/mitmproxy-ca-cert.pem" ]; then
+    echo "Generating mitmproxy CA certificate..."
+    mitmdump --set confdir="$CERTS_DIR" -q &
+    MITM_INIT_PID=$!
+    sleep 2
+    kill "$MITM_INIT_PID" 2>/dev/null || true
+    wait "$MITM_INIT_PID" 2>/dev/null || true
+    echo "CA certificate generated at $CERTS_DIR/mitmproxy-ca-cert.pem"
+else
+    echo "Using existing CA certificate"
+fi
+
+# --- Set up iptables for transparent proxying ---
+# Both ports redirect to 8080 — mitmdump transparent mode auto-detects TLS
+# by inspecting the ClientHello on the same listener port.
+echo "Configuring iptables for transparent proxy..."
+iptables -t nat -A PREROUTING -i eth0 -p tcp --dport 80 -j REDIRECT --to-port 8080
+iptables -t nat -A PREROUTING -i eth0 -p tcp --dport 443 -j REDIRECT --to-port 8080
+
+# --- Start mitmdump in transparent mode ---
+# mitmdump is the headless version of mitmproxy (no interactive TUI).
+# Transparent mode on a single port handles both plain HTTP and TLS — it
+# detects TLS via the ClientHello and performs MITM interception automatically.
+echo "Starting mitmdump (transparent mode) on :8080..."
+echo "Addon: /etc/proxy/addon.py"
+exec mitmdump --mode transparent --showhost \
+    --set confdir="$CERTS_DIR" \
+    --listen-port 8080 \
+    --ssl-insecure \
+    -s /etc/proxy/addon.py \
+    --set block_global=false \
+    --set stream_large_bodies=1m

--- a/src/docker/proxy/entrypoint.sh
+++ b/src/docker/proxy/entrypoint.sh
@@ -66,71 +66,90 @@ else
     echo "Using existing CA certificate"
 fi
 
-# --- Set up TPROXY transparent interception ---
+# --- Set up transparent interception via DNAT ---
 # Agent containers share this container's network namespace via
 # --network container:<proxy>. All TCP 80/443 originating from any process
 # whose UID != 9999 (i.e. every non-mitmdump process) is intercepted.
 #
 # How it works:
-#   OUTPUT chain:  mark packets from non-mitmdump processes (UID != 9999)
-#                  with fwmark 1.
-#   Policy routing: fwmark 1 → routing table 100; table 100 routes everything
-#                  to loopback, re-injecting packets into the netfilter
-#                  PREROUTING hook as if they arrived from outside.
-#   PREROUTING:    TPROXY target on port 80/443 redirects to mitmdump :8080
-#                  while preserving the original destination address via the
-#                  IP_TRANSPARENT socket option.
-#   Loop prevention: mitmdump runs as uid 9999; the OUTPUT MARK rule has
-#                  ! --uid-owner 9999, so mitmdump's upstream connections
-#                  to the real internet are never re-marked and never looped.
-# PREROUTING: intercept TCP 80/443 arriving from outside this namespace.
-# OUTPUT: intercept TCP 80/443 generated locally (agent processes sharing
-#         this network namespace via --network container:<proxy>).
-# uid 9999 (mitmdump) is excluded from OUTPUT REDIRECT so its upstream
-# connections to the real internet are never re-intercepted (loop prevention).
-# mitmproxy --mode transparent uses SO_ORIGINAL_DST to recover the original
-# destination after REDIRECT. No policy routing or IP_TRANSPARENT needed.
-# --- Disable reverse-path filtering on loopback ---
-# nat OUTPUT REDIRECT rewrites external destinations (e.g. 140.82.114.6:443) to
-# 127.0.0.1:8080, causing the packet to be re-routed through lo. The packet
-# arrives on lo with its ORIGINAL source address (the container's bridge IP,
-# e.g. 172.18.0.2), which is NOT in 127.0.0.0/8. With rp_filter=1 (strict,
-# the Fedora/RHEL default), the kernel silently drops the packet because the
-# source is not reachable via lo. Disabling rp_filter on lo and all interfaces
-# allows these REDIRECT-ed packets through.
-echo "Disabling rp_filter for transparent proxy..."
-sysctl -w net.ipv4.conf.all.rp_filter=0 >/dev/null 2>&1 || echo "  (sysctl failed — pass --sysctl net.ipv4.conf.all.rp_filter=0 to docker run)"
-sysctl -w net.ipv4.conf.lo.rp_filter=0 >/dev/null 2>&1 || true
+#   PREROUTING: REDIRECT intercepts TCP 80/443 arriving from external
+#               interfaces (e.g. if containers route through this namespace).
+#   OUTPUT:     DNAT rewrites locally-generated TCP 80/443 to PROXY_IP:8080.
+#               The kernel re-routes the packet to the local address, delivering
+#               it to mitmdump's listening socket on :8080.
+#   Loop prevention: mitmdump runs as uid 9999; the OUTPUT DNAT rule has
+#               ! --uid-owner 9999, so mitmdump's upstream connections to the
+#               real internet are never re-intercepted (no loop).
+#   SO_ORIGINAL_DST: mitmproxy --mode transparent uses getsockopt(SOL_IP, 80)
+#               to recover the original destination from conntrack. This works
+#               identically with DNAT and REDIRECT.
+#
+# Why DNAT instead of REDIRECT?
+#   REDIRECT in OUTPUT always rewrites the destination to 127.0.0.1, routing
+#   the packet through lo. The packet arrives on lo with the container's bridge
+#   IP as source (e.g. 172.18.0.2), which is NOT in 127.0.0.0/8. The Linux
+#   kernel silently drops these packets — a check beyond rp_filter rejects
+#   non-loopback sources on the lo interface.
+#   DNAT to the container's own bridge IP avoids this: both source and
+#   destination are the same local address, so the kernel accepts the packet.
+
+# Detect the container's primary IP for DNAT target.
+PROXY_IP=$(ip -4 addr show eth0 2>/dev/null | grep -oP '(?<=inet\s)\d+(\.\d+){3}' || true)
+if [ -z "$PROXY_IP" ]; then
+    # Fallback: first non-loopback IPv4 address
+    PROXY_IP=$(ip -4 addr show scope global 2>/dev/null | grep -oP '(?<=inet\s)\d+(\.\d+){3}' | head -1 || true)
+fi
+if [ -z "$PROXY_IP" ]; then
+    echo "ERROR: Could not detect container IP for DNAT. Transparent proxy will not work."
+    PROXY_IP="127.0.0.1"  # Fallback (will likely fail, but avoids syntax error)
+fi
+echo "Container IP for DNAT: $PROXY_IP"
 
 echo "Configuring transparent proxy iptables..."
+# PREROUTING: intercept traffic arriving from external interfaces.
+# REDIRECT is fine here — packets arrive on a real interface with matching source.
 iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-port 8080
 iptables -t nat -A PREROUTING -p tcp --dport 443 -j REDIRECT --to-port 8080
+# OUTPUT: intercept locally-generated TCP 80/443 (agent processes).
+# DNAT to the container's own IP avoids the lo routing issue with REDIRECT.
 iptables -t nat -A OUTPUT -p tcp --dport 80 \
-    -m owner ! --uid-owner 9999 -j REDIRECT --to-port 8080
+    -m owner ! --uid-owner 9999 -j DNAT --to-destination "${PROXY_IP}:8080"
 iptables -t nat -A OUTPUT -p tcp --dport 443 \
-    -m owner ! --uid-owner 9999 -j REDIRECT --to-port 8080
+    -m owner ! --uid-owner 9999 -j DNAT --to-destination "${PROXY_IP}:8080"
 
 # --- Default-deny TCP OUTPUT ---
 # Block all TCP from non-proxy processes on ports other than 80/443, closing
-# the 2B gap (raw IP + non-HTTP/HTTPS was previously unrestricted).
+# the raw-IP gap (non-HTTP/HTTPS TCP was previously unrestricted).
 #
 # Rule order:
-#   lo ACCEPT: covers redirected agent traffic (nat REDIRECT rewrites dst to
-#     127.0.0.1:8080 → routing picks lo → filter sees -o lo → ACCEPT) and
-#     all loopback communication between processes in this namespace.
-#   uid 9999 ACCEPT: mitmdump upstream connections to the real internet.
-#     Works because mitmdump is a child process (not PID 1); xt_owner uid
-#     matching is reliable for non-PID-1 processes.
-#   tcp DROP: everything else (agent TCP to non-80/443 ports, port 22, etc.).
-#
-# The dport 80/443 rules are intentionally absent: agent TCP to those ports
-# is always redirected to lo by nat OUTPUT before filter runs, so they are
-# caught by the lo ACCEPT rule and never reach the DROP.
+#   1. lo ACCEPT: covers DNAT-ed agent traffic (nat OUTPUT DNAT rewrites dst
+#      to PROXY_IP:8080 → kernel recognizes local address → routes through
+#      lo → filter sees -o lo → ACCEPT) and all inter-process loopback comms.
+#   2. ESTABLISHED,RELATED ACCEPT: allows TCP handshakes to complete and
+#      return traffic for all established connections.
+#   3. uid 9999 NEW ACCEPT: mitmdump upstream connections to the real internet.
+#      Works because mitmdump is a child process (not PID 1); xt_owner uid
+#      matching is reliable for non-PID-1 processes.
+#   4. dport 80,443 NEW ACCEPT: agent TCP to these ports must pass filter
+#      before nat OUTPUT DNAT fires. Without this, they'd hit the DROP rule
+#      and never reach the DNAT target.
+#   5. tcp NEW DROP: everything else (agent TCP to port 22, 8443, etc.).
 echo "Configuring default-deny TCP OUTPUT..."
+
+# 1. Allow all loopback traffic (DNAT-ed agent traffic + inter-process comms).
 iptables -A OUTPUT -o lo -j ACCEPT
-iptables -A OUTPUT -m owner --uid-owner 9999 -m state --state ESTABLISHED,RELATED -j ACCEPT
-iptables -A OUTPUT -p tcp -m owner --uid-owner 9999 -j ACCEPT
-iptables -A OUTPUT -p tcp -j DROP
+
+# 2. Allow established/related traffic (TCP handshake completion, return traffic).
+iptables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+
+# 3. Allow mitmdump (uid 9999) to initiate new upstream connections.
+iptables -A OUTPUT -p tcp -m owner --uid-owner 9999 -m conntrack --ctstate NEW -j ACCEPT
+
+# 4. Allow agent NEW TCP to ports 80/443 so packets reach nat OUTPUT DNAT.
+iptables -A OUTPUT -p tcp -m multiport --dports 80,443 -m conntrack --ctstate NEW -j ACCEPT
+
+# 5. Drop all other new outbound TCP (port 22, 8443, arbitrary ports, etc.).
+iptables -A OUTPUT -p tcp -m conntrack --ctstate NEW -j DROP
 
 # --- Default-deny UDP OUTPUT ---
 # Block all UDP from non-proxy processes. This prevents DNS exfiltration via
@@ -149,11 +168,11 @@ iptables -A OUTPUT -p udp -j DROP
 # setpriv drops to uid/gid 9999. CAP_NET_ADMIN is not needed for
 # transparent mode (it uses SO_ORIGINAL_DST, not IP_TRANSPARENT).
 #
-# IMPORTANT: do NOT use exec here. The iptables nat OUTPUT REDIRECT rule
+# IMPORTANT: do NOT use exec here. The iptables nat OUTPUT DNAT rule
 # uses "! --uid-owner 9999" to exclude mitmproxy's own upstream connections
 # from being re-intercepted. The Linux kernel's xt_owner module does not
 # reliably match uid for PID 1; if mitmdump were exec'd into PID 1, its
-# upstream connections would fail the uid match and be redirected back to
+# upstream connections would fail the uid match and be DNAT-ed back to
 # itself (loop). Running as a child process (non-PID-1) ensures uid 9999
 # is matched correctly by the owner module.
 #

--- a/src/docker/proxy/entrypoint.sh
+++ b/src/docker/proxy/entrypoint.sh
@@ -66,77 +66,72 @@ else
     echo "Using existing CA certificate"
 fi
 
-# --- Set up transparent interception via DNAT ---
+# --- Set up TPROXY transparent interception ---
 # Agent containers share this container's network namespace via
 # --network container:<proxy>. All TCP 80/443 originating from any process
 # whose UID != 9999 (i.e. every non-mitmdump process) is intercepted.
 #
-# How it works:
-#   PREROUTING: REDIRECT intercepts TCP 80/443 arriving from external
-#               interfaces (e.g. if containers route through this namespace).
-#   OUTPUT:     DNAT rewrites locally-generated TCP 80/443 to PROXY_IP:8080.
-#               The kernel re-routes the packet to the local address, delivering
-#               it to mitmdump's listening socket on :8080.
-#   Loop prevention: mitmdump runs as uid 9999; the OUTPUT DNAT rule has
-#               ! --uid-owner 9999, so mitmdump's upstream connections to the
-#               real internet are never re-intercepted (no loop).
-#   SO_ORIGINAL_DST: mitmproxy --mode transparent uses getsockopt(SOL_IP, 80)
-#               to recover the original destination from conntrack. This works
-#               identically with DNAT and REDIRECT.
+# How it works (TPROXY for locally-generated traffic):
+#   1. mangle OUTPUT marks agent TCP 80/443 with fwmark 1.
+#   2. Policy routing (ip rule) sends fwmark-1 packets to table 100.
+#   3. Table 100 routes everything to loopback, re-injecting packets into
+#      the PREROUTING chain as if they arrived from outside.
+#   4. mangle PREROUTING TPROXY assigns packets directly to mitmdump's
+#      listening socket via IP_TRANSPARENT, WITHOUT changing the destination.
+#      mitmdump sees the original destination (e.g. 140.82.114.6:443) as the
+#      accepted socket's local address.
+#   Loop prevention: mitmdump runs as uid 9999; the mangle OUTPUT MARK rule
+#      has ! --uid-owner 9999, so mitmdump's upstream connections are never
+#      marked and never re-intercepted.
 #
-# Why DNAT instead of REDIRECT?
-#   REDIRECT in OUTPUT always rewrites the destination to 127.0.0.1, routing
-#   the packet through lo. The packet arrives on lo with the container's bridge
-#   IP as source (e.g. 172.18.0.2), which is NOT in 127.0.0.0/8. The Linux
-#   kernel silently drops these packets — a check beyond rp_filter rejects
-#   non-loopback sources on the lo interface.
-#   DNAT to the container's own bridge IP avoids this: both source and
-#   destination are the same local address, so the kernel accepts the packet.
+# Why TPROXY instead of REDIRECT/DNAT?
+#   Both REDIRECT and DNAT in the nat OUTPUT chain fail for locally-generated
+#   traffic: REDIRECT rewrites dst to 127.0.0.1 (kernel drops non-loopback src
+#   on lo); DNAT to the container's bridge IP also silently fails to deliver
+#   packets to the local socket. TPROXY avoids both issues by operating in
+#   mangle PREROUTING after policy-routing re-injects packets through lo.
 
-# Detect the container's primary IP for DNAT target.
-PROXY_IP=$(ip -4 addr show eth0 2>/dev/null | grep -oP '(?<=inet\s)\d+(\.\d+){3}' || true)
-if [ -z "$PROXY_IP" ]; then
-    # Fallback: first non-loopback IPv4 address
-    PROXY_IP=$(ip -4 addr show scope global 2>/dev/null | grep -oP '(?<=inet\s)\d+(\.\d+){3}' | head -1 || true)
-fi
-if [ -z "$PROXY_IP" ]; then
-    echo "ERROR: Could not detect container IP for DNAT. Transparent proxy will not work."
-    PROXY_IP="127.0.0.1"  # Fallback (will likely fail, but avoids syntax error)
-fi
-echo "Container IP for DNAT: $PROXY_IP"
+echo "Configuring TPROXY transparent proxy..."
 
-echo "Configuring transparent proxy iptables..."
-# PREROUTING: intercept traffic arriving from external interfaces.
-# REDIRECT is fine here — packets arrive on a real interface with matching source.
-iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-port 8080
-iptables -t nat -A PREROUTING -p tcp --dport 443 -j REDIRECT --to-port 8080
-# OUTPUT: intercept locally-generated TCP 80/443 (agent processes).
-# DNAT to the container's own IP avoids the lo routing issue with REDIRECT.
-iptables -t nat -A OUTPUT -p tcp --dport 80 \
-    -m owner ! --uid-owner 9999 -j DNAT --to-destination "${PROXY_IP}:8080"
-iptables -t nat -A OUTPUT -p tcp --dport 443 \
-    -m owner ! --uid-owner 9999 -j DNAT --to-destination "${PROXY_IP}:8080"
+# Step 1: Mark agent TCP 80/443 in mangle OUTPUT.
+# uid 9999 (mitmdump) is excluded to prevent re-interception loops.
+iptables -t mangle -A OUTPUT -p tcp --dport 80 \
+    -m owner ! --uid-owner 9999 -j MARK --set-mark 1
+iptables -t mangle -A OUTPUT -p tcp --dport 443 \
+    -m owner ! --uid-owner 9999 -j MARK --set-mark 1
+
+# Step 2: Policy routing — fwmark 1 → table 100 → local delivery via lo.
+# This re-injects marked packets into PREROUTING as if they arrived externally.
+ip rule add fwmark 1 lookup 100
+ip route add local 0.0.0.0/0 dev lo table 100
+
+# Step 3: TPROXY in mangle PREROUTING intercepts re-injected packets.
+# --on-port 8080 delivers to mitmdump's listening socket.
+# --tproxy-mark re-applies fwmark so return traffic uses the same routing.
+iptables -t mangle -A PREROUTING -p tcp --dport 80 \
+    -j TPROXY --tproxy-mark 0x1/0x1 --on-port 8080
+iptables -t mangle -A PREROUTING -p tcp --dport 443 \
+    -j TPROXY --tproxy-mark 0x1/0x1 --on-port 8080
 
 # --- Default-deny TCP OUTPUT ---
 # Block all TCP from non-proxy processes on ports other than 80/443, closing
 # the raw-IP gap (non-HTTP/HTTPS TCP was previously unrestricted).
 #
 # Rule order:
-#   1. lo ACCEPT: covers DNAT-ed agent traffic (nat OUTPUT DNAT rewrites dst
-#      to PROXY_IP:8080 → kernel recognizes local address → routes through
-#      lo → filter sees -o lo → ACCEPT) and all inter-process loopback comms.
+#   1. lo ACCEPT: covers TPROXY-redirected agent traffic (mangle OUTPUT marks
+#      it → policy routing sends to lo → filter sees -o lo → ACCEPT) and all
+#      inter-process loopback communication.
 #   2. ESTABLISHED,RELATED ACCEPT: allows TCP handshakes to complete and
-#      return traffic for all established connections.
+#      return traffic for established connections.
 #   3. uid 9999 NEW ACCEPT: mitmdump upstream connections to the real internet.
 #      Works because mitmdump is a child process (not PID 1); xt_owner uid
 #      matching is reliable for non-PID-1 processes.
-#   4. dport 80,443 NEW ACCEPT: agent TCP to these ports must pass filter
-#      before nat OUTPUT DNAT fires. Without this, they'd hit the DROP rule
-#      and never reach the DNAT target.
-#   5. tcp NEW DROP: everything else (agent TCP to port 22, 8443, etc.).
+#   4. tcp NEW DROP: everything else (agent TCP to port 22, 8443, etc.).
+#      Agent TCP to 80/443 is safe: it's already marked and routed to lo
+#      by mangle OUTPUT, so it never reaches this rule.
 echo "Configuring default-deny TCP OUTPUT..."
 
-# 1. Allow all loopback traffic (DNAT-ed agent traffic + inter-process comms).
+# 1. Allow all loopback traffic (TPROXY-marked agent traffic + inter-process comms).
 iptables -A OUTPUT -o lo -j ACCEPT
 
 # 2. Allow established/related traffic (TCP handshake completion, return traffic).
@@ -145,10 +140,7 @@ iptables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 # 3. Allow mitmdump (uid 9999) to initiate new upstream connections.
 iptables -A OUTPUT -p tcp -m owner --uid-owner 9999 -m conntrack --ctstate NEW -j ACCEPT
 
-# 4. Allow agent NEW TCP to ports 80/443 so packets reach nat OUTPUT DNAT.
-iptables -A OUTPUT -p tcp -m multiport --dports 80,443 -m conntrack --ctstate NEW -j ACCEPT
-
-# 5. Drop all other new outbound TCP (port 22, 8443, arbitrary ports, etc.).
+# 4. Drop all other new outbound TCP (port 22, 8443, arbitrary ports, etc.).
 iptables -A OUTPUT -p tcp -m conntrack --ctstate NEW -j DROP
 
 # --- Default-deny UDP OUTPUT ---
@@ -165,22 +157,25 @@ iptables -A OUTPUT -p udp -m owner --uid-owner 9998 -j ACCEPT
 iptables -A OUTPUT -p udp -j DROP
 
 # --- Start mitmdump in transparent mode as uid 9999 ---
-# setpriv drops to uid/gid 9999. CAP_NET_ADMIN is not needed for
-# transparent mode (it uses SO_ORIGINAL_DST, not IP_TRANSPARENT).
+# setpriv drops to uid/gid 9999 but retains CAP_NET_ADMIN as an ambient
+# capability. TPROXY requires IP_TRANSPARENT on the listening socket, which
+# needs CAP_NET_ADMIN. The --inh-caps and --ambient-caps flags promote
+# the capability so it's effective for the unprivileged mitmdump process.
 #
-# IMPORTANT: do NOT use exec here. The iptables nat OUTPUT DNAT rule
-# uses "! --uid-owner 9999" to exclude mitmproxy's own upstream connections
+# IMPORTANT: do NOT use exec here. The mangle OUTPUT MARK rule uses
+# "! --uid-owner 9999" to exclude mitmproxy's own upstream connections
 # from being re-intercepted. The Linux kernel's xt_owner module does not
 # reliably match uid for PID 1; if mitmdump were exec'd into PID 1, its
-# upstream connections would fail the uid match and be DNAT-ed back to
+# upstream connections would fail the uid match and be re-marked back to
 # itself (loop). Running as a child process (non-PID-1) ensures uid 9999
 # is matched correctly by the owner module.
 #
 # PID 1 (this shell) remains as the container's init process and forwards
 # SIGTERM/SIGINT to the child processes for clean shutdown.
-echo "Starting mitmdump (transparent mode) on :8080..."
+echo "Starting mitmdump (transparent mode + TPROXY) on :8080..."
 echo "Addon: /etc/proxy/addon.py"
-PYTHONUNBUFFERED=1 setpriv --reuid=9999 --regid=9999 --clear-groups -- \
+PYTHONUNBUFFERED=1 setpriv --reuid=9999 --regid=9999 --clear-groups \
+    --inh-caps +net_admin --ambient-caps +net_admin -- \
     mitmdump --mode transparent --showhost -v \
     --set confdir="$CERTS_DIR" \
     --listen-port 8080 \

--- a/src/docker/proxy/entrypoint.sh
+++ b/src/docker/proxy/entrypoint.sh
@@ -116,7 +116,9 @@ iptables -t nat -A OUTPUT -p tcp --dport 443 \
 # caught by the lo ACCEPT rule and never reach the DROP.
 echo "Configuring default-deny TCP OUTPUT..."
 iptables -A OUTPUT -o lo -j ACCEPT
+iptables -A OUTPUT -m owner --uid-owner 9999 -m state --state ESTABLISHED,RELATED -j ACCEPT
 iptables -A OUTPUT -p tcp -m owner --uid-owner 9999 -j ACCEPT
+iptables -A OUTPUT -p tcp -j LOG --log-prefix "TCP-DROP: " --log-level 4
 iptables -A OUTPUT -p tcp -j DROP
 
 # --- Default-deny UDP OUTPUT ---
@@ -130,6 +132,7 @@ iptables -A OUTPUT -p tcp -j DROP
 # To add future protocol proxies: insert uid ACCEPT before the DROP.
 echo "Configuring default-deny UDP OUTPUT..."
 iptables -A OUTPUT -p udp -m owner --uid-owner 9998 -j ACCEPT
+iptables -A OUTPUT -p udp -j LOG --log-prefix "UDP-DROP: " --log-level 4
 iptables -A OUTPUT -p udp -j DROP
 
 # --- Start mitmdump in transparent mode as uid 9999 ---

--- a/src/docker/proxy/entrypoint.sh
+++ b/src/docker/proxy/entrypoint.sh
@@ -118,7 +118,6 @@ echo "Configuring default-deny TCP OUTPUT..."
 iptables -A OUTPUT -o lo -j ACCEPT
 iptables -A OUTPUT -m owner --uid-owner 9999 -m state --state ESTABLISHED,RELATED -j ACCEPT
 iptables -A OUTPUT -p tcp -m owner --uid-owner 9999 -j ACCEPT
-iptables -A OUTPUT -p tcp -j LOG --log-prefix "TCP-DROP: " --log-level 4
 iptables -A OUTPUT -p tcp -j DROP
 
 # --- Default-deny UDP OUTPUT ---
@@ -132,7 +131,6 @@ iptables -A OUTPUT -p tcp -j DROP
 # To add future protocol proxies: insert uid ACCEPT before the DROP.
 echo "Configuring default-deny UDP OUTPUT..."
 iptables -A OUTPUT -p udp -m owner --uid-owner 9998 -j ACCEPT
-iptables -A OUTPUT -p udp -j LOG --log-prefix "UDP-DROP: " --log-level 4
 iptables -A OUTPUT -p udp -j DROP
 
 # --- Start mitmdump in transparent mode as uid 9999 ---
@@ -151,7 +149,7 @@ iptables -A OUTPUT -p udp -j DROP
 # SIGTERM/SIGINT to the child processes for clean shutdown.
 echo "Starting mitmdump (transparent mode) on :8080..."
 echo "Addon: /etc/proxy/addon.py"
-setpriv --reuid=9999 --regid=9999 --clear-groups -- \
+PYTHONUNBUFFERED=1 setpriv --reuid=9999 --regid=9999 --clear-groups -- \
     mitmdump --mode transparent --showhost -v \
     --set confdir="$CERTS_DIR" \
     --listen-port 8080 \

--- a/src/docker/proxy/entrypoint.sh
+++ b/src/docker/proxy/entrypoint.sh
@@ -58,6 +58,14 @@ else
     echo "Using existing CA certificate"
 fi
 
+# --- Enable IP forwarding and NAT ---
+# Required to act as a gateway: forward packets from agent-net to internet
+# (bridge-net), and masquerade the source IP so return traffic routes back.
+echo "Enabling IP forwarding and NAT..."
+echo 1 > /proc/sys/net/ipv4/ip_forward
+iptables -t nat -A POSTROUTING -j MASQUERADE
+iptables -A FORWARD -j ACCEPT
+
 # --- Set up iptables for transparent proxying ---
 # Redirect all TCP 80/443 arriving at any interface to mitmdump on :8080.
 # No -i restriction: the proxy container connects to multiple Docker networks
@@ -65,6 +73,8 @@ fi
 # interface name for agent-net is not predictable at build time.
 # Agent containers route through the proxy as their default gateway, so their
 # traffic arrives at the proxy's agent-net interface and is caught here.
+# Exclude traffic originating from this container itself (OUTPUT chain handles
+# local traffic separately; PREROUTING only sees forwarded/incoming packets).
 echo "Configuring iptables for transparent proxy..."
 iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-port 8080
 iptables -t nat -A PREROUTING -p tcp --dport 443 -j REDIRECT --to-port 8080

--- a/src/docker/proxy/entrypoint.sh
+++ b/src/docker/proxy/entrypoint.sh
@@ -58,40 +58,48 @@ else
     echo "Using existing CA certificate"
 fi
 
-# --- Enable IP forwarding and NAT ---
-# Required to act as a gateway: forward packets from agent-net to internet
-# (bridge-net), and masquerade the source IP so return traffic routes back.
-# ip_forward is set via --sysctl net.ipv4.ip_forward=1 at docker run time;
-# the write below is a belt-and-suspenders attempt that may be a no-op if
-# /proc/sys is read-only (which is normal for non-privileged containers).
-echo "Enabling IP forwarding and NAT..."
-echo 1 > /proc/sys/net/ipv4/ip_forward 2>/dev/null || true
-IP_FWD=$(cat /proc/sys/net/ipv4/ip_forward 2>/dev/null || echo "unknown")
-echo "ip_forward = $IP_FWD"
-iptables -t nat -A POSTROUTING -j MASQUERADE
-iptables -A FORWARD -j ACCEPT
+# --- Set up TPROXY transparent interception ---
+# Agent containers share this container's network namespace via
+# --network container:<proxy>. All TCP 80/443 originating from any process
+# whose UID != 9999 (i.e. every non-mitmdump process) is intercepted.
+#
+# How it works:
+#   OUTPUT chain:  mark packets from non-mitmdump processes (UID != 9999)
+#                  with fwmark 1.
+#   Policy routing: fwmark 1 → routing table 100; table 100 routes everything
+#                  to loopback, re-injecting packets into the netfilter
+#                  PREROUTING hook as if they arrived from outside.
+#   PREROUTING:    TPROXY target on port 80/443 redirects to mitmdump :8080
+#                  while preserving the original destination address via the
+#                  IP_TRANSPARENT socket option.
+#   Loop prevention: mitmdump runs as uid 9999; the OUTPUT MARK rule has
+#                  ! --uid-owner 9999, so mitmdump's upstream connections
+#                  to the real internet are never re-marked and never looped.
+echo "Configuring TPROXY policy routing and iptables..."
+ip rule add fwmark 1 lookup 100 2>/dev/null || true
+ip route add local 0.0.0.0/0 dev lo table 100 2>/dev/null || true
 
-# --- Set up iptables for transparent proxying ---
-# Redirect all TCP 80/443 arriving at any interface to mitmdump on :8080.
-# No -i restriction: the proxy container connects to multiple Docker networks
-# (bridge-net for internet egress, agent-net for agent traffic) and the
-# interface name for agent-net is not predictable at build time.
-# Agent containers route through the proxy as their default gateway, so their
-# traffic arrives at the proxy's agent-net interface and is caught here.
-# Exclude traffic originating from this container itself (OUTPUT chain handles
-# local traffic separately; PREROUTING only sees forwarded/incoming packets).
-echo "Configuring iptables for transparent proxy..."
-iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-port 8080
-iptables -t nat -A PREROUTING -p tcp --dport 443 -j REDIRECT --to-port 8080
+iptables -t mangle -A PREROUTING -p tcp --dport 80 -j TPROXY \
+    --tproxy-mark 1 --on-port 8080
+iptables -t mangle -A PREROUTING -p tcp --dport 443 -j TPROXY \
+    --tproxy-mark 1 --on-port 8080
 
-# --- Start mitmdump in transparent mode ---
-# mitmdump is the headless version of mitmproxy (no interactive TUI).
-# Transparent mode uses SO_ORIGINAL_DST to recover the original destination
-# after iptables REDIRECT has rewritten it, enabling MITM of all TCP 80/443
-# regardless of whether the client has proxy env vars set.
-echo "Starting mitmdump (transparent mode) on :8080..."
+iptables -t mangle -A OUTPUT -p tcp --dport 80 \
+    -m owner ! --uid-owner 9999 -j MARK --set-mark 1
+iptables -t mangle -A OUTPUT -p tcp --dport 443 \
+    -m owner ! --uid-owner 9999 -j MARK --set-mark 1
+
+# --- Start mitmdump in TPROXY mode as uid 9999 ---
+# setpriv drops to uid/gid 9999 while preserving CAP_NET_ADMIN in the ambient
+# capability set. CAP_NET_ADMIN is required for the IP_TRANSPARENT socket
+# option that TPROXY mode uses to bind on behalf of the original destination.
+# --inh-caps promotes cap_net_admin into the inheritable set first; Linux
+# requires a cap to be inheritable before it can be made ambient.
+echo "Starting mitmdump (tproxy mode) on :8080..."
 echo "Addon: /etc/proxy/addon.py"
-exec mitmdump --mode transparent --showhost \
+exec setpriv --reuid=9999 --regid=9999 --clear-groups \
+    --inh-caps +cap_net_admin --ambient-caps +cap_net_admin -- \
+    mitmdump --mode tproxy --showhost \
     --set confdir="$CERTS_DIR" \
     --listen-port 8080 \
     --ssl-insecure \

--- a/src/docker/proxy/entrypoint.sh
+++ b/src/docker/proxy/entrypoint.sh
@@ -136,7 +136,7 @@ iptables -A OUTPUT -p udp -j DROP
 echo "Starting mitmdump (tproxy mode) on :8080..."
 echo "Addon: /etc/proxy/addon.py"
 exec setpriv --reuid=9999 --regid=9999 --clear-groups \
-    --inh-caps +cap_net_admin --ambient-caps +cap_net_admin -- \
+    --inh-caps +net_admin --ambient-caps +net_admin -- \
     mitmdump --mode tproxy --showhost \
     --set confdir="$CERTS_DIR" \
     --listen-port 8080 \

--- a/src/docker/proxy/test-proxy.sh
+++ b/src/docker/proxy/test-proxy.sh
@@ -112,6 +112,34 @@ run_agent() {
         -c "echo 'nameserver 127.0.0.1' > /etc/resolv.conf; cat /etc/proxy-ca/mitmproxy-ca-cert.pem >> /etc/ssl/certs/ca-certificates.crt 2>/dev/null || true; $cmd"
 }
 
+# --- Diagnostics: test REDIRECT + uid-owner from INSIDE the proxy container ---
+# These run curl from the proxy container itself (no agent container involved)
+# to isolate whether the issue is REDIRECT/mitmproxy or --network container: sharing.
+echo ""
+info "Diag A: curl as root (uid 0) from proxy container → should be REDIRECT-ed to mitmproxy..."
+DIAG_A=$(docker exec "$PROXY_CONTAINER" \
+    curl -s --max-time 8 -o /dev/null -w "HTTP_%{http_code}" http://api.github.com/ 2>&1 || true)
+info "  Result: ${DIAG_A:-<no output>}"
+
+info "Diag B: curl as uid 9999 from proxy container → should BYPASS REDIRECT, go direct..."
+DIAG_B=$(docker exec "$PROXY_CONTAINER" \
+    setpriv --reuid=9999 --regid=9999 --clear-groups -- \
+    curl -s --max-time 8 -o /dev/null -w "HTTP_%{http_code}" http://api.github.com/ 2>&1 || true)
+info "  Result: ${DIAG_B:-<no output>}"
+
+info "Diag C: curl as uid 0 to raw IP :80 from proxy container → should be REDIRECT-ed, addon 403..."
+DIAG_C=$(docker exec "$PROXY_CONTAINER" \
+    curl -s --max-time 8 -o /dev/null -w "HTTP_%{http_code}" http://93.184.216.34/ 2>&1 || true)
+info "  Result: ${DIAG_C:-<no output>}"
+
+info "Diag D: agent container wget with verbose stderr → shows connection/TLS details..."
+DIAG_D=$(run_agent "test-diag" alpine \
+    "wget -T 8 -O /dev/null http://api.github.com/ 2>&1 | head -5" 2>&1 || true)
+info "  Result:"
+echo "$DIAG_D" | head -10
+
+echo ""
+
 # --- Probe: direct TCP to mitmproxy :8080 (no REDIRECT needed) ---
 # Verifies mitmdump is reachable at all before any iptables rules are involved.
 # An HTTP request to the proxy port directly should return a 400 (bad request /

--- a/src/docker/proxy/test-proxy.sh
+++ b/src/docker/proxy/test-proxy.sh
@@ -49,12 +49,13 @@ docker run -d \
     --name "$PROXY_CONTAINER" \
     --network "$BRIDGE_NET" \
     --cap-add NET_ADMIN \
-    -v "$CERTS_DIR:/root/.mitmproxy" \
+    -v "$CERTS_DIR:/var/lib/mitmproxy" \
     "$PROXY_IMAGE"
 
 # Wait for proxy to initialize
 info "Waiting for proxy to start..."
 sleep 5
+docker logs "$PROXY_CONTAINER" --tail 10
 
 # Agent containers share the proxy's network namespace; CoreDNS listens on
 # loopback :53, so 127.0.0.1 resolves allowlisted domains and blocks others.

--- a/src/docker/proxy/test-proxy.sh
+++ b/src/docker/proxy/test-proxy.sh
@@ -138,6 +138,50 @@ DIAG_D=$(run_agent "test-diag" alpine \
 info "  Result:"
 echo "$DIAG_D" | head -10
 
+info "Diag E: SO_ORIGINAL_DST test — does OUTPUT REDIRECT store original dest in conntrack?"
+docker exec "$PROXY_CONTAINER" python3 -c "
+import socket, struct, sys, threading, time
+
+SO_ORIGINAL_DST = 80  # SOL_IP=0, SO_ORIGINAL_DST=80
+
+result = []
+def server():
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind(('0.0.0.0', 18999))
+    s.listen(1)
+    conn, addr = s.accept()
+    try:
+        dst = conn.getsockopt(socket.SOL_IP, SO_ORIGINAL_DST, 16)
+        port = struct.unpack('!H', dst[2:4])[0]
+        ip = '.'.join(str(b) for b in dst[4:8])
+        result.append(f'SO_ORIGINAL_DST={ip}:{port}')
+    except Exception as e:
+        result.append(f'SO_ORIGINAL_DST error: {e}')
+    conn.close()
+    s.close()
+
+t = threading.Thread(target=server, daemon=True)
+t.start()
+time.sleep(0.2)
+
+# Temp REDIRECT: port 18080 → 18999
+import subprocess
+subprocess.run(['iptables','-t','nat','-A','OUTPUT','-p','tcp','--dport','18080','-j','REDIRECT','--to-port','18999'], check=True)
+try:
+    c = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    c.settimeout(3)
+    c.connect(('127.0.0.1', 18080))  # goes to 18999 via REDIRECT
+    c.close()
+except Exception as e:
+    result.append(f'connect error: {e}')
+finally:
+    subprocess.run(['iptables','-t','nat','-D','OUTPUT','-p','tcp','--dport','18080','-j','REDIRECT','--to-port','18999'])
+
+t.join(timeout=3)
+print(result[0] if result else 'no result')
+" 2>&1 || true
+
 echo ""
 
 # --- Probe: direct TCP to mitmproxy :8080 (no REDIRECT needed) ---

--- a/src/docker/proxy/test-proxy.sh
+++ b/src/docker/proxy/test-proxy.sh
@@ -65,11 +65,8 @@ docker exec "$PROXY_CONTAINER" ps aux 2>/dev/null || true
 info "Listening sockets in proxy namespace:"
 docker exec "$PROXY_CONTAINER" ss -tlunp 2>/dev/null || true
 
-info "iptables nat OUTPUT rules:"
-docker exec "$PROXY_CONTAINER" iptables -t nat -L OUTPUT -n -v 2>/dev/null || true
-
-info "iptables filter OUTPUT rules:"
-docker exec "$PROXY_CONTAINER" iptables -L OUTPUT -n -v 2>/dev/null || true
+info "Mitmdump uid check:"
+docker exec "$PROXY_CONTAINER" sh -c 'cat /proc/$(pgrep mitmdump)/status 2>/dev/null | grep -E "^(Name|Uid)" || echo "mitmdump not found in proc"'
 
 # Agent containers share the proxy's network namespace; CoreDNS listens on
 # loopback :53, so 127.0.0.1 resolves allowlisted domains and blocks others.
@@ -103,6 +100,29 @@ run_agent() {
         "$image" \
         -c "echo 'nameserver 127.0.0.1' > /etc/resolv.conf; cat /etc/proxy-ca/mitmproxy-ca-cert.pem >> /etc/ssl/certs/ca-certificates.crt 2>/dev/null || true; $cmd"
 }
+
+# --- Probe: direct TCP to mitmproxy :8080 (no REDIRECT needed) ---
+# Verifies mitmdump is reachable at all before any iptables rules are involved.
+# An HTTP request to the proxy port directly should return a 400 (bad request /
+# upstream connection error) — anything other than a connection refusal means
+# mitmdump is up and accepting connections.
+info "Probe: direct HTTP to mitmdump :8080 (bypasses iptables)..."
+DIRECT_RESP=$(run_agent "test-probe" alpine \
+    "wget -qO- --timeout=5 http://127.0.0.1:8080/ 2>&1 | head -3" 2>/dev/null || true)
+info "  Direct :8080 response: ${DIRECT_RESP:-<no output>}"
+
+# --- Test 1a: Allowlisted domain (HTTP, transparent interception) ---
+# Isolates REDIRECT firing from TLS/CA trust. HTTP goes through REDIRECT to
+# mitmdump :8080 which then forwards upstream. If this passes but 1b fails,
+# the issue is TLS certificate trust, not REDIRECT.
+info "Test 1a: HTTP (port 80) request to allowlisted domain (api.github.com) — transparent..."
+if run_agent "test-allow-http" alpine \
+    "timeout 15 wget -T 10 -qO- http://api.github.com/ >/dev/null" \
+    >/dev/null 2>&1; then
+    pass "Allowlisted HTTP request succeeded (transparently intercepted)"
+else
+    fail "Allowlisted HTTP request failed (REDIRECT may not be firing)"
+fi
 
 # --- Test 1: Allowlisted domain (HTTPS, transparent interception) ---
 # No proxy env vars. Traffic routes through proxy via iptables REDIRECT.
@@ -216,6 +236,17 @@ echo ""
 echo "=== Proxy container logs ==="
 docker logs "$PROXY_CONTAINER" 2>&1
 echo "============================"
+
+# --- iptables packet counters (post-test) ---
+# Non-zero counters on nat OUTPUT REDIRECT rules confirm REDIRECT is firing.
+# Zero counters after tests = REDIRECT never matched (likely -m owner issue).
+echo ""
+echo "=== iptables nat table (post-test) ==="
+docker exec "$PROXY_CONTAINER" iptables -t nat -L -v -n 2>/dev/null || true
+echo ""
+echo "=== iptables filter table (post-test) ==="
+docker exec "$PROXY_CONTAINER" iptables -L -v -n 2>/dev/null || true
+echo "========================================"
 
 # --- Results ---
 echo ""

--- a/src/docker/proxy/test-proxy.sh
+++ b/src/docker/proxy/test-proxy.sh
@@ -67,6 +67,9 @@ docker exec "$PROXY_CONTAINER" ps aux 2>/dev/null || true
 info "Listening sockets in proxy namespace:"
 docker exec "$PROXY_CONTAINER" ss -tlunp 2>/dev/null || true
 
+info "rp_filter values (must be 0 for OUTPUT REDIRECT):"
+docker exec "$PROXY_CONTAINER" sh -c 'echo "  all=$(cat /proc/sys/net/ipv4/conf/all/rp_filter) lo=$(cat /proc/sys/net/ipv4/conf/lo/rp_filter) eth0=$(cat /proc/sys/net/ipv4/conf/eth0/rp_filter 2>/dev/null || echo N/A)"' 2>/dev/null || true
+
 info "Mitmdump uid check:"
 docker exec "$PROXY_CONTAINER" sh -c '
   for pid in /proc/[0-9]*; do

--- a/src/docker/proxy/test-proxy.sh
+++ b/src/docker/proxy/test-proxy.sh
@@ -66,7 +66,18 @@ info "Listening sockets in proxy namespace:"
 docker exec "$PROXY_CONTAINER" ss -tlunp 2>/dev/null || true
 
 info "Mitmdump uid check:"
-docker exec "$PROXY_CONTAINER" sh -c 'cat /proc/$(pgrep mitmdump)/status 2>/dev/null | grep -E "^(Name|Uid)" || echo "mitmdump not found in proc"'
+docker exec "$PROXY_CONTAINER" sh -c '
+  for pid in /proc/[0-9]*; do
+    cmd=$(cat "$pid/cmdline" 2>/dev/null | tr "\0" " ")
+    case "$cmd" in
+      *mitmdump*)
+        echo "Found mitmdump PID ${pid##*/}:"
+        grep -E "^(Name|Uid)" "$pid/status" 2>/dev/null
+        break
+        ;;
+    esac
+  done || echo "mitmdump not found in /proc"
+'
 
 # Agent containers share the proxy's network namespace; CoreDNS listens on
 # loopback :53, so 127.0.0.1 resolves allowlisted domains and blocks others.

--- a/src/docker/proxy/test-proxy.sh
+++ b/src/docker/proxy/test-proxy.sh
@@ -65,8 +65,8 @@ docker exec "$PROXY_CONTAINER" ps aux 2>/dev/null || true
 info "Listening sockets in proxy namespace:"
 docker exec "$PROXY_CONTAINER" ss -tlunp 2>/dev/null || true
 
-info "Container DNAT target IP:"
-docker exec "$PROXY_CONTAINER" ip -4 addr show eth0 2>/dev/null | grep -oP '(?<=inet\s)\d+(\.\d+){3}' || echo "  (could not detect eth0 IP)"
+info "TPROXY policy routing:"
+docker exec "$PROXY_CONTAINER" sh -c 'echo "  ip rules:"; ip rule show | grep fwmark; echo "  table 100:"; ip route show table 100 2>/dev/null || echo "    (empty)"' 2>/dev/null || true
 
 info "Mitmdump uid check:"
 docker exec "$PROXY_CONTAINER" sh -c '
@@ -171,44 +171,38 @@ finally: subprocess.run(['iptables','-t','nat','-D','OUTPUT','-p','tcp','--dport
 t.join(timeout=3); print(result[0] if result else 'no result')
 " 2>&1 || true
 
-info "Diag F: SO_ORIGINAL_DST — DNAT to container IP (→1.1.1.1:18080 DNAT→PROXY_IP:18999)..."
+info "Diag F: TPROXY pipeline — mark + policy route + TPROXY to local server on :18999..."
 docker exec "$PROXY_CONTAINER" python3 -c "
 import socket, struct, subprocess, threading, time
-SO_ORIGINAL_DST = 80
+IP_TRANSPARENT = 19
 result = []
-# Detect container IP (same logic as entrypoint.sh)
-import re
-ip_out = subprocess.check_output(['ip','-4','addr','show','eth0'], text=True)
-m = re.search(r'inet (\d+\.\d+\.\d+\.\d+)', ip_out)
-proxy_ip = m.group(1) if m else '127.0.0.1'
-print(f'DNAT target: {proxy_ip}:18999')
 def server():
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.setsockopt(socket.SOL_IP, IP_TRANSPARENT, 1)
     s.bind(('0.0.0.0', 18999))
     s.listen(1)
     s.settimeout(5)
     try:
         conn, addr = s.accept()
-        try:
-            dst = conn.getsockopt(socket.SOL_IP, SO_ORIGINAL_DST, 16)
-            port = struct.unpack('!H', dst[2:4])[0]
-            ip = '.'.join(str(b) for b in dst[4:8])
-            result.append(f'peer={addr[0]}:{addr[1]} SO_ORIGINAL_DST={ip}:{port}')
-        except Exception as e:
-            result.append(f'peer={addr[0]}:{addr[1]} SO_ORIGINAL_DST error: {e}')
+        local = conn.getsockname()
+        result.append(f'peer={addr[0]}:{addr[1]} getsockname={local[0]}:{local[1]}')
         conn.close()
     except socket.timeout:
         result.append('server accept() TIMED OUT — packet never reached server')
     s.close()
 t = threading.Thread(target=server, daemon=True); t.start(); time.sleep(0.2)
-subprocess.run(['iptables','-t','nat','-A','OUTPUT','-p','tcp','--dport','18080','-j','DNAT','--to-destination',f'{proxy_ip}:18999'], check=True)
+# Set up TPROXY pipeline for port 18080: mark → policy route (reuses table 100) → TPROXY
+subprocess.run(['iptables','-t','mangle','-A','OUTPUT','-p','tcp','--dport','18080','-j','MARK','--set-mark','1'], check=True)
+subprocess.run(['iptables','-t','mangle','-A','PREROUTING','-p','tcp','--dport','18080','-j','TPROXY','--tproxy-mark','0x1/0x1','--on-port','18999'], check=True)
 try:
     c = socket.socket(socket.AF_INET, socket.SOCK_STREAM); c.settimeout(4)
-    c.connect(('1.1.1.1', 18080))  # external IP — DNAT rewrites to proxy_ip:18999
+    c.connect(('1.1.1.1', 18080))  # external IP — should be TPROXY-ed to :18999
     c.close()
 except Exception as e: result.append(f'connect error: {e}')
-finally: subprocess.run(['iptables','-t','nat','-D','OUTPUT','-p','tcp','--dport','18080','-j','DNAT','--to-destination',f'{proxy_ip}:18999'])
+finally:
+    subprocess.run(['iptables','-t','mangle','-D','OUTPUT','-p','tcp','--dport','18080','-j','MARK','--set-mark','1'])
+    subprocess.run(['iptables','-t','mangle','-D','PREROUTING','-p','tcp','--dport','18080','-j','TPROXY','--tproxy-mark','0x1/0x1','--on-port','18999'])
 t.join(timeout=6); print('; '.join(result) if result else 'no result')
 " 2>&1 || true
 
@@ -353,6 +347,9 @@ echo "============================"
 # --- iptables packet counters (post-test) ---
 # Non-zero counters on nat OUTPUT REDIRECT rules confirm REDIRECT is firing.
 # Zero counters after tests = REDIRECT never matched (likely -m owner issue).
+echo ""
+echo "=== iptables mangle table (post-test) ==="
+docker exec "$PROXY_CONTAINER" iptables -t mangle -L -v -n 2>/dev/null || true
 echo ""
 echo "=== iptables nat table (post-test) ==="
 docker exec "$PROXY_CONTAINER" iptables -t nat -L -v -n 2>/dev/null || true

--- a/src/docker/proxy/test-proxy.sh
+++ b/src/docker/proxy/test-proxy.sh
@@ -49,8 +49,6 @@ docker run -d \
     --name "$PROXY_CONTAINER" \
     --network "$BRIDGE_NET" \
     --cap-add NET_ADMIN \
-    --sysctl net.ipv4.conf.all.rp_filter=0 \
-    --sysctl net.ipv4.conf.lo.rp_filter=0 \
     -v "$CERTS_DIR:/var/lib/mitmproxy" \
     "$PROXY_IMAGE"
 
@@ -67,8 +65,8 @@ docker exec "$PROXY_CONTAINER" ps aux 2>/dev/null || true
 info "Listening sockets in proxy namespace:"
 docker exec "$PROXY_CONTAINER" ss -tlunp 2>/dev/null || true
 
-info "rp_filter values (must be 0 for OUTPUT REDIRECT):"
-docker exec "$PROXY_CONTAINER" sh -c 'echo "  all=$(cat /proc/sys/net/ipv4/conf/all/rp_filter) lo=$(cat /proc/sys/net/ipv4/conf/lo/rp_filter) eth0=$(cat /proc/sys/net/ipv4/conf/eth0/rp_filter 2>/dev/null || echo N/A)"' 2>/dev/null || true
+info "Container DNAT target IP:"
+docker exec "$PROXY_CONTAINER" ip -4 addr show eth0 2>/dev/null | grep -oP '(?<=inet\s)\d+(\.\d+){3}' || echo "  (could not detect eth0 IP)"
 
 info "Mitmdump uid check:"
 docker exec "$PROXY_CONTAINER" sh -c '
@@ -173,11 +171,17 @@ finally: subprocess.run(['iptables','-t','nat','-D','OUTPUT','-p','tcp','--dport
 t.join(timeout=3); print(result[0] if result else 'no result')
 " 2>&1 || true
 
-info "Diag F: SO_ORIGINAL_DST — external src (→1.1.1.1:18080 REDIRECT→18999, non-lo source)..."
+info "Diag F: SO_ORIGINAL_DST — DNAT to container IP (→1.1.1.1:18080 DNAT→PROXY_IP:18999)..."
 docker exec "$PROXY_CONTAINER" python3 -c "
 import socket, struct, subprocess, threading, time
 SO_ORIGINAL_DST = 80
 result = []
+# Detect container IP (same logic as entrypoint.sh)
+import re
+ip_out = subprocess.check_output(['ip','-4','addr','show','eth0'], text=True)
+m = re.search(r'inet (\d+\.\d+\.\d+\.\d+)', ip_out)
+proxy_ip = m.group(1) if m else '127.0.0.1'
+print(f'DNAT target: {proxy_ip}:18999')
 def server():
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -198,13 +202,13 @@ def server():
         result.append('server accept() TIMED OUT — packet never reached server')
     s.close()
 t = threading.Thread(target=server, daemon=True); t.start(); time.sleep(0.2)
-subprocess.run(['iptables','-t','nat','-A','OUTPUT','-p','tcp','--dport','18080','-j','REDIRECT','--to-port','18999'], check=True)
+subprocess.run(['iptables','-t','nat','-A','OUTPUT','-p','tcp','--dport','18080','-j','DNAT','--to-destination',f'{proxy_ip}:18999'], check=True)
 try:
     c = socket.socket(socket.AF_INET, socket.SOCK_STREAM); c.settimeout(4)
-    c.connect(('1.1.1.1', 18080))  # external IP — source will be bridge IP, not 127.0.0.1
+    c.connect(('1.1.1.1', 18080))  # external IP — DNAT rewrites to proxy_ip:18999
     c.close()
 except Exception as e: result.append(f'connect error: {e}')
-finally: subprocess.run(['iptables','-t','nat','-D','OUTPUT','-p','tcp','--dport','18080','-j','REDIRECT','--to-port','18999'])
+finally: subprocess.run(['iptables','-t','nat','-D','OUTPUT','-p','tcp','--dport','18080','-j','DNAT','--to-destination',f'{proxy_ip}:18999'])
 t.join(timeout=6); print('; '.join(result) if result else 'no result')
 " 2>&1 || true
 

--- a/src/docker/proxy/test-proxy.sh
+++ b/src/docker/proxy/test-proxy.sh
@@ -156,19 +156,17 @@ else
     pass "Direct HTTP to raw IP blocked (TPROXY intercepted, addon returned 403)"
 fi
 
-# --- Test 7: SSH TCP to allowlisted domain (port 22, unintercepted) ---
-# TPROXY rules only cover ports 80 and 443. Port 22 traffic from the agent
-# process exits through the proxy's bridge-net interface directly, with no
-# iptables interception. DNS for github.com resolves (it is allowlisted).
-# nc connects; GitHub returns the SSH banner; nc exits 0 when stdin closes.
-# This verifies that non-HTTP/HTTPS traffic on allowlisted domains is permitted.
-info "Test 7: SSH TCP connect to allowlisted domain (github.com:22) — port 22 unintercepted..."
+# --- Test 7: SSH TCP to allowlisted domain (port 22, blocked by default-deny) ---
+# DNS for github.com resolves (it is allowlisted), but the default-deny OUTPUT
+# rule drops all TCP that is not port 80/443 or from uid 9999. Port 22 never
+# reaches the wire regardless of whether the domain is allowlisted.
+info "Test 7: SSH TCP to allowlisted domain (github.com:22) — blocked by default-deny OUTPUT..."
 if run_agent "test-ssh" alpine \
     "timeout 5 nc -w 3 github.com 22 </dev/null 2>/dev/null" \
     >/dev/null 2>&1; then
-    pass "SSH to allowlisted domain succeeded (port 22 bypasses TPROXY, DNS resolved)"
+    fail "SSH to allowlisted domain should be blocked by default-deny OUTPUT"
 else
-    fail "SSH to allowlisted domain failed"
+    pass "SSH to allowlisted domain blocked (default-deny OUTPUT, port 22 not permitted)"
 fi
 
 # --- Test 8: SSH TCP to non-allowlisted domain (DNS blocks it) ---

--- a/src/docker/proxy/test-proxy.sh
+++ b/src/docker/proxy/test-proxy.sh
@@ -55,7 +55,21 @@ docker run -d \
 # Wait for proxy to initialize
 info "Waiting for proxy to start..."
 sleep 5
-docker logs "$PROXY_CONTAINER" --tail 10
+
+info "Proxy startup logs:"
+docker logs "$PROXY_CONTAINER" 2>&1
+
+info "Proxy process list:"
+docker exec "$PROXY_CONTAINER" ps aux 2>/dev/null || true
+
+info "Listening sockets in proxy namespace:"
+docker exec "$PROXY_CONTAINER" ss -tlunp 2>/dev/null || true
+
+info "iptables nat OUTPUT rules:"
+docker exec "$PROXY_CONTAINER" iptables -t nat -L OUTPUT -n -v 2>/dev/null || true
+
+info "iptables filter OUTPUT rules:"
+docker exec "$PROXY_CONTAINER" iptables -L OUTPUT -n -v 2>/dev/null || true
 
 # Agent containers share the proxy's network namespace; CoreDNS listens on
 # loopback :53, so 127.0.0.1 resolves allowlisted domains and blocks others.

--- a/src/docker/proxy/test-proxy.sh
+++ b/src/docker/proxy/test-proxy.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Configuration
+PROXY_IMAGE="claude-proxy:local"
+PROXY_CONTAINER="claude-proxy-test"
+AGENT_NET="agent-net-test"
+BRIDGE_NET="bridge-net-test"
+CERTS_DIR="$(cd "$(dirname "$0")" && pwd)/certs"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}PASS${NC}: $1"; }
+fail() { echo -e "${RED}FAIL${NC}: $1"; FAILURES=$((FAILURES + 1)); }
+info() { echo -e "${YELLOW}INFO${NC}: $1"; }
+
+FAILURES=0
+
+cleanup() {
+    info "Cleaning up..."
+    docker rm -f "$PROXY_CONTAINER" 2>/dev/null || true
+    docker rm -f test-agent 2>/dev/null || true
+    docker network rm "$AGENT_NET" 2>/dev/null || true
+    docker network rm "$BRIDGE_NET" 2>/dev/null || true
+    info "Cleanup complete"
+}
+
+trap cleanup EXIT
+
+# --- Setup ---
+info "Building proxy image..."
+docker build -t "$PROXY_IMAGE" "$SCRIPT_DIR"
+
+info "Creating networks..."
+docker network create --internal "$AGENT_NET" 2>/dev/null || true
+docker network create "$BRIDGE_NET" 2>/dev/null || true
+
+info "Creating certs directory..."
+mkdir -p "$CERTS_DIR"
+
+info "Starting proxy container..."
+docker run -d \
+    --name "$PROXY_CONTAINER" \
+    --network "$BRIDGE_NET" \
+    --cap-add NET_ADMIN \
+    -v "$CERTS_DIR:/root/.mitmproxy" \
+    "$PROXY_IMAGE"
+
+# Attach proxy to agent network
+docker network connect "$AGENT_NET" "$PROXY_CONTAINER"
+
+# Wait for proxy to initialize
+info "Waiting for proxy to start..."
+sleep 5
+
+# Get proxy IP on agent network
+PROXY_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{if eq .NetworkID "'$(docker network inspect "$AGENT_NET" -f '{{.Id}}')'"}}{{.IPAddress}}{{end}}{{end}}' "$PROXY_CONTAINER")
+
+if [ -z "$PROXY_IP" ]; then
+    # Fallback: try simpler inspection
+    PROXY_IP=$(docker inspect "$PROXY_CONTAINER" --format '{{json .NetworkSettings.Networks}}' | jq -r '."'"$AGENT_NET"'".IPAddress')
+fi
+
+info "Proxy IP on agent network: $PROXY_IP"
+
+# Verify CA cert was generated
+if [ -f "$CERTS_DIR/mitmproxy-ca-cert.pem" ]; then
+    pass "CA certificate generated at $CERTS_DIR/mitmproxy-ca-cert.pem"
+else
+    fail "CA certificate not found"
+    exit 1
+fi
+
+# --- Helper: run test container ---
+run_agent() {
+    local name="$1"
+    shift
+    docker run --rm \
+        --name test-agent \
+        --network "$AGENT_NET" \
+        --dns "$PROXY_IP" \
+        -e "REQUESTS_CA_BUNDLE=/etc/proxy-ca/mitmproxy-ca-cert.pem" \
+        -e "SSL_CERT_FILE=/etc/proxy-ca/mitmproxy-ca-cert.pem" \
+        -e "NODE_EXTRA_CA_CERTS=/etc/proxy-ca/mitmproxy-ca-cert.pem" \
+        -e "CURL_CA_BUNDLE=/etc/proxy-ca/mitmproxy-ca-cert.pem" \
+        -e "GIT_SSL_CAINFO=/etc/proxy-ca/mitmproxy-ca-cert.pem" \
+        -e "http_proxy=http://$PROXY_IP:8080" \
+        -e "https_proxy=http://$PROXY_IP:8080" \
+        -e "HTTP_PROXY=http://$PROXY_IP:8080" \
+        -e "HTTPS_PROXY=http://$PROXY_IP:8080" \
+        -v "$CERTS_DIR/mitmproxy-ca-cert.pem:/etc/proxy-ca/mitmproxy-ca-cert.pem:ro" \
+        "$@"
+}
+
+# --- Test 1: Allowlisted domain (HTTPS) ---
+info "Test 1: HTTPS request to allowlisted domain (api.github.com)..."
+if run_agent "test-allow" debian:bookworm-slim \
+    bash -c "apt-get update -qq && apt-get install -y -qq curl >/dev/null 2>&1 && curl -sf --max-time 15 --cacert /etc/proxy-ca/mitmproxy-ca-cert.pem https://api.github.com/ >/dev/null 2>&1"; then
+    pass "Allowlisted HTTPS request succeeded"
+else
+    fail "Allowlisted HTTPS request failed"
+fi
+
+# --- Test 2: Non-allowlisted domain (HTTPS) ---
+info "Test 2: HTTPS request to non-allowlisted domain (example.com)..."
+HTTP_CODE=$(run_agent "test-deny" debian:bookworm-slim \
+    bash -c "apt-get update -qq && apt-get install -y -qq curl >/dev/null 2>&1 && curl -s --max-time 15 --cacert /etc/proxy-ca/mitmproxy-ca-cert.pem -o /dev/null -w '%{http_code}' https://example.com/ 2>/dev/null || echo 'BLOCKED'" || echo "BLOCKED")
+
+if [ "$HTTP_CODE" = "403" ] || [ "$HTTP_CODE" = "BLOCKED" ]; then
+    pass "Non-allowlisted HTTPS request blocked (code: $HTTP_CODE)"
+else
+    fail "Non-allowlisted HTTPS request not blocked (code: $HTTP_CODE)"
+fi
+
+# --- Test 3: DNS allowlisted domain ---
+info "Test 3: DNS resolution for allowlisted domain..."
+if run_agent "test-dns-allow" debian:bookworm-slim \
+    bash -c "apt-get update -qq && apt-get install -y -qq dnsutils >/dev/null 2>&1 && nslookup api.github.com $PROXY_IP >/dev/null 2>&1"; then
+    pass "DNS resolution for allowlisted domain succeeded"
+else
+    fail "DNS resolution for allowlisted domain failed"
+fi
+
+# --- Test 4: DNS non-allowlisted domain (NXDOMAIN) ---
+info "Test 4: DNS resolution for non-allowlisted domain..."
+if run_agent "test-dns-deny" debian:bookworm-slim \
+    bash -c "apt-get update -qq && apt-get install -y -qq dnsutils >/dev/null 2>&1 && nslookup example.com $PROXY_IP >/dev/null 2>&1"; then
+    fail "DNS resolution for non-allowlisted domain should have failed"
+else
+    pass "DNS for non-allowlisted domain returned NXDOMAIN"
+fi
+
+# --- Test 5: Node.js DNS bypass path ---
+info "Test 5: Node.js native fetch to non-allowlisted domain..."
+if run_agent "test-node-bypass" node:22-slim \
+    node -e "fetch('https://blocked.example.com').then(r => { console.log(r.status); process.exit(0); }).catch(e => { console.error(e.cause?.code || e.message); process.exit(1); })" 2>/dev/null; then
+    fail "Node.js fetch to non-allowlisted domain should have failed"
+else
+    pass "Node.js fetch blocked for non-allowlisted domain (DNS-level)"
+fi
+
+# --- Test 6: Direct connection attempt (no proxy) ---
+info "Test 6: Direct TCP connection attempt (bypassing proxy)..."
+if run_agent "test-direct" debian:bookworm-slim \
+    bash -c "timeout 5 bash -c 'echo | nc -w 3 93.184.216.34 80' 2>/dev/null"; then
+    fail "Direct TCP connection should have failed on internal network"
+else
+    pass "Direct TCP connection blocked (no internet route on internal network)"
+fi
+
+# --- Results ---
+echo ""
+echo "=============================="
+if [ $FAILURES -eq 0 ]; then
+    echo -e "${GREEN}All tests passed${NC}"
+    exit 0
+else
+    echo -e "${RED}$FAILURES test(s) failed${NC}"
+    exit 1
+fi

--- a/src/docker/proxy/test-proxy.sh
+++ b/src/docker/proxy/test-proxy.sh
@@ -170,9 +170,8 @@ else
 fi
 
 # --- Test 8: SSH TCP to non-allowlisted domain (DNS blocks it) ---
-# DNS NXDOMAIN for example.com prevents nc from resolving the host, so the
-# TCP connection is never attempted. Port 22 is not intercepted by TPROXY;
-# the only enforcement is DNS-level blocking for non-allowlisted domains.
+# DNS NXDOMAIN for example.com prevents nc from resolving the host; the
+# default-deny TCP DROP would also block it if DNS somehow resolved.
 info "Test 8: SSH TCP connect to non-allowlisted domain (example.com:22) — DNS blocked..."
 if run_agent "test-ssh-deny" alpine \
     "timeout 5 nc -w 3 example.com 22 </dev/null 2>/dev/null" \
@@ -180,6 +179,21 @@ if run_agent "test-ssh-deny" alpine \
     fail "SSH to non-allowlisted domain should have failed (DNS NXDOMAIN)"
 else
     pass "SSH to non-allowlisted domain blocked (DNS NXDOMAIN)"
+fi
+
+# --- Test 9: UDP to external resolver (DNS exfiltration path, now blocked) ---
+# nslookup with an explicit server address sends UDP directly to 1.1.1.1:53,
+# bypassing CoreDNS entirely. The default-deny UDP OUTPUT DROP blocks it;
+# the query times out and nslookup exits non-zero.
+# This closes the 2B gap for UDP: raw IP + non-HTTP/HTTPS protocol was
+# previously unrestricted; default-deny now covers both TCP and UDP.
+info "Test 9: UDP DNS query to external resolver (1.1.1.1) — blocked by default-deny UDP..."
+if run_agent "test-udp-exfil" alpine \
+    "nslookup api.github.com 1.1.1.1 >/dev/null 2>&1" \
+    >/dev/null 2>&1; then
+    fail "Direct UDP to external resolver should be blocked by default-deny"
+else
+    pass "UDP to external resolver blocked (default-deny UDP OUTPUT)"
 fi
 
 # --- Results ---

--- a/src/docker/proxy/test-proxy.sh
+++ b/src/docker/proxy/test-proxy.sh
@@ -257,6 +257,9 @@ docker exec "$PROXY_CONTAINER" iptables -t nat -L -v -n 2>/dev/null || true
 echo ""
 echo "=== iptables filter table (post-test) ==="
 docker exec "$PROXY_CONTAINER" iptables -L -v -n 2>/dev/null || true
+echo ""
+echo "=== kernel log — dropped packets ==="
+docker exec "$PROXY_CONTAINER" dmesg 2>/dev/null | grep -E "TCP-DROP|UDP-DROP" | tail -30 || echo "(no dmesg access or no matches)"
 echo "========================================"
 
 # --- Results ---

--- a/src/docker/proxy/test-proxy.sh
+++ b/src/docker/proxy/test-proxy.sh
@@ -98,9 +98,10 @@ run_agent() {
 }
 
 # --- Test 1: Allowlisted domain (HTTPS) ---
+# Uses curlimages/curl — curl pre-installed, no apt-get needed
 info "Test 1: HTTPS request to allowlisted domain (api.github.com)..."
-if run_agent "test-allow" debian:bookworm-slim \
-    bash -c "apt-get update -qq && apt-get install -y -qq curl >/dev/null 2>&1 && curl -sf --max-time 15 --cacert /etc/proxy-ca/mitmproxy-ca-cert.pem https://api.github.com/ >/dev/null 2>&1"; then
+if run_agent "test-allow" curlimages/curl \
+    -sf --max-time 15 --cacert /etc/proxy-ca/mitmproxy-ca-cert.pem https://api.github.com/ >/dev/null 2>&1; then
     pass "Allowlisted HTTPS request succeeded"
 else
     fail "Allowlisted HTTPS request failed"
@@ -108,8 +109,8 @@ fi
 
 # --- Test 2: Non-allowlisted domain (HTTPS) ---
 info "Test 2: HTTPS request to non-allowlisted domain (example.com)..."
-HTTP_CODE=$(run_agent "test-deny" debian:bookworm-slim \
-    bash -c "apt-get update -qq && apt-get install -y -qq curl >/dev/null 2>&1 && curl -s --max-time 15 --cacert /etc/proxy-ca/mitmproxy-ca-cert.pem -o /dev/null -w '%{http_code}' https://example.com/ 2>/dev/null || echo 'BLOCKED'" || echo "BLOCKED")
+HTTP_CODE=$(run_agent "test-deny" curlimages/curl \
+    -s --max-time 15 --cacert /etc/proxy-ca/mitmproxy-ca-cert.pem -o /dev/null -w '%{http_code}' https://example.com/ 2>/dev/null || echo "BLOCKED")
 
 if [ "$HTTP_CODE" = "403" ] || [ "$HTTP_CODE" = "BLOCKED" ]; then
     pass "Non-allowlisted HTTPS request blocked (code: $HTTP_CODE)"
@@ -118,9 +119,10 @@ else
 fi
 
 # --- Test 3: DNS allowlisted domain ---
+# Uses busybox — nslookup pre-installed, no apt-get needed
 info "Test 3: DNS resolution for allowlisted domain..."
-if run_agent "test-dns-allow" debian:bookworm-slim \
-    bash -c "apt-get update -qq && apt-get install -y -qq dnsutils >/dev/null 2>&1 && nslookup api.github.com $PROXY_IP >/dev/null 2>&1"; then
+if run_agent "test-dns-allow" busybox \
+    nslookup api.github.com "$PROXY_IP" >/dev/null 2>&1; then
     pass "DNS resolution for allowlisted domain succeeded"
 else
     fail "DNS resolution for allowlisted domain failed"
@@ -128,8 +130,8 @@ fi
 
 # --- Test 4: DNS non-allowlisted domain (NXDOMAIN) ---
 info "Test 4: DNS resolution for non-allowlisted domain..."
-if run_agent "test-dns-deny" debian:bookworm-slim \
-    bash -c "apt-get update -qq && apt-get install -y -qq dnsutils >/dev/null 2>&1 && nslookup example.com $PROXY_IP >/dev/null 2>&1"; then
+if run_agent "test-dns-deny" busybox \
+    nslookup example.com "$PROXY_IP" >/dev/null 2>&1; then
     fail "DNS resolution for non-allowlisted domain should have failed"
 else
     pass "DNS for non-allowlisted domain returned NXDOMAIN"
@@ -145,9 +147,10 @@ else
 fi
 
 # --- Test 6: Direct connection attempt (no proxy) ---
+# Uses busybox — nc pre-installed, no apt-get needed
 info "Test 6: Direct TCP connection attempt (bypassing proxy)..."
-if run_agent "test-direct" debian:bookworm-slim \
-    bash -c "timeout 5 bash -c 'echo | nc -w 3 93.184.216.34 80' 2>/dev/null"; then
+if run_agent "test-direct" busybox \
+    sh -c "timeout 5 nc -w 3 93.184.216.34 80 </dev/null 2>/dev/null"; then
     fail "Direct TCP connection should have failed on internal network"
 else
     pass "Direct TCP connection blocked (no internet route on internal network)"

--- a/src/docker/proxy/test-proxy.sh
+++ b/src/docker/proxy/test-proxy.sh
@@ -143,12 +143,10 @@ DIAG_D=$(run_agent "test-diag" alpine \
 info "  Result:"
 echo "$DIAG_D" | head -10
 
-info "Diag E: SO_ORIGINAL_DST test — does OUTPUT REDIRECT store original dest in conntrack?"
+info "Diag E: SO_ORIGINAL_DST — loopback src (127.0.0.1→127.0.0.1:18080 REDIRECT→18999)..."
 docker exec "$PROXY_CONTAINER" python3 -c "
-import socket, struct, sys, threading, time
-
-SO_ORIGINAL_DST = 80  # SOL_IP=0, SO_ORIGINAL_DST=80
-
+import socket, struct, subprocess, threading, time
+SO_ORIGINAL_DST = 80
 result = []
 def server():
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -160,31 +158,54 @@ def server():
         dst = conn.getsockopt(socket.SOL_IP, SO_ORIGINAL_DST, 16)
         port = struct.unpack('!H', dst[2:4])[0]
         ip = '.'.join(str(b) for b in dst[4:8])
-        result.append(f'SO_ORIGINAL_DST={ip}:{port}')
+        result.append(f'peer={addr[0]}:{addr[1]} SO_ORIGINAL_DST={ip}:{port}')
     except Exception as e:
-        result.append(f'SO_ORIGINAL_DST error: {e}')
+        result.append(f'peer={addr[0]}:{addr[1]} SO_ORIGINAL_DST error: {e}')
     conn.close()
     s.close()
-
-t = threading.Thread(target=server, daemon=True)
-t.start()
-time.sleep(0.2)
-
-# Temp REDIRECT: port 18080 → 18999
-import subprocess
+t = threading.Thread(target=server, daemon=True); t.start(); time.sleep(0.2)
 subprocess.run(['iptables','-t','nat','-A','OUTPUT','-p','tcp','--dport','18080','-j','REDIRECT','--to-port','18999'], check=True)
 try:
-    c = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    c.settimeout(3)
-    c.connect(('127.0.0.1', 18080))  # goes to 18999 via REDIRECT
-    c.close()
-except Exception as e:
-    result.append(f'connect error: {e}')
-finally:
-    subprocess.run(['iptables','-t','nat','-D','OUTPUT','-p','tcp','--dport','18080','-j','REDIRECT','--to-port','18999'])
+    c = socket.socket(socket.AF_INET, socket.SOCK_STREAM); c.settimeout(3)
+    c.connect(('127.0.0.1', 18080)); c.close()
+except Exception as e: result.append(f'connect error: {e}')
+finally: subprocess.run(['iptables','-t','nat','-D','OUTPUT','-p','tcp','--dport','18080','-j','REDIRECT','--to-port','18999'])
+t.join(timeout=3); print(result[0] if result else 'no result')
+" 2>&1 || true
 
-t.join(timeout=3)
-print(result[0] if result else 'no result')
+info "Diag F: SO_ORIGINAL_DST — external src (→1.1.1.1:18080 REDIRECT→18999, non-lo source)..."
+docker exec "$PROXY_CONTAINER" python3 -c "
+import socket, struct, subprocess, threading, time
+SO_ORIGINAL_DST = 80
+result = []
+def server():
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind(('0.0.0.0', 18999))
+    s.listen(1)
+    s.settimeout(5)
+    try:
+        conn, addr = s.accept()
+        try:
+            dst = conn.getsockopt(socket.SOL_IP, SO_ORIGINAL_DST, 16)
+            port = struct.unpack('!H', dst[2:4])[0]
+            ip = '.'.join(str(b) for b in dst[4:8])
+            result.append(f'peer={addr[0]}:{addr[1]} SO_ORIGINAL_DST={ip}:{port}')
+        except Exception as e:
+            result.append(f'peer={addr[0]}:{addr[1]} SO_ORIGINAL_DST error: {e}')
+        conn.close()
+    except socket.timeout:
+        result.append('server accept() TIMED OUT — packet never reached server')
+    s.close()
+t = threading.Thread(target=server, daemon=True); t.start(); time.sleep(0.2)
+subprocess.run(['iptables','-t','nat','-A','OUTPUT','-p','tcp','--dport','18080','-j','REDIRECT','--to-port','18999'], check=True)
+try:
+    c = socket.socket(socket.AF_INET, socket.SOCK_STREAM); c.settimeout(4)
+    c.connect(('1.1.1.1', 18080))  # external IP — source will be bridge IP, not 127.0.0.1
+    c.close()
+except Exception as e: result.append(f'connect error: {e}')
+finally: subprocess.run(['iptables','-t','nat','-D','OUTPUT','-p','tcp','--dport','18080','-j','REDIRECT','--to-port','18999'])
+t.join(timeout=6); print('; '.join(result) if result else 'no result')
 " 2>&1 || true
 
 echo ""

--- a/src/docker/proxy/test-proxy.sh
+++ b/src/docker/proxy/test-proxy.sh
@@ -67,6 +67,7 @@ docker network connect --ip "$PROXY_IP" "$AGENT_NET" "$PROXY_CONTAINER"
 # Wait for proxy to initialize
 info "Waiting for proxy to start..."
 sleep 5
+docker logs "$PROXY_CONTAINER" || true
 
 info "Proxy IP on agent network: $PROXY_IP"
 
@@ -98,7 +99,7 @@ run_agent() {
         -v "$CERTS_DIR/mitmproxy-ca-cert.pem:/etc/proxy-ca/mitmproxy-ca-cert.pem:ro" \
         --entrypoint sh \
         "$image" \
-        -c "ip route add default via $PROXY_IP 2>/dev/null || true; $cmd"
+        -c "cat /etc/proxy-ca/mitmproxy-ca-cert.pem >> /etc/ssl/certs/ca-certificates.crt 2>/dev/null || true; ip route add default via $PROXY_IP 2>/dev/null || true; $cmd"
 }
 
 # --- Test 1: Allowlisted domain (HTTPS, transparent interception) ---
@@ -106,7 +107,7 @@ run_agent() {
 # mitmdump intercepts TLS, presents mitmproxy CA-signed cert; wget trusts it.
 info "Test 1: HTTPS request to allowlisted domain (api.github.com) — transparent..."
 if run_agent "test-allow" alpine \
-    "wget -qO- --ca-certificate=/etc/proxy-ca/mitmproxy-ca-cert.pem https://api.github.com/ >/dev/null" \
+    "wget -qO- https://api.github.com/ >/dev/null" \
     >/dev/null 2>&1; then
     pass "Allowlisted HTTPS request succeeded (transparently intercepted)"
 else

--- a/src/docker/proxy/test-proxy.sh
+++ b/src/docker/proxy/test-proxy.sh
@@ -37,11 +37,13 @@ info "Building proxy image..."
 docker build -t "$PROXY_IMAGE" "$SCRIPT_DIR"
 
 info "Creating networks..."
-# agent-net: specific subnet, no --internal. --internal would add a host-level
-# iptables isolation rule that blocks the proxy from forwarding traffic, even
-# with IP forwarding enabled. Instead, the proxy's own iptables (PREROUTING +
-# MASQUERADE) enforces policy, and mitmproxy's addon enforces the allowlist.
-docker network create --subnet 10.100.0.0/24 "$AGENT_NET" 2>/dev/null || true
+# agent-net: --internal so agents have no default internet route (must use proxy).
+# --subnet 10.100.0.0/24 gives deterministic addressing for the static proxy IP.
+# The proxy container is multi-homed (bridge-net + agent-net) and bridges them
+# within its own network namespace via IP forwarding + MASQUERADE. Docker's
+# --internal isolation rules only block host-level forwarding between bridges,
+# not forwarding done inside the proxy container's network namespace.
+docker network create --internal --subnet 10.100.0.0/24 "$AGENT_NET" 2>/dev/null || true
 docker network create "$BRIDGE_NET" 2>/dev/null || true
 
 info "Creating certs directory..."

--- a/src/docker/proxy/test-proxy.sh
+++ b/src/docker/proxy/test-proxy.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 # Configuration
 PROXY_IMAGE="claude-proxy:local"
 PROXY_CONTAINER="claude-proxy-test"
+NETINIT_CONTAINER="net-init-test"
 AGENT_NET="agent-net-test"
 BRIDGE_NET="bridge-net-test"
 CERTS_DIR="$(cd "$(dirname "$0")" && pwd)/certs"
@@ -24,6 +25,7 @@ FAILURES=0
 cleanup() {
     info "Cleaning up..."
     docker rm -f "$PROXY_CONTAINER" 2>/dev/null || true
+    docker rm -f "$NETINIT_CONTAINER" 2>/dev/null || true
     docker rm -f test-agent 2>/dev/null || true
     docker network rm "$AGENT_NET" 2>/dev/null || true
     docker network rm "$BRIDGE_NET" 2>/dev/null || true
@@ -59,8 +61,6 @@ docker run -d \
     "$PROXY_IMAGE"
 
 # Attach proxy to agent network with a static IP so PROXY_IP is predictable.
-# Agent containers add a default route to this IP via ip route, routing all
-# their traffic through the proxy for transparent interception.
 PROXY_IP="10.100.0.2"
 docker network connect --ip "$PROXY_IP" "$AGENT_NET" "$PROXY_CONTAINER"
 
@@ -78,27 +78,34 @@ else
     exit 1
 fi
 
-# --- Helper: run test container with transparent proxy routing ---
-# Agent containers use --cap-add NET_ADMIN to add a default route through the
-# proxy. This routes all TCP through the proxy's iptables PREROUTING rules,
-# which redirect ports 80/443 to mitmdump (transparent mode). No explicit
-# proxy env vars needed — interception is transparent to the application.
-# Uses alpine as base (wget, nslookup, nc, ip all included via busybox).
+# --- Network init sidecar ---
+# A single sidecar container with NET_ADMIN configures the default route
+# through the proxy. Agent test containers use --network container:net-init
+# to inherit the pre-configured network namespace without needing NET_ADMIN
+# themselves. DNS is set by writing /etc/resolv.conf in each container's
+# wrapper command (--dns is not available with --network container:).
+info "Starting network init sidecar..."
+docker run -d \
+    --name "$NETINIT_CONTAINER" \
+    --network "$AGENT_NET" \
+    --cap-add NET_ADMIN \
+    alpine \
+    sh -c "ip route add default via $PROXY_IP 2>/dev/null || true && sleep infinity"
+sleep 1
+
+# --- Helper: run test container sharing net-init's network namespace ---
 run_agent() {
     local name="$1"
     local image="$2"
     local cmd="$3"
     docker run --rm \
         --name test-agent \
-        --network "$AGENT_NET" \
-        --dns "$PROXY_IP" \
-        --cap-add NET_ADMIN \
-        -e "SSL_CERT_FILE=/etc/proxy-ca/mitmproxy-ca-cert.pem" \
+        --network "container:$NETINIT_CONTAINER" \
         -e "NODE_EXTRA_CA_CERTS=/etc/proxy-ca/mitmproxy-ca-cert.pem" \
         -v "$CERTS_DIR/mitmproxy-ca-cert.pem:/etc/proxy-ca/mitmproxy-ca-cert.pem:ro" \
         --entrypoint sh \
         "$image" \
-        -c "cat /etc/proxy-ca/mitmproxy-ca-cert.pem >> /etc/ssl/certs/ca-certificates.crt 2>/dev/null || true; ip route add default via $PROXY_IP 2>/dev/null || true; $cmd"
+        -c "echo 'nameserver $PROXY_IP' > /etc/resolv.conf; cat /etc/proxy-ca/mitmproxy-ca-cert.pem >> /etc/ssl/certs/ca-certificates.crt 2>/dev/null || true; $cmd"
 }
 
 # --- Test 1: Allowlisted domain (HTTPS, transparent interception) ---
@@ -117,7 +124,7 @@ fi
 # DNS returns NXDOMAIN for example.com (CoreDNS catch-all block).
 info "Test 2: HTTPS request to non-allowlisted domain (example.com) — transparent..."
 if run_agent "test-deny" alpine \
-    "wget -qO- --ca-certificate=/etc/proxy-ca/mitmproxy-ca-cert.pem https://example.com/ >/dev/null 2>&1"; then
+    "wget -qO- https://example.com/ >/dev/null 2>&1"; then
     fail "Non-allowlisted HTTPS request should have been blocked"
 else
     pass "Non-allowlisted HTTPS request blocked (DNS NXDOMAIN or mitmproxy 403)"

--- a/src/docker/proxy/test-proxy.sh
+++ b/src/docker/proxy/test-proxy.sh
@@ -54,6 +54,7 @@ docker run -d \
     --name "$PROXY_CONTAINER" \
     --network "$BRIDGE_NET" \
     --cap-add NET_ADMIN \
+    --sysctl net.ipv4.ip_forward=1 \
     -v "$CERTS_DIR:/root/.mitmproxy" \
     "$PROXY_IMAGE"
 

--- a/src/docker/proxy/test-proxy.sh
+++ b/src/docker/proxy/test-proxy.sh
@@ -49,6 +49,8 @@ docker run -d \
     --name "$PROXY_CONTAINER" \
     --network "$BRIDGE_NET" \
     --cap-add NET_ADMIN \
+    --sysctl net.ipv4.conf.all.rp_filter=0 \
+    --sysctl net.ipv4.conf.lo.rp_filter=0 \
     -v "$CERTS_DIR:/var/lib/mitmproxy" \
     "$PROXY_IMAGE"
 

--- a/src/docker/proxy/test-proxy.sh
+++ b/src/docker/proxy/test-proxy.sh
@@ -76,53 +76,56 @@ else
     exit 1
 fi
 
-# --- Helper: run test container ---
+# --- Helper: run test container with transparent proxy routing ---
+# Agent containers use --cap-add NET_ADMIN to add a default route through the
+# proxy. This routes all TCP through the proxy's iptables PREROUTING rules,
+# which redirect ports 80/443 to mitmdump (transparent mode). No explicit
+# proxy env vars needed — interception is transparent to the application.
+# Uses alpine as base (wget, nslookup, nc, ip all included via busybox).
 run_agent() {
     local name="$1"
-    shift
+    local image="$2"
+    local cmd="$3"
     docker run --rm \
         --name test-agent \
         --network "$AGENT_NET" \
         --dns "$PROXY_IP" \
-        -e "REQUESTS_CA_BUNDLE=/etc/proxy-ca/mitmproxy-ca-cert.pem" \
+        --cap-add NET_ADMIN \
         -e "SSL_CERT_FILE=/etc/proxy-ca/mitmproxy-ca-cert.pem" \
         -e "NODE_EXTRA_CA_CERTS=/etc/proxy-ca/mitmproxy-ca-cert.pem" \
-        -e "CURL_CA_BUNDLE=/etc/proxy-ca/mitmproxy-ca-cert.pem" \
-        -e "GIT_SSL_CAINFO=/etc/proxy-ca/mitmproxy-ca-cert.pem" \
-        -e "http_proxy=http://$PROXY_IP:8080" \
-        -e "https_proxy=http://$PROXY_IP:8080" \
-        -e "HTTP_PROXY=http://$PROXY_IP:8080" \
-        -e "HTTPS_PROXY=http://$PROXY_IP:8080" \
         -v "$CERTS_DIR/mitmproxy-ca-cert.pem:/etc/proxy-ca/mitmproxy-ca-cert.pem:ro" \
-        "$@"
+        --entrypoint sh \
+        "$image" \
+        -c "ip route add default via $PROXY_IP 2>/dev/null || true; $cmd"
 }
 
-# --- Test 1: Allowlisted domain (HTTPS) ---
-# Uses curlimages/curl — curl pre-installed, no apt-get needed
-info "Test 1: HTTPS request to allowlisted domain (api.github.com)..."
-if run_agent "test-allow" curlimages/curl \
-    -sf --max-time 15 --cacert /etc/proxy-ca/mitmproxy-ca-cert.pem https://api.github.com/ >/dev/null 2>&1; then
-    pass "Allowlisted HTTPS request succeeded"
+# --- Test 1: Allowlisted domain (HTTPS, transparent interception) ---
+# No proxy env vars. Traffic routes through proxy via iptables REDIRECT.
+# mitmdump intercepts TLS, presents mitmproxy CA-signed cert; wget trusts it.
+info "Test 1: HTTPS request to allowlisted domain (api.github.com) — transparent..."
+if run_agent "test-allow" alpine \
+    "wget -qO- --ca-certificate=/etc/proxy-ca/mitmproxy-ca-cert.pem https://api.github.com/ >/dev/null" \
+    >/dev/null 2>&1; then
+    pass "Allowlisted HTTPS request succeeded (transparently intercepted)"
 else
     fail "Allowlisted HTTPS request failed"
 fi
 
-# --- Test 2: Non-allowlisted domain (HTTPS) ---
-info "Test 2: HTTPS request to non-allowlisted domain (example.com)..."
-HTTP_CODE=$(run_agent "test-deny" curlimages/curl \
-    -s --max-time 15 --cacert /etc/proxy-ca/mitmproxy-ca-cert.pem -o /dev/null -w '%{http_code}' https://example.com/ 2>/dev/null || echo "BLOCKED")
-
-if [ "$HTTP_CODE" = "403" ] || [ "$HTTP_CODE" = "BLOCKED" ]; then
-    pass "Non-allowlisted HTTPS request blocked (code: $HTTP_CODE)"
+# --- Test 2: Non-allowlisted domain (HTTPS, transparent interception) ---
+# DNS returns NXDOMAIN for example.com (CoreDNS catch-all block).
+info "Test 2: HTTPS request to non-allowlisted domain (example.com) — transparent..."
+if run_agent "test-deny" alpine \
+    "wget -qO- --ca-certificate=/etc/proxy-ca/mitmproxy-ca-cert.pem https://example.com/ >/dev/null 2>&1"; then
+    fail "Non-allowlisted HTTPS request should have been blocked"
 else
-    fail "Non-allowlisted HTTPS request not blocked (code: $HTTP_CODE)"
+    pass "Non-allowlisted HTTPS request blocked (DNS NXDOMAIN or mitmproxy 403)"
 fi
 
 # --- Test 3: DNS allowlisted domain ---
-# Uses busybox — nslookup pre-installed, no apt-get needed
 info "Test 3: DNS resolution for allowlisted domain..."
-if run_agent "test-dns-allow" busybox \
-    nslookup api.github.com "$PROXY_IP" >/dev/null 2>&1; then
+if run_agent "test-dns-allow" alpine \
+    "nslookup api.github.com $PROXY_IP >/dev/null 2>&1" \
+    >/dev/null 2>&1; then
     pass "DNS resolution for allowlisted domain succeeded"
 else
     fail "DNS resolution for allowlisted domain failed"
@@ -130,30 +133,36 @@ fi
 
 # --- Test 4: DNS non-allowlisted domain (NXDOMAIN) ---
 info "Test 4: DNS resolution for non-allowlisted domain..."
-if run_agent "test-dns-deny" busybox \
-    nslookup example.com "$PROXY_IP" >/dev/null 2>&1; then
+if run_agent "test-dns-deny" alpine \
+    "nslookup example.com $PROXY_IP >/dev/null 2>&1" \
+    >/dev/null 2>&1; then
     fail "DNS resolution for non-allowlisted domain should have failed"
 else
     pass "DNS for non-allowlisted domain returned NXDOMAIN"
 fi
 
-# --- Test 5: Node.js DNS bypass path ---
-info "Test 5: Node.js native fetch to non-allowlisted domain..."
+# --- Test 5: Node.js native fetch to non-allowlisted domain ---
+# No proxy env vars. DNS NXDOMAIN prevents resolution.
+info "Test 5: Node.js native fetch to non-allowlisted domain (transparent)..."
 if run_agent "test-node-bypass" node:22-slim \
-    node -e "fetch('https://blocked.example.com').then(r => { console.log(r.status); process.exit(0); }).catch(e => { console.error(e.cause?.code || e.message); process.exit(1); })" 2>/dev/null; then
+    "node -e \"fetch('https://blocked.example.com').then(r => { console.log(r.status); process.exit(0); }).catch(e => { console.error(e.cause?.code || e.message); process.exit(1); })\"" \
+    >/dev/null 2>&1; then
     fail "Node.js fetch to non-allowlisted domain should have failed"
 else
     pass "Node.js fetch blocked for non-allowlisted domain (DNS-level)"
 fi
 
-# --- Test 6: Direct connection attempt (no proxy) ---
-# Uses busybox — nc pre-installed, no apt-get needed
-info "Test 6: Direct TCP connection attempt (bypassing proxy)..."
-if run_agent "test-direct" busybox \
-    sh -c "timeout 5 nc -w 3 93.184.216.34 80 </dev/null 2>/dev/null"; then
-    fail "Direct TCP connection should have failed on internal network"
+# --- Test 6: Direct TCP to raw IP (bypass DNS, test iptables interception) ---
+# Connects to a raw IP (example.com's address) on port 80, bypassing DNS.
+# iptables PREROUTING redirects this to mitmdump transparent mode.
+# The IP does not match any allowlisted domain → mitmproxy blocks it.
+info "Test 6: Direct TCP to raw IP — iptables transparent interception..."
+if run_agent "test-direct" alpine \
+    "timeout 5 nc -w 3 93.184.216.34 80 </dev/null 2>/dev/null" \
+    >/dev/null 2>&1; then
+    fail "Direct TCP to raw IP should have been intercepted and blocked"
 else
-    pass "Direct TCP connection blocked (no internet route on internal network)"
+    pass "Direct TCP to raw IP blocked (transparently intercepted by iptables)"
 fi
 
 # --- Results ---

--- a/src/docker/proxy/test-proxy.sh
+++ b/src/docker/proxy/test-proxy.sh
@@ -67,7 +67,6 @@ docker network connect --ip "$PROXY_IP" "$AGENT_NET" "$PROXY_CONTAINER"
 # Wait for proxy to initialize
 info "Waiting for proxy to start..."
 sleep 5
-docker logs "$PROXY_CONTAINER" || true
 
 info "Proxy IP on agent network: $PROXY_IP"
 

--- a/src/docker/proxy/test-proxy.sh
+++ b/src/docker/proxy/test-proxy.sh
@@ -4,8 +4,6 @@ set -euo pipefail
 # Configuration
 PROXY_IMAGE="claude-proxy:local"
 PROXY_CONTAINER="claude-proxy-test"
-NETINIT_CONTAINER="net-init-test"
-AGENT_NET="agent-net-test"
 BRIDGE_NET="bridge-net-test"
 CERTS_DIR="$(cd "$(dirname "$0")" && pwd)/certs"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -25,9 +23,7 @@ FAILURES=0
 cleanup() {
     info "Cleaning up..."
     docker rm -f "$PROXY_CONTAINER" 2>/dev/null || true
-    docker rm -f "$NETINIT_CONTAINER" 2>/dev/null || true
     docker rm -f test-agent 2>/dev/null || true
-    docker network rm "$AGENT_NET" 2>/dev/null || true
     docker network rm "$BRIDGE_NET" 2>/dev/null || true
     info "Cleanup complete"
 }
@@ -39,13 +35,10 @@ info "Building proxy image..."
 docker build -t "$PROXY_IMAGE" "$SCRIPT_DIR"
 
 info "Creating networks..."
-# agent-net: --internal so agents have no default internet route (must use proxy).
-# --subnet 10.100.0.0/24 gives deterministic addressing for the static proxy IP.
-# The proxy container is multi-homed (bridge-net + agent-net) and bridges them
-# within its own network namespace via IP forwarding + MASQUERADE. Docker's
-# --internal isolation rules only block host-level forwarding between bridges,
-# not forwarding done inside the proxy container's network namespace.
-docker network create --internal --subnet 10.100.0.0/24 "$AGENT_NET" 2>/dev/null || true
+# bridge-net: gives the proxy container outbound internet access.
+# Agent containers share the proxy's network namespace via
+# --network container:<proxy>; they inherit all proxy interfaces and routing,
+# but TPROXY iptables rules intercept their traffic before it leaves.
 docker network create "$BRIDGE_NET" 2>/dev/null || true
 
 info "Creating certs directory..."
@@ -56,19 +49,16 @@ docker run -d \
     --name "$PROXY_CONTAINER" \
     --network "$BRIDGE_NET" \
     --cap-add NET_ADMIN \
-    --sysctl net.ipv4.ip_forward=1 \
     -v "$CERTS_DIR:/root/.mitmproxy" \
     "$PROXY_IMAGE"
-
-# Attach proxy to agent network with a static IP so PROXY_IP is predictable.
-PROXY_IP="10.100.0.2"
-docker network connect --ip "$PROXY_IP" "$AGENT_NET" "$PROXY_CONTAINER"
 
 # Wait for proxy to initialize
 info "Waiting for proxy to start..."
 sleep 5
 
-info "Proxy IP on agent network: $PROXY_IP"
+# Agent containers share the proxy's network namespace; CoreDNS listens on
+# loopback :53, so 127.0.0.1 resolves allowlisted domains and blocks others.
+PROXY_IP="127.0.0.1"
 
 # Verify CA cert was generated
 if [ -f "$CERTS_DIR/mitmproxy-ca-cert.pem" ]; then
@@ -78,34 +68,24 @@ else
     exit 1
 fi
 
-# --- Network init sidecar ---
-# A single sidecar container with NET_ADMIN configures the default route
-# through the proxy. Agent test containers use --network container:net-init
-# to inherit the pre-configured network namespace without needing NET_ADMIN
-# themselves. DNS is set by writing /etc/resolv.conf in each container's
-# wrapper command (--dns is not available with --network container:).
-info "Starting network init sidecar..."
-docker run -d \
-    --name "$NETINIT_CONTAINER" \
-    --network "$AGENT_NET" \
-    --cap-add NET_ADMIN \
-    alpine \
-    sh -c "ip route add default via $PROXY_IP 2>/dev/null || true && sleep infinity"
-sleep 1
-
-# --- Helper: run test container sharing net-init's network namespace ---
+# --- Helper: run test container sharing the proxy's network namespace ---
+# --network container:<proxy> gives the agent the same network interfaces,
+# iptables rules, and loopback as the proxy. TPROXY intercepts all TCP 80/443
+# from non-uid-9999 processes; no capability or route configuration needed in
+# the agent container. DNS is set by pointing resolv.conf at 127.0.0.1 where
+# CoreDNS is listening (--dns is not usable with --network container:).
 run_agent() {
     local name="$1"
     local image="$2"
     local cmd="$3"
     docker run --rm \
         --name test-agent \
-        --network "container:$NETINIT_CONTAINER" \
+        --network "container:$PROXY_CONTAINER" \
         -e "NODE_EXTRA_CA_CERTS=/etc/proxy-ca/mitmproxy-ca-cert.pem" \
         -v "$CERTS_DIR/mitmproxy-ca-cert.pem:/etc/proxy-ca/mitmproxy-ca-cert.pem:ro" \
         --entrypoint sh \
         "$image" \
-        -c "echo 'nameserver $PROXY_IP' > /etc/resolv.conf; cat /etc/proxy-ca/mitmproxy-ca-cert.pem >> /etc/ssl/certs/ca-certificates.crt 2>/dev/null || true; $cmd"
+        -c "echo 'nameserver 127.0.0.1' > /etc/resolv.conf; cat /etc/proxy-ca/mitmproxy-ca-cert.pem >> /etc/ssl/certs/ca-certificates.crt 2>/dev/null || true; $cmd"
 }
 
 # --- Test 1: Allowlisted domain (HTTPS, transparent interception) ---
@@ -161,17 +141,19 @@ else
     pass "Node.js fetch blocked for non-allowlisted domain (DNS-level)"
 fi
 
-# --- Test 6: Direct TCP to raw IP (bypass DNS, test iptables interception) ---
-# Connects to a raw IP (example.com's address) on port 80, bypassing DNS.
-# iptables PREROUTING redirects this to mitmdump transparent mode.
-# The IP does not match any allowlisted domain → mitmproxy blocks it.
-info "Test 6: Direct TCP to raw IP — iptables transparent interception..."
+# --- Test 6: Direct HTTP to raw IP (bypass DNS, test TPROXY interception) ---
+# Sends an HTTP GET to example.com's IP (93.184.216.34) on port 80, bypassing
+# DNS entirely. TPROXY OUTPUT MARK rule catches the outbound SYN, policy
+# routing re-injects it via loopback, PREROUTING TPROXY redirects it to
+# mitmdump :8080. The raw IP does not match any allowlisted domain so the
+# addon returns HTTP 403. wget treats 4xx as an error and exits non-zero.
+info "Test 6: Direct HTTP to raw IP — TPROXY interception and block..."
 if run_agent "test-direct" alpine \
-    "timeout 5 nc -w 3 93.184.216.34 80 </dev/null 2>/dev/null" \
+    "wget -qO- http://93.184.216.34/ >/dev/null 2>&1" \
     >/dev/null 2>&1; then
-    fail "Direct TCP to raw IP should have been intercepted and blocked"
+    fail "Direct HTTP to raw IP should have been intercepted and blocked (403)"
 else
-    pass "Direct TCP to raw IP blocked (transparently intercepted by iptables)"
+    pass "Direct HTTP to raw IP blocked (TPROXY intercepted, addon returned 403)"
 fi
 
 # --- Results ---

--- a/src/docker/proxy/test-proxy.sh
+++ b/src/docker/proxy/test-proxy.sh
@@ -156,6 +156,34 @@ else
     pass "Direct HTTP to raw IP blocked (TPROXY intercepted, addon returned 403)"
 fi
 
+# --- Test 7: SSH TCP to allowlisted domain (port 22, unintercepted) ---
+# TPROXY rules only cover ports 80 and 443. Port 22 traffic from the agent
+# process exits through the proxy's bridge-net interface directly, with no
+# iptables interception. DNS for github.com resolves (it is allowlisted).
+# nc connects; GitHub returns the SSH banner; nc exits 0 when stdin closes.
+# This verifies that non-HTTP/HTTPS traffic on allowlisted domains is permitted.
+info "Test 7: SSH TCP connect to allowlisted domain (github.com:22) — port 22 unintercepted..."
+if run_agent "test-ssh" alpine \
+    "timeout 5 nc -w 3 github.com 22 </dev/null 2>/dev/null" \
+    >/dev/null 2>&1; then
+    pass "SSH to allowlisted domain succeeded (port 22 bypasses TPROXY, DNS resolved)"
+else
+    fail "SSH to allowlisted domain failed"
+fi
+
+# --- Test 8: SSH TCP to non-allowlisted domain (DNS blocks it) ---
+# DNS NXDOMAIN for example.com prevents nc from resolving the host, so the
+# TCP connection is never attempted. Port 22 is not intercepted by TPROXY;
+# the only enforcement is DNS-level blocking for non-allowlisted domains.
+info "Test 8: SSH TCP connect to non-allowlisted domain (example.com:22) — DNS blocked..."
+if run_agent "test-ssh-deny" alpine \
+    "timeout 5 nc -w 3 example.com 22 </dev/null 2>/dev/null" \
+    >/dev/null 2>&1; then
+    fail "SSH to non-allowlisted domain should have failed (DNS NXDOMAIN)"
+else
+    pass "SSH to non-allowlisted domain blocked (DNS NXDOMAIN)"
+fi
+
 # --- Results ---
 echo ""
 echo "=============================="

--- a/src/docker/proxy/test-proxy.sh
+++ b/src/docker/proxy/test-proxy.sh
@@ -71,10 +71,11 @@ fi
 
 # --- Helper: run test container sharing the proxy's network namespace ---
 # --network container:<proxy> gives the agent the same network interfaces,
-# iptables rules, and loopback as the proxy. TPROXY intercepts all TCP 80/443
-# from non-uid-9999 processes; no capability or route configuration needed in
-# the agent container. DNS is set by pointing resolv.conf at 127.0.0.1 where
-# CoreDNS is listening (--dns is not usable with --network container:).
+# iptables rules, and loopback as the proxy. nat OUTPUT REDIRECT intercepts
+# all TCP 80/443 from non-uid-9999 processes; no capability or route
+# configuration needed in the agent container. DNS is set by pointing
+# resolv.conf at 127.0.0.1 where CoreDNS is listening
+# (--dns is not usable with --network container:).
 run_agent() {
     local name="$1"
     local image="$2"
@@ -94,7 +95,7 @@ run_agent() {
 # mitmdump intercepts TLS, presents mitmproxy CA-signed cert; wget trusts it.
 info "Test 1: HTTPS request to allowlisted domain (api.github.com) — transparent..."
 if run_agent "test-allow" alpine \
-    "wget -qO- https://api.github.com/ >/dev/null" \
+    "timeout 15 wget -T 10 -qO- https://api.github.com/ >/dev/null" \
     >/dev/null 2>&1; then
     pass "Allowlisted HTTPS request succeeded (transparently intercepted)"
 else
@@ -105,7 +106,7 @@ fi
 # DNS returns NXDOMAIN for example.com (CoreDNS catch-all block).
 info "Test 2: HTTPS request to non-allowlisted domain (example.com) — transparent..."
 if run_agent "test-deny" alpine \
-    "wget -qO- https://example.com/ >/dev/null 2>&1"; then
+    "timeout 15 wget -T 10 -qO- https://example.com/ >/dev/null 2>&1"; then
     fail "Non-allowlisted HTTPS request should have been blocked"
 else
     pass "Non-allowlisted HTTPS request blocked (DNS NXDOMAIN or mitmproxy 403)"
@@ -142,15 +143,14 @@ else
     pass "Node.js fetch blocked for non-allowlisted domain (DNS-level)"
 fi
 
-# --- Test 6: Direct HTTP to raw IP (bypass DNS, test TPROXY interception) ---
+# --- Test 6: Direct HTTP to raw IP (bypass DNS, test OUTPUT REDIRECT) ---
 # Sends an HTTP GET to example.com's IP (93.184.216.34) on port 80, bypassing
-# DNS entirely. TPROXY OUTPUT MARK rule catches the outbound SYN, policy
-# routing re-injects it via loopback, PREROUTING TPROXY redirects it to
+# DNS entirely. The nat OUTPUT REDIRECT rule catches port 80 and redirects to
 # mitmdump :8080. The raw IP does not match any allowlisted domain so the
 # addon returns HTTP 403. wget treats 4xx as an error and exits non-zero.
-info "Test 6: Direct HTTP to raw IP — TPROXY interception and block..."
+info "Test 6: Direct HTTP to raw IP — OUTPUT REDIRECT interception and block..."
 if run_agent "test-direct" alpine \
-    "wget -qO- http://93.184.216.34/ >/dev/null 2>&1" \
+    "timeout 15 wget -T 10 -qO- http://93.184.216.34/ >/dev/null 2>&1" \
     >/dev/null 2>&1; then
     fail "Direct HTTP to raw IP should have been intercepted and blocked (403)"
 else
@@ -196,6 +196,12 @@ if run_agent "test-udp-exfil" alpine \
 else
     pass "UDP to external resolver blocked (default-deny UDP OUTPUT)"
 fi
+
+# --- Proxy traffic log ---
+echo ""
+echo "=== Proxy container logs ==="
+docker logs "$PROXY_CONTAINER" 2>&1
+echo "============================"
 
 # --- Results ---
 echo ""

--- a/src/docker/proxy/test-proxy.sh
+++ b/src/docker/proxy/test-proxy.sh
@@ -37,7 +37,11 @@ info "Building proxy image..."
 docker build -t "$PROXY_IMAGE" "$SCRIPT_DIR"
 
 info "Creating networks..."
-docker network create --internal "$AGENT_NET" 2>/dev/null || true
+# agent-net: specific subnet, no --internal. --internal would add a host-level
+# iptables isolation rule that blocks the proxy from forwarding traffic, even
+# with IP forwarding enabled. Instead, the proxy's own iptables (PREROUTING +
+# MASQUERADE) enforces policy, and mitmproxy's addon enforces the allowlist.
+docker network create --subnet 10.100.0.0/24 "$AGENT_NET" 2>/dev/null || true
 docker network create "$BRIDGE_NET" 2>/dev/null || true
 
 info "Creating certs directory..."
@@ -51,20 +55,15 @@ docker run -d \
     -v "$CERTS_DIR:/root/.mitmproxy" \
     "$PROXY_IMAGE"
 
-# Attach proxy to agent network
-docker network connect "$AGENT_NET" "$PROXY_CONTAINER"
+# Attach proxy to agent network with a static IP so PROXY_IP is predictable.
+# Agent containers add a default route to this IP via ip route, routing all
+# their traffic through the proxy for transparent interception.
+PROXY_IP="10.100.0.1"
+docker network connect --ip "$PROXY_IP" "$AGENT_NET" "$PROXY_CONTAINER"
 
 # Wait for proxy to initialize
 info "Waiting for proxy to start..."
 sleep 5
-
-# Get proxy IP on agent network
-PROXY_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{if eq .NetworkID "'$(docker network inspect "$AGENT_NET" -f '{{.Id}}')'"}}{{.IPAddress}}{{end}}{{end}}' "$PROXY_CONTAINER")
-
-if [ -z "$PROXY_IP" ]; then
-    # Fallback: try simpler inspection
-    PROXY_IP=$(docker inspect "$PROXY_CONTAINER" --format '{{json .NetworkSettings.Networks}}' | jq -r '."'"$AGENT_NET"'".IPAddress')
-fi
 
 info "Proxy IP on agent network: $PROXY_IP"
 

--- a/src/docker/proxy/test-proxy.sh
+++ b/src/docker/proxy/test-proxy.sh
@@ -60,7 +60,7 @@ docker run -d \
 # Attach proxy to agent network with a static IP so PROXY_IP is predictable.
 # Agent containers add a default route to this IP via ip route, routing all
 # their traffic through the proxy for transparent interception.
-PROXY_IP="10.100.0.1"
+PROXY_IP="10.100.0.2"
 docker network connect --ip "$PROXY_IP" "$AGENT_NET" "$PROXY_CONTAINER"
 
 # Wait for proxy to initialize


### PR DESCRIPTION
## Summary

- Adds `src/docker/proxy/` — a standalone Docker container combining **CoreDNS** (DNS allowlisting) and **mitmdump in TPROXY mode** (transparent HTTPS interception and domain enforcement)
- Agent containers attach via `--network container:<proxy>` (no separate sidecar needed); TPROXY iptables rules intercept all TCP 80/443 from any non-mitmdump process in the shared namespace
- Loop prevention: mitmdump runs as uid 9999; OUTPUT MARK rule has `! --uid-owner 9999` so upstream connections bypass re-interception
- No changes to any existing application files except appending `src/docker/proxy/certs/` to `.gitignore`

## Architecture

```
Agent process (uid != 9999)
  └─ TCP 80/443 → OUTPUT mangle MARK fwmark=1
                → policy routing table 100 → lo
                → PREROUTING mangle TPROXY → mitmdump:8080
                → addon.py domain check
                    → ALLOW: forward to real internet (uid 9999, no re-intercept)
                    → DENY:  HTTP 403 JSON response
```

## Files

| File | Purpose |
|------|---------|
| `Dockerfile` | debian:bookworm-slim + pipx mitmproxy (system-wide, uid 9999) + CoreDNS |
| `entrypoint.sh` | CoreDNS config generation, CA cert init, TPROXY iptables + policy routing, mitmdump via setpriv |
| `addon.py` | mitmproxy Python addon — exact/subdomain allowlist match, 403 on block |
| `allowlist.json` | Default allowed domains (api.github.com, github.com, pypi.org, npmjs.org, pythonhosted.org) |
| `Corefile` | Seed CoreDNS config (regenerated at startup from allowlist.json) |
| `test-proxy.sh` | 6-scenario acceptance test script |

## Manual Testing

Requires Docker on the test machine. No automated CI run — manual verification required before merge.

```bash
cd src/docker/proxy
bash test-proxy.sh
```

**Expected output — all 6 pass:**
1. `PASS: Allowlisted HTTPS request succeeded (transparently intercepted)`
2. `PASS: Non-allowlisted HTTPS request blocked (DNS NXDOMAIN or mitmproxy 403)`
3. `PASS: DNS resolution for allowlisted domain succeeded`
4. `PASS: DNS for non-allowlisted domain returned NXDOMAIN`
5. `PASS: Node.js fetch blocked for non-allowlisted domain (DNS-level)`
6. `PASS: Direct HTTP to raw IP blocked (TPROXY intercepted, addon returned 403)`

The script builds the image, creates test networks, runs the proxy and agent containers, and cleans up on exit.

Resolves #1048

🤖 Generated with [Claude Code](https://claude.com/claude-code)