### PR TITLE
fix: resolve proxy container transparent interception (#1048)

### DIFF
--- a/src/docker/proxy/entrypoint.sh
+++ b/src/docker/proxy/entrypoint.sh
@@ -49,6 +49,11 @@ setpriv --reuid=9998 --regid=9998 --clear-groups -- \
     coredns -conf "$COREFILE" -dns.port 53 &
 COREDNS_PID=$!
 
+# --- Ensure cert directory is writable by mitmproxy uid ---
+# Volume bind mounts override Dockerfile ownership; re-apply here as root
+# before dropping privileges to uid 9999 for cert generation.
+chown 9999:9999 "$CERTS_DIR"
+
 # --- Generate CA cert if not present ---
 if [ ! -f "$CERTS_DIR/mitmproxy-ca-cert.pem" ]; then
     echo "Generating mitmproxy CA certificate..."
@@ -66,72 +71,67 @@ else
     echo "Using existing CA certificate"
 fi
 
-# --- Set up TPROXY transparent interception ---
+# --- Set up NAT transparent interception ---
 # Agent containers share this container's network namespace via
 # --network container:<proxy>. All TCP 80/443 originating from any process
 # whose UID != 9999 (i.e. every non-mitmdump process) is intercepted.
 #
-# How it works (TPROXY for locally-generated traffic):
-#   1. mangle OUTPUT marks agent TCP 80/443 with fwmark 1.
-#   2. Policy routing (ip rule) sends fwmark-1 packets to table 100.
-#   3. Table 100 routes everything to loopback, re-injecting packets into
-#      the PREROUTING chain as if they arrived from outside.
-#   4. mangle PREROUTING TPROXY assigns packets directly to mitmdump's
-#      listening socket via IP_TRANSPARENT, WITHOUT changing the destination.
-#      mitmdump sees the original destination (e.g. 140.82.114.6:443) as the
-#      accepted socket's local address.
-#   Loop prevention: mitmdump runs as uid 9999; the mangle OUTPUT MARK rule
-#      has ! --uid-owner 9999, so mitmdump's upstream connections are never
-#      marked and never re-intercepted.
+# How it works (nat OUTPUT DNAT to the container's own eth0 IP):
 #
-# Why TPROXY instead of REDIRECT/DNAT?
-#   Both REDIRECT and DNAT in the nat OUTPUT chain fail for locally-generated
-#   traffic: REDIRECT rewrites dst to 127.0.0.1 (kernel drops non-loopback src
-#   on lo); DNAT to the container's bridge IP also silently fails to deliver
-#   packets to the local socket. TPROXY avoids both issues by operating in
-#   mangle PREROUTING after policy-routing re-injects packets through lo.
+#   mitmproxy's transparent mode reads the original destination via SO_ORIGINAL_DST,
+#   which requires a conntrack entry created by NAT in the OUTPUT chain. Two
+#   previous approaches failed:
+#     - REDIRECT to 127.0.0.1: the kernel implicitly changes the source address
+#       to 127.0.0.1 for loopback-bound traffic, so the conntrack lookup by
+#       SO_ORIGINAL_DST can't find the entry (wrong source key).
+#     - MARK + policy routing + PREROUTING REDIRECT: conntrack already has an
+#       entry for the flow from the OUTPUT path; re-injected packets arrive at
+#       PREROUTING as ESTABLISHED and the nat table is skipped entirely.
+#
+#   The fix: DNAT to the container's own eth0 IP (not 127.0.0.1).
+#   1. nat OUTPUT DNAT changes dst to $CONTAINER_IP:8080.
+#   2. ip_route_me_harder() (called inside the nat OUTPUT hook) detects that
+#      the new destination is a local address and re-routes to local delivery
+#      BEFORE filter OUTPUT runs. Because $CONTAINER_IP is the eth0 address
+#      (not a loopback address), the kernel routes via eth0, so filter OUTPUT
+#      sees -o eth0 (not -o lo). A dedicated filter rule allows these packets.
+#   3. Since the destination is a non-loopback local IP, the kernel does NOT
+#      change the source address. The original source (e.g. 172.19.0.2:SP)
+#      is preserved.
+#   4. mitmproxy accepts at $CONTAINER_IP:8080.
+#   5. SO_ORIGINAL_DST: conntrack finds the entry (source matches) and returns
+#      the pre-DNAT destination (e.g. 140.82.113.6:80). ✓
+#   Loop prevention: mitmdump runs as uid 9999; the DNAT rule excludes uid 9999
+#      so mitmdump's upstream connections go directly to the internet.
 
-echo "Configuring TPROXY transparent proxy..."
+# Determine the container's primary outbound IP (used as DNAT destination to
+# avoid loopback source-address rewriting).
+CONTAINER_IP=$(ip route get 8.8.8.8 2>/dev/null | awk 'NR==1 {for(i=1;i<=NF;i++) if ($i=="src") {print $(i+1); exit}}')
+if [ -z "$CONTAINER_IP" ]; then
+    CONTAINER_IP=$(ip -4 addr show eth0 | awk '/inet / {gsub(/\/.*/, "", $2); print $2; exit}')
+fi
+echo "Container IP for DNAT: $CONTAINER_IP"
 
-# Step 1: Mark agent TCP 80/443 in mangle OUTPUT.
-# uid 9999 (mitmdump) is excluded to prevent re-interception loops.
-iptables -t mangle -A OUTPUT -p tcp --dport 80 \
-    -m owner ! --uid-owner 9999 -j MARK --set-mark 1
-iptables -t mangle -A OUTPUT -p tcp --dport 443 \
-    -m owner ! --uid-owner 9999 -j MARK --set-mark 1
+echo "Configuring NAT transparent proxy (OUTPUT DNAT → $CONTAINER_IP:8080)..."
 
-# Step 2: Policy routing — fwmark 1 → table 100 → local delivery via lo.
-# This re-injects marked packets into PREROUTING as if they arrived externally.
-ip rule add fwmark 1 lookup 100
-ip route add local 0.0.0.0/0 dev lo table 100
-
-# Step 3: TPROXY in mangle PREROUTING intercepts re-injected packets.
-# --on-port 8080 delivers to mitmdump's listening socket.
-# --tproxy-mark re-applies fwmark so return traffic uses the same routing.
-iptables -t mangle -A PREROUTING -p tcp --dport 80 \
-    -j TPROXY --tproxy-mark 0x1/0x1 --on-port 8080
-iptables -t mangle -A PREROUTING -p tcp --dport 443 \
-    -j TPROXY --tproxy-mark 0x1/0x1 --on-port 8080
+# DNAT agent TCP 80/443 to mitmdump. uid 9999 (mitmdump) is excluded to
+# prevent re-interception of mitmdump's own upstream connections.
+iptables -t nat -A OUTPUT -p tcp --dport 80 \
+    -m owner ! --uid-owner 9999 -j DNAT --to-destination "$CONTAINER_IP:8080"
+iptables -t nat -A OUTPUT -p tcp --dport 443 \
+    -m owner ! --uid-owner 9999 -j DNAT --to-destination "$CONTAINER_IP:8080"
 
 # --- Default-deny TCP OUTPUT ---
 # Block all TCP from non-proxy processes on ports other than 80/443, closing
 # the raw-IP gap (non-HTTP/HTTPS TCP was previously unrestricted).
 #
-# CRITICAL ordering note: filter OUTPUT runs BEFORE the fwmark policy-routing
-# reroute. When mangle OUTPUT sets fwmark 1, the packet still has its original
-# output interface (eth0). The reroute to lo only happens AFTER all OUTPUT
-# hooks complete. Therefore, fwmark-1 packets must be explicitly accepted in
-# filter OUTPUT — they will NOT match the -o lo rule.
-#
 # Rule order:
-#   1. lo ACCEPT: inter-process loopback communication (CoreDNS, mitmdump
-#      return traffic, etc.).
-#   2. fwmark 1 ACCEPT: TPROXY-bound agent TCP 80/443. These packets were
-#      marked by mangle OUTPUT and will be rerouted to lo after filter, then
-#      TPROXY-ed in PREROUTING. Must pass filter first since the reroute
-#      hasn't happened yet (packet still shows -o eth0 at this point).
-#   3. ESTABLISHED,RELATED ACCEPT: allows TCP handshakes to complete and
-#      return traffic for established connections.
+#   1. lo ACCEPT: loopback traffic (inter-process comms, CoreDNS responses).
+#   2. DNAT'd HTTP/HTTPS ACCEPT: nat OUTPUT DNAT changes dst to $CONTAINER_IP:8080.
+#      ip_route_me_harder() re-routes to local delivery via eth0 (because
+#      $CONTAINER_IP is an eth0 address, not a loopback address), so filter
+#      OUTPUT sees -o eth0 for intercepted packets. This rule allows them through.
+#   3. ESTABLISHED,RELATED ACCEPT: TCP handshake completion, return traffic.
 #   4. uid 9999 NEW ACCEPT: mitmdump upstream connections to the real internet.
 #      Works because mitmdump is a child process (not PID 1); xt_owner uid
 #      matching is reliable for non-PID-1 processes.
@@ -141,10 +141,12 @@ echo "Configuring default-deny TCP OUTPUT..."
 # 1. Allow all loopback traffic (inter-process comms).
 iptables -A OUTPUT -o lo -j ACCEPT
 
-# 2. Allow TPROXY-marked packets (fwmark 1) to pass filter before reroute.
-# These are agent TCP 80/443 that mangle OUTPUT marked; they'll be rerouted
-# to lo and TPROXY-ed in PREROUTING after filter OUTPUT completes.
-iptables -A OUTPUT -m mark --mark 1 -j ACCEPT
+# 2. Allow DNAT'd agent HTTP/HTTPS traffic to reach mitmproxy at $CONTAINER_IP:8080.
+#    After nat OUTPUT DNAT, ip_route_me_harder() routes these via eth0 (not lo)
+#    because $CONTAINER_IP is an eth0 address. The -o lo rule above does not
+#    match; this rule fills the gap so they reach mitmdump.
+iptables -A OUTPUT -p tcp -d "$CONTAINER_IP" --dport 8080 \
+    -m conntrack --ctstate NEW -j ACCEPT
 
 # 3. Allow established/related traffic (TCP handshake completion, return traffic).
 iptables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
@@ -170,21 +172,19 @@ iptables -A OUTPUT -p udp -j DROP
 
 # --- Start mitmdump in transparent mode as uid 9999 ---
 # setpriv drops to uid/gid 9999 but retains CAP_NET_ADMIN as an ambient
-# capability. TPROXY requires IP_TRANSPARENT on the listening socket, which
-# needs CAP_NET_ADMIN. The --inh-caps and --ambient-caps flags promote
-# the capability so it's effective for the unprivileged mitmdump process.
+# capability so mitmproxy can use privileged socket options if needed.
 #
-# IMPORTANT: do NOT use exec here. The mangle OUTPUT MARK rule uses
+# IMPORTANT: do NOT use exec here. The nat OUTPUT DNAT rule uses
 # "! --uid-owner 9999" to exclude mitmproxy's own upstream connections
 # from being re-intercepted. The Linux kernel's xt_owner module does not
 # reliably match uid for PID 1; if mitmdump were exec'd into PID 1, its
-# upstream connections would fail the uid match and be re-marked back to
+# upstream connections would fail the uid match and be DNAT-ed back to
 # itself (loop). Running as a child process (non-PID-1) ensures uid 9999
 # is matched correctly by the owner module.
 #
 # PID 1 (this shell) remains as the container's init process and forwards
 # SIGTERM/SIGINT to the child processes for clean shutdown.
-echo "Starting mitmdump (transparent mode + TPROXY) on :8080..."
+echo "Starting mitmdump (transparent mode) on :8080..."
 echo "Addon: /etc/proxy/addon.py"
 PYTHONUNBUFFERED=1 setpriv --reuid=9999 --regid=9999 --clear-groups \
     --inh-caps +net_admin --ambient-caps +net_admin -- \

--- a/src/docker/proxy/test-proxy.sh
+++ b/src/docker/proxy/test-proxy.sh
@@ -1,14 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Configuration
+# Usage: test-proxy.sh [-v|--verbose]
+#   -v / --verbose  Show startup state, per-rule diagnostics, and post-test
+#                   iptables counters. Useful when a test fails unexpectedly.
+
 PROXY_IMAGE="claude-proxy:local"
 PROXY_CONTAINER="claude-proxy-test"
 BRIDGE_NET="bridge-net-test"
 CERTS_DIR="$(cd "$(dirname "$0")" && pwd)/certs"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+VERBOSE=0
 
-# Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
@@ -20,28 +23,31 @@ info() { echo -e "${YELLOW}INFO${NC}: $1"; }
 
 FAILURES=0
 
+for arg in "$@"; do
+    case "$arg" in
+        -v|--verbose) VERBOSE=1 ;;
+        -h|--help) echo "Usage: $0 [-v|--verbose]"; exit 0 ;;
+        *) echo "Unknown argument: $arg" >&2; exit 1 ;;
+    esac
+done
+
 cleanup() {
-    info "Cleaning up..."
     docker rm -f "$PROXY_CONTAINER" 2>/dev/null || true
     docker rm -f test-agent 2>/dev/null || true
     docker network rm "$BRIDGE_NET" 2>/dev/null || true
-    info "Cleanup complete"
 }
 
 trap cleanup EXIT
 
 # --- Setup ---
 info "Building proxy image..."
-docker build -t "$PROXY_IMAGE" "$SCRIPT_DIR"
+if [ "$VERBOSE" -eq 1 ]; then
+    docker build -t "$PROXY_IMAGE" "$SCRIPT_DIR"
+else
+    docker build -q -t "$PROXY_IMAGE" "$SCRIPT_DIR" >/dev/null
+fi
 
-info "Creating networks..."
-# bridge-net: gives the proxy container outbound internet access.
-# Agent containers share the proxy's network namespace via
-# --network container:<proxy>; they inherit all proxy interfaces and routing,
-# but TPROXY iptables rules intercept their traffic before it leaves.
 docker network create "$BRIDGE_NET" 2>/dev/null || true
-
-info "Creating certs directory..."
 mkdir -p "$CERTS_DIR"
 
 info "Starting proxy container..."
@@ -52,40 +58,36 @@ docker run -d \
     --sysctl net.ipv4.ip_forward=1 \
     --sysctl net.ipv4.conf.lo.accept_local=1 \
     -v "$CERTS_DIR:/var/lib/mitmproxy" \
-    "$PROXY_IMAGE"
+    "$PROXY_IMAGE" >/dev/null
 
-# Wait for proxy to initialize
 info "Waiting for proxy to start..."
 sleep 5
 
-info "Proxy startup logs:"
-docker logs "$PROXY_CONTAINER" 2>&1
-
-info "Proxy process list:"
-docker exec "$PROXY_CONTAINER" ps aux 2>/dev/null || true
-
-info "Listening sockets in proxy namespace:"
-docker exec "$PROXY_CONTAINER" ss -tlunp 2>/dev/null || true
-
-info "Policy routing (fwmark rules, if any):"
-docker exec "$PROXY_CONTAINER" sh -c 'echo "  ip rules:"; ip rule show | grep fwmark || echo "    (none)"; echo "  table 100:"; ip route show table 100 2>/dev/null || echo "    (empty)"' 2>/dev/null || true
-
-info "Mitmdump uid check:"
-docker exec "$PROXY_CONTAINER" sh -c '
-  for pid in /proc/[0-9]*; do
-    cmd=$(cat "$pid/cmdline" 2>/dev/null | tr "\0" " ")
-    case "$cmd" in
-      *mitmdump*)
-        echo "Found mitmdump PID ${pid##*/}:"
-        grep -E "^(Name|Uid)" "$pid/status" 2>/dev/null
-        break
-        ;;
-    esac
-  done || echo "mitmdump not found in /proc"
-'
+if [ "$VERBOSE" -eq 1 ]; then
+    echo ""
+    info "Proxy startup logs:"
+    docker logs "$PROXY_CONTAINER" 2>&1
+    echo ""
+    info "Proxy process list:"
+    docker exec "$PROXY_CONTAINER" ps aux 2>/dev/null || true
+    info "Listening sockets:"
+    docker exec "$PROXY_CONTAINER" ss -tlunp 2>/dev/null || true
+    info "Mitmdump uid:"
+    docker exec "$PROXY_CONTAINER" sh -c '
+      for pid in /proc/[0-9]*; do
+        cmd=$(cat "$pid/cmdline" 2>/dev/null | tr "\0" " ")
+        case "$cmd" in
+          *mitmdump*)
+            grep -E "^(Name|Uid)" "$pid/status" 2>/dev/null
+            break;;
+        esac
+      done' 2>/dev/null || true
+    echo ""
+fi
 
 # Agent containers share the proxy's network namespace; CoreDNS listens on
-# loopback :53, so 127.0.0.1 resolves allowlisted domains and blocks others.
+# loopback :53, so 127.0.0.1 resolves allowlisted domains and returns NXDOMAIN
+# for everything else.
 PROXY_IP="127.0.0.1"
 
 # Verify CA cert was generated
@@ -93,19 +95,18 @@ if [ -f "$CERTS_DIR/mitmproxy-ca-cert.pem" ]; then
     pass "CA certificate generated at $CERTS_DIR/mitmproxy-ca-cert.pem"
 else
     fail "CA certificate not found"
+    info "Proxy logs:"
+    docker logs "$PROXY_CONTAINER" 2>&1
     exit 1
 fi
 
-# --- Helper: run test container sharing the proxy's network namespace ---
-# --network container:<proxy> gives the agent the same network interfaces,
-# iptables rules, and routing as the proxy. nat OUTPUT DNAT redirects agent
-# TCP 80/443 to $CONTAINER_IP:8080 (the proxy's own eth0 IP); ip_route_me_harder()
-# re-routes to local delivery before filter OUTPUT runs, so the loopback ACCEPT
-# rule covers intercepted traffic. mitmproxy reads the pre-DNAT destination via
-# SO_ORIGINAL_DST (conntrack preserves the original source, so lookup succeeds).
-# No capability or route configuration needed in the agent container.
-# DNS is set by pointing resolv.conf at 127.0.0.1 where CoreDNS is listening
-# (--dns is not usable with --network container:).
+# --- Helper: run a test container sharing the proxy's network namespace ---
+# --network container:<proxy> gives the agent the same interfaces, iptables
+# rules, and routing as the proxy. nat OUTPUT DNAT redirects agent TCP 80/443
+# to the proxy's own eth0 IP:8080; mitmproxy reads the pre-DNAT destination via
+# SO_ORIGINAL_DST. No extra capabilities needed in the agent container.
+# DNS is set by pointing resolv.conf at 127.0.0.1 (CoreDNS); --dns is not
+# usable with --network container:.
 run_agent() {
     local name="$1"
     local image="$2"
@@ -120,126 +121,53 @@ run_agent() {
         -c "echo 'nameserver 127.0.0.1' > /etc/resolv.conf; cat /etc/proxy-ca/mitmproxy-ca-cert.pem >> /etc/ssl/certs/ca-certificates.crt 2>/dev/null || true; $cmd"
 }
 
-# --- Diagnostics: test REDIRECT + uid-owner from INSIDE the proxy container ---
-# These run curl from the proxy container itself (no agent container involved)
-# to isolate whether the issue is REDIRECT/mitmproxy or --network container: sharing.
-echo ""
-info "Diag A: curl as root (uid 0) from proxy container → should be marked+re-injected → REDIRECT-ed to mitmproxy..."
-DIAG_A=$(docker exec "$PROXY_CONTAINER" \
-    curl -s --max-time 8 -o /dev/null -w "HTTP_%{http_code}" http://api.github.com/ 2>&1 || true)
-info "  Result: ${DIAG_A:-<no output>}"
+# --- Verbose diagnostics ---
+# Run before the main tests to confirm interception is working from both
+# inside the proxy container and from an agent container.
+if [ "$VERBOSE" -eq 1 ]; then
+    echo ""
+    info "Diag A: curl as root (uid 0) from proxy container → DNAT → mitmproxy..."
+    DIAG_A=$(docker exec "$PROXY_CONTAINER" \
+        curl -s --max-time 8 -o /dev/null -w "HTTP_%{http_code}" http://api.github.com/ 2>&1 || true)
+    info "  Result: ${DIAG_A:-<no output>}"
 
-info "Diag B: curl as uid 9999 from proxy container → should BYPASS REDIRECT, go direct..."
-DIAG_B=$(docker exec "$PROXY_CONTAINER" \
-    setpriv --reuid=9999 --regid=9999 --clear-groups -- \
-    curl -s --max-time 8 -o /dev/null -w "HTTP_%{http_code}" http://api.github.com/ 2>&1 || true)
-info "  Result: ${DIAG_B:-<no output>}"
+    info "Diag B: curl as uid 9999 from proxy container → bypasses DNAT, goes direct..."
+    DIAG_B=$(docker exec "$PROXY_CONTAINER" \
+        setpriv --reuid=9999 --regid=9999 --clear-groups -- \
+        curl -s --max-time 8 -o /dev/null -w "HTTP_%{http_code}" http://api.github.com/ 2>&1 || true)
+    info "  Result: ${DIAG_B:-<no output>}"
 
-info "Diag C: curl as uid 0 to raw IP :80 from proxy container → should be REDIRECT-ed, addon 403..."
-DIAG_C=$(docker exec "$PROXY_CONTAINER" \
-    curl -s --max-time 8 -o /dev/null -w "HTTP_%{http_code}" http://93.184.216.34/ 2>&1 || true)
-info "  Result: ${DIAG_C:-<no output>}"
+    info "Diag C: curl as root to raw IP :80 from proxy container → DNAT → addon 403..."
+    DIAG_C=$(docker exec "$PROXY_CONTAINER" \
+        curl -s --max-time 8 -o /dev/null -w "HTTP_%{http_code}" http://93.184.216.34/ 2>&1 || true)
+    info "  Result: ${DIAG_C:-<no output>}"
 
-info "Diag D: agent container wget with verbose stderr → shows connection/TLS details..."
-DIAG_D=$(run_agent "test-diag" alpine \
-    "wget -T 8 -O /dev/null http://api.github.com/ 2>&1 | head -5" 2>&1 || true)
-info "  Result:"
-echo "$DIAG_D" | head -10
+    info "Diag D: agent container wget → shows connection/TLS details..."
+    DIAG_D=$(run_agent "test-diag" alpine \
+        "wget -T 8 -O /dev/null http://api.github.com/ 2>&1 | head -5" 2>&1 || true)
+    info "  Result:"
+    echo "$DIAG_D" | head -10
+    echo ""
+fi
 
-info "Diag E: SO_ORIGINAL_DST — loopback src (127.0.0.1→127.0.0.1:18080 REDIRECT→18999)..."
-docker exec "$PROXY_CONTAINER" python3 -c "
-import socket, struct, subprocess, threading, time
-SO_ORIGINAL_DST = 80
-result = []
-def server():
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    s.bind(('0.0.0.0', 18999))
-    s.listen(1)
-    conn, addr = s.accept()
-    try:
-        dst = conn.getsockopt(socket.SOL_IP, SO_ORIGINAL_DST, 16)
-        port = struct.unpack('!H', dst[2:4])[0]
-        ip = '.'.join(str(b) for b in dst[4:8])
-        result.append(f'peer={addr[0]}:{addr[1]} SO_ORIGINAL_DST={ip}:{port}')
-    except Exception as e:
-        result.append(f'peer={addr[0]}:{addr[1]} SO_ORIGINAL_DST error: {e}')
-    conn.close()
-    s.close()
-t = threading.Thread(target=server, daemon=True); t.start(); time.sleep(0.2)
-subprocess.run(['iptables','-t','nat','-A','OUTPUT','-p','tcp','--dport','18080','-j','REDIRECT','--to-port','18999'], check=True)
-try:
-    c = socket.socket(socket.AF_INET, socket.SOCK_STREAM); c.settimeout(3)
-    c.connect(('127.0.0.1', 18080)); c.close()
-except Exception as e: result.append(f'connect error: {e}')
-finally: subprocess.run(['iptables','-t','nat','-D','OUTPUT','-p','tcp','--dport','18080','-j','REDIRECT','--to-port','18999'])
-t.join(timeout=3); print(result[0] if result else 'no result')
-" 2>&1 || true
+# --- Tests ---
 
-info "Diag F: TPROXY pipeline — mark + policy route + TPROXY to local server on :18999..."
-docker exec "$PROXY_CONTAINER" python3 -c "
-import socket, struct, subprocess, threading, time
-IP_TRANSPARENT = 19
-result = []
-def server():
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    s.setsockopt(socket.SOL_IP, IP_TRANSPARENT, 1)
-    s.bind(('0.0.0.0', 18999))
-    s.listen(1)
-    s.settimeout(5)
-    try:
-        conn, addr = s.accept()
-        local = conn.getsockname()
-        result.append(f'peer={addr[0]}:{addr[1]} getsockname={local[0]}:{local[1]}')
-        conn.close()
-    except socket.timeout:
-        result.append('server accept() TIMED OUT — packet never reached server')
-    s.close()
-t = threading.Thread(target=server, daemon=True); t.start(); time.sleep(0.2)
-# Set up TPROXY pipeline for port 18080: mark → policy route (reuses table 100) → TPROXY
-subprocess.run(['iptables','-t','mangle','-A','OUTPUT','-p','tcp','--dport','18080','-j','MARK','--set-mark','1'], check=True)
-subprocess.run(['iptables','-t','mangle','-A','PREROUTING','-p','tcp','--dport','18080','-j','TPROXY','--tproxy-mark','0x1/0x1','--on-port','18999'], check=True)
-try:
-    c = socket.socket(socket.AF_INET, socket.SOCK_STREAM); c.settimeout(4)
-    c.connect(('1.1.1.1', 18080))  # external IP — should be TPROXY-ed to :18999
-    c.close()
-except Exception as e: result.append(f'connect error: {e}')
-finally:
-    subprocess.run(['iptables','-t','mangle','-D','OUTPUT','-p','tcp','--dport','18080','-j','MARK','--set-mark','1'])
-    subprocess.run(['iptables','-t','mangle','-D','PREROUTING','-p','tcp','--dport','18080','-j','TPROXY','--tproxy-mark','0x1/0x1','--on-port','18999'])
-t.join(timeout=6); print('; '.join(result) if result else 'no result')
-" 2>&1 || true
-
-echo ""
-
-# --- Probe: direct TCP to mitmproxy :8080 (no REDIRECT needed) ---
-# Verifies mitmdump is reachable at all before any iptables rules are involved.
-# An HTTP request to the proxy port directly should return a 400 (bad request /
-# upstream connection error) — anything other than a connection refusal means
-# mitmdump is up and accepting connections.
-info "Probe: direct HTTP to mitmdump :8080 (bypasses iptables)..."
-DIRECT_RESP=$(run_agent "test-probe" alpine \
-    "wget -qO- --timeout=5 http://127.0.0.1:8080/ 2>&1 | head -3" 2>/dev/null || true)
-info "  Direct :8080 response: ${DIRECT_RESP:-<no output>}"
-
-# --- Test 1a: Allowlisted domain (HTTP, transparent interception) ---
-# Isolates REDIRECT firing from TLS/CA trust. HTTP goes through REDIRECT to
-# mitmdump :8080 which then forwards upstream. If this passes but 1b fails,
-# the issue is TLS certificate trust, not REDIRECT.
-info "Test 1a: HTTP (port 80) request to allowlisted domain (api.github.com) — transparent..."
+# Test 1: Allowlisted domain (HTTP)
+# Confirms DNAT is firing and the addon allows the domain. If this passes
+# but Test 2 fails, the issue is TLS certificate trust, not interception.
+info "Test 1: HTTP request to allowlisted domain (api.github.com) — transparent..."
 if run_agent "test-allow-http" alpine \
     "timeout 15 wget -T 10 -qO- http://api.github.com/ >/dev/null" \
     >/dev/null 2>&1; then
     pass "Allowlisted HTTP request succeeded (transparently intercepted)"
 else
-    fail "Allowlisted HTTP request failed (REDIRECT may not be firing)"
+    fail "Allowlisted HTTP request failed"
 fi
 
-# --- Test 1: Allowlisted domain (HTTPS, transparent interception) ---
-# No proxy env vars. Traffic routes through proxy via iptables REDIRECT.
-# mitmdump intercepts TLS, presents mitmproxy CA-signed cert; wget trusts it.
-info "Test 1: HTTPS request to allowlisted domain (api.github.com) — transparent..."
+# Test 2: Allowlisted domain (HTTPS)
+# No proxy env vars. DNAT intercepts TCP 443; mitmdump terminates TLS and
+# presents a CA-signed cert; wget trusts it via the mounted CA bundle.
+info "Test 2: HTTPS request to allowlisted domain (api.github.com) — transparent..."
 if run_agent "test-allow" alpine \
     "timeout 15 wget -T 10 -qO- https://api.github.com/ >/dev/null" \
     >/dev/null 2>&1; then
@@ -248,18 +176,18 @@ else
     fail "Allowlisted HTTPS request failed"
 fi
 
-# --- Test 2: Non-allowlisted domain (HTTPS, transparent interception) ---
-# DNS returns NXDOMAIN for example.com (CoreDNS catch-all block).
-info "Test 2: HTTPS request to non-allowlisted domain (example.com) — transparent..."
+# Test 3: Non-allowlisted domain (HTTPS)
+# CoreDNS returns NXDOMAIN for example.com; wget cannot connect.
+info "Test 3: HTTPS request to non-allowlisted domain (example.com) — should be blocked..."
 if run_agent "test-deny" alpine \
     "timeout 15 wget -T 10 -qO- https://example.com/ >/dev/null 2>&1"; then
     fail "Non-allowlisted HTTPS request should have been blocked"
 else
-    pass "Non-allowlisted HTTPS request blocked (DNS NXDOMAIN or mitmproxy 403)"
+    pass "Non-allowlisted HTTPS request blocked (DNS NXDOMAIN)"
 fi
 
-# --- Test 3: DNS allowlisted domain ---
-info "Test 3: DNS resolution for allowlisted domain..."
+# Test 4: DNS — allowlisted domain resolves
+info "Test 4: DNS resolution for allowlisted domain..."
 if run_agent "test-dns-allow" alpine \
     "nslookup api.github.com $PROXY_IP >/dev/null 2>&1" \
     >/dev/null 2>&1; then
@@ -268,8 +196,8 @@ else
     fail "DNS resolution for allowlisted domain failed"
 fi
 
-# --- Test 4: DNS non-allowlisted domain (NXDOMAIN) ---
-info "Test 4: DNS resolution for non-allowlisted domain..."
+# Test 5: DNS — non-allowlisted domain returns NXDOMAIN
+info "Test 5: DNS resolution for non-allowlisted domain — should return NXDOMAIN..."
 if run_agent "test-dns-deny" alpine \
     "nslookup example.com $PROXY_IP >/dev/null 2>&1" \
     >/dev/null 2>&1; then
@@ -278,9 +206,10 @@ else
     pass "DNS for non-allowlisted domain returned NXDOMAIN"
 fi
 
-# --- Test 5: Node.js native fetch to non-allowlisted domain ---
-# No proxy env vars. DNS NXDOMAIN prevents resolution.
-info "Test 5: Node.js native fetch to non-allowlisted domain (transparent)..."
+# Test 6: Node.js native fetch to non-allowlisted domain
+# DNS NXDOMAIN prevents resolution; verifies that Node's built-in fetch is
+# also blocked (no http_proxy env var required).
+info "Test 6: Node.js native fetch to non-allowlisted domain — should be blocked..."
 if run_agent "test-node-bypass" node:22-slim \
     "node -e \"fetch('https://blocked.example.com').then(r => { console.log(r.status); process.exit(0); }).catch(e => { console.error(e.cause?.code || e.message); process.exit(1); })\"" \
     >/dev/null 2>&1; then
@@ -289,26 +218,23 @@ else
     pass "Node.js fetch blocked for non-allowlisted domain (DNS-level)"
 fi
 
-# --- Test 6: Direct HTTP to raw IP (bypass DNS, test mangle OUTPUT MARK + PREROUTING REDIRECT) ---
-# Sends an HTTP GET to example.com's IP (93.184.216.34) on port 80, bypassing
-# DNS entirely. mangle OUTPUT marks port 80 traffic; policy routing re-injects
-# via loopback; nat PREROUTING REDIRECT delivers to mitmdump :8080. The raw IP
-# does not match any allowlisted domain so the addon returns HTTP 403. wget
-# treats 4xx as an error and exits non-zero.
-info "Test 6: Direct HTTP to raw IP — OUTPUT REDIRECT interception and block..."
+# Test 7: Direct HTTP to raw IP (bypasses DNS)
+# Sends HTTP to 93.184.216.34:80 without DNS. DNAT intercepts it; the raw IP
+# does not match any allowlisted domain so the addon returns 403. wget treats
+# 4xx as an error and exits non-zero.
+info "Test 7: Direct HTTP to raw IP — should be intercepted and blocked (addon 403)..."
 if run_agent "test-direct" alpine \
     "timeout 15 wget -T 10 -qO- http://93.184.216.34/ >/dev/null 2>&1" \
     >/dev/null 2>&1; then
     fail "Direct HTTP to raw IP should have been intercepted and blocked (403)"
 else
-    pass "Direct HTTP to raw IP blocked (TPROXY intercepted, addon returned 403)"
+    pass "Direct HTTP to raw IP blocked (DNAT intercepted, addon returned 403)"
 fi
 
-# --- Test 7: SSH TCP to allowlisted domain (port 22, blocked by default-deny) ---
+# Test 8: SSH TCP to allowlisted domain (port 22, default-deny)
 # DNS for github.com resolves (it is allowlisted), but the default-deny OUTPUT
-# rule drops all TCP that is not port 80/443 or from uid 9999. Port 22 never
-# reaches the wire regardless of whether the domain is allowlisted.
-info "Test 7: SSH TCP to allowlisted domain (github.com:22) — blocked by default-deny OUTPUT..."
+# rule drops all TCP that is not port 80/443 or from uid 9999.
+info "Test 8: SSH TCP to allowlisted domain (github.com:22) — blocked by default-deny..."
 if run_agent "test-ssh" alpine \
     "timeout 5 nc -w 3 github.com 22 </dev/null 2>/dev/null" \
     >/dev/null 2>&1; then
@@ -317,25 +243,22 @@ else
     pass "SSH to allowlisted domain blocked (default-deny OUTPUT, port 22 not permitted)"
 fi
 
-# --- Test 8: SSH TCP to non-allowlisted domain (DNS blocks it) ---
-# DNS NXDOMAIN for example.com prevents nc from resolving the host; the
-# default-deny TCP DROP would also block it if DNS somehow resolved.
-info "Test 8: SSH TCP connect to non-allowlisted domain (example.com:22) — DNS blocked..."
+# Test 9: SSH TCP to non-allowlisted domain (DNS + default-deny)
+# DNS NXDOMAIN prevents nc from resolving example.com; default-deny would
+# also block it if resolution somehow succeeded.
+info "Test 9: SSH TCP to non-allowlisted domain (example.com:22) — should be blocked..."
 if run_agent "test-ssh-deny" alpine \
     "timeout 5 nc -w 3 example.com 22 </dev/null 2>/dev/null" \
     >/dev/null 2>&1; then
-    fail "SSH to non-allowlisted domain should have failed (DNS NXDOMAIN)"
+    fail "SSH to non-allowlisted domain should have failed"
 else
     pass "SSH to non-allowlisted domain blocked (DNS NXDOMAIN)"
 fi
 
-# --- Test 9: UDP to external resolver (DNS exfiltration path, now blocked) ---
+# Test 10: UDP to external resolver (DNS exfiltration path)
 # nslookup with an explicit server address sends UDP directly to 1.1.1.1:53,
-# bypassing CoreDNS entirely. The default-deny UDP OUTPUT DROP blocks it;
-# the query times out and nslookup exits non-zero.
-# This closes the 2B gap for UDP: raw IP + non-HTTP/HTTPS protocol was
-# previously unrestricted; default-deny now covers both TCP and UDP.
-info "Test 9: UDP DNS query to external resolver (1.1.1.1) — blocked by default-deny UDP..."
+# bypassing CoreDNS. The default-deny UDP OUTPUT DROP blocks it.
+info "Test 10: UDP DNS query to external resolver (1.1.1.1) — blocked by default-deny UDP..."
 if run_agent "test-udp-exfil" alpine \
     "nslookup api.github.com 1.1.1.1 >/dev/null 2>&1" \
     >/dev/null 2>&1; then
@@ -344,32 +267,22 @@ else
     pass "UDP to external resolver blocked (default-deny UDP OUTPUT)"
 fi
 
-# --- Proxy traffic log ---
-echo ""
-echo "=== Proxy container logs ==="
-docker logs "$PROXY_CONTAINER" 2>&1
-echo "============================"
-
-# --- iptables packet counters (post-test) ---
-# Non-zero counters on nat PREROUTING REDIRECT confirm interception is firing.
-# Zero counters after tests = re-injection or mark never matched.
-echo ""
-echo "=== iptables mangle table (post-test) ==="
-docker exec "$PROXY_CONTAINER" iptables -t mangle -L -v -n 2>/dev/null || true
-echo ""
-echo "=== iptables nat table (post-test) ==="
-docker exec "$PROXY_CONTAINER" iptables -t nat -L -v -n 2>/dev/null || true
-echo ""
-echo "=== iptables filter table (post-test) ==="
-docker exec "$PROXY_CONTAINER" iptables -L -v -n 2>/dev/null || true
-echo ""
-echo "=== kernel log — dropped packets ==="
-docker exec "$PROXY_CONTAINER" dmesg 2>/dev/null | grep -E "TCP-DROP|UDP-DROP" | tail -30 || echo "(no dmesg access or no matches)"
-echo "========================================"
+# --- Verbose post-test dumps ---
+if [ "$VERBOSE" -eq 1 ]; then
+    echo ""
+    echo "=== Proxy container logs ==="
+    docker logs "$PROXY_CONTAINER" 2>&1
+    echo ""
+    echo "=== iptables nat table (post-test) ==="
+    docker exec "$PROXY_CONTAINER" iptables -t nat -L -v -n 2>/dev/null || true
+    echo ""
+    echo "=== iptables filter table (post-test) ==="
+    docker exec "$PROXY_CONTAINER" iptables -L -v -n 2>/dev/null || true
+    echo "========================================"
+fi
 
 # --- Results ---
 echo ""
-echo "=============================="
 if [ $FAILURES -eq 0 ]; then
     echo -e "${GREEN}All tests passed${NC}"
     exit 0

--- a/src/docker/proxy/test-proxy.sh
+++ b/src/docker/proxy/test-proxy.sh
@@ -49,6 +49,8 @@ docker run -d \
     --name "$PROXY_CONTAINER" \
     --network "$BRIDGE_NET" \
     --cap-add NET_ADMIN \
+    --sysctl net.ipv4.ip_forward=1 \
+    --sysctl net.ipv4.conf.lo.accept_local=1 \
     -v "$CERTS_DIR:/var/lib/mitmproxy" \
     "$PROXY_IMAGE"
 
@@ -65,8 +67,8 @@ docker exec "$PROXY_CONTAINER" ps aux 2>/dev/null || true
 info "Listening sockets in proxy namespace:"
 docker exec "$PROXY_CONTAINER" ss -tlunp 2>/dev/null || true
 
-info "TPROXY policy routing:"
-docker exec "$PROXY_CONTAINER" sh -c 'echo "  ip rules:"; ip rule show | grep fwmark; echo "  table 100:"; ip route show table 100 2>/dev/null || echo "    (empty)"' 2>/dev/null || true
+info "Policy routing (fwmark rules, if any):"
+docker exec "$PROXY_CONTAINER" sh -c 'echo "  ip rules:"; ip rule show | grep fwmark || echo "    (none)"; echo "  table 100:"; ip route show table 100 2>/dev/null || echo "    (empty)"' 2>/dev/null || true
 
 info "Mitmdump uid check:"
 docker exec "$PROXY_CONTAINER" sh -c '
@@ -96,10 +98,13 @@ fi
 
 # --- Helper: run test container sharing the proxy's network namespace ---
 # --network container:<proxy> gives the agent the same network interfaces,
-# iptables rules, and loopback as the proxy. nat OUTPUT REDIRECT intercepts
-# all TCP 80/443 from non-uid-9999 processes; no capability or route
-# configuration needed in the agent container. DNS is set by pointing
-# resolv.conf at 127.0.0.1 where CoreDNS is listening
+# iptables rules, and routing as the proxy. nat OUTPUT DNAT redirects agent
+# TCP 80/443 to $CONTAINER_IP:8080 (the proxy's own eth0 IP); ip_route_me_harder()
+# re-routes to local delivery before filter OUTPUT runs, so the loopback ACCEPT
+# rule covers intercepted traffic. mitmproxy reads the pre-DNAT destination via
+# SO_ORIGINAL_DST (conntrack preserves the original source, so lookup succeeds).
+# No capability or route configuration needed in the agent container.
+# DNS is set by pointing resolv.conf at 127.0.0.1 where CoreDNS is listening
 # (--dns is not usable with --network container:).
 run_agent() {
     local name="$1"
@@ -119,7 +124,7 @@ run_agent() {
 # These run curl from the proxy container itself (no agent container involved)
 # to isolate whether the issue is REDIRECT/mitmproxy or --network container: sharing.
 echo ""
-info "Diag A: curl as root (uid 0) from proxy container → should be REDIRECT-ed to mitmproxy..."
+info "Diag A: curl as root (uid 0) from proxy container → should be marked+re-injected → REDIRECT-ed to mitmproxy..."
 DIAG_A=$(docker exec "$PROXY_CONTAINER" \
     curl -s --max-time 8 -o /dev/null -w "HTTP_%{http_code}" http://api.github.com/ 2>&1 || true)
 info "  Result: ${DIAG_A:-<no output>}"
@@ -284,11 +289,12 @@ else
     pass "Node.js fetch blocked for non-allowlisted domain (DNS-level)"
 fi
 
-# --- Test 6: Direct HTTP to raw IP (bypass DNS, test OUTPUT REDIRECT) ---
+# --- Test 6: Direct HTTP to raw IP (bypass DNS, test mangle OUTPUT MARK + PREROUTING REDIRECT) ---
 # Sends an HTTP GET to example.com's IP (93.184.216.34) on port 80, bypassing
-# DNS entirely. The nat OUTPUT REDIRECT rule catches port 80 and redirects to
-# mitmdump :8080. The raw IP does not match any allowlisted domain so the
-# addon returns HTTP 403. wget treats 4xx as an error and exits non-zero.
+# DNS entirely. mangle OUTPUT marks port 80 traffic; policy routing re-injects
+# via loopback; nat PREROUTING REDIRECT delivers to mitmdump :8080. The raw IP
+# does not match any allowlisted domain so the addon returns HTTP 403. wget
+# treats 4xx as an error and exits non-zero.
 info "Test 6: Direct HTTP to raw IP — OUTPUT REDIRECT interception and block..."
 if run_agent "test-direct" alpine \
     "timeout 15 wget -T 10 -qO- http://93.184.216.34/ >/dev/null 2>&1" \
@@ -345,8 +351,8 @@ docker logs "$PROXY_CONTAINER" 2>&1
 echo "============================"
 
 # --- iptables packet counters (post-test) ---
-# Non-zero counters on nat OUTPUT REDIRECT rules confirm REDIRECT is firing.
-# Zero counters after tests = REDIRECT never matched (likely -m owner issue).
+# Non-zero counters on nat PREROUTING REDIRECT confirm interception is firing.
+# Zero counters after tests = re-injection or mark never matched.
 echo ""
 echo "=== iptables mangle table (post-test) ==="
 docker exec "$PROXY_CONTAINER" iptables -t mangle -L -v -n 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Fixed volume bind mount ownership (`chown 9999:9999` before cert generation so mitmproxy can write CA cert to host-mounted volume)
- Switched interception approach from TPROXY to `nat OUTPUT DNAT → $CONTAINER_IP:8080` (TPROXY rejected: mitmproxy uses `SO_ORIGINAL_DST` not `getsockname()`; REDIRECT rejected: loopback source rewriting corrupts conntrack key)
- Added explicit filter OUTPUT ACCEPT for DNAT'd packets to `$CONTAINER_IP:8080` (ip_route_me_harder routes via eth0, not lo, so `-o lo ACCEPT` didn't match)
- Moved `sysctl` settings to `docker run` flags (`--sysctl net.ipv4.ip_forward=1`, `--sysctl net.ipv4.conf.lo.accept_local=1`) — `/proc/sys` is read-only inside containers even with NET_ADMIN
- Cleaned up `test-proxy.sh`: verbose flag, renumbered tests 1–10, removed TPROXY/REDIRECT diagnostic dead ends, suppressed noisy build output in normal mode

## Test plan

- [x] All 10 tests pass in `test-proxy.sh` (confirmed by Tester-1048b on host)
- [x] Manually validated by user
- [x] Backward compatible — no changes to session_manager or coordinator

Closes #1048

🤖 Generated with [Claude Code](https://claude.com/claude-code)