### PR TITLE
feat: expose max concurrent minions in project configuration (#1064)

### DIFF
--- a/frontend/src/components/project/ProjectCreateModal.vue
+++ b/frontend/src/components/project/ProjectCreateModal.vue
@@ -58,6 +58,20 @@
               </div>
             </div>
 
+            <div class="mb-3">
+              <label for="maxConcurrentMinions" class="form-label">Max Concurrent Minions</label>
+              <input
+                type="number"
+                class="form-control"
+                id="maxConcurrentMinions"
+                v-model.number="formData.maxConcurrentMinions"
+                :class="{ 'is-invalid': errors.maxConcurrentMinions }"
+                min="1"
+              />
+              <div class="invalid-feedback" v-if="errors.maxConcurrentMinions">{{ errors.maxConcurrentMinions }}</div>
+              <div class="form-text">Maximum minions that can run simultaneously in this project.</div>
+            </div>
+
             <!-- Issue #313: Removed multi-agent checkbox - all projects support minions -->
             <div class="mb-3 form-check">
               <input
@@ -126,13 +140,15 @@ const formData = ref({
   name: '',
   workingDirectory: '',
   createSession: true,
-  sessionName: 'main'
+  sessionName: 'main',
+  maxConcurrentMinions: 20
 })
 
 // Validation errors
 const errors = ref({
   name: '',
-  workingDirectory: ''
+  workingDirectory: '',
+  maxConcurrentMinions: ''
 })
 
 // UI state
@@ -167,6 +183,11 @@ function validate() {
     isValid = false
   }
 
+  if (!formData.value.maxConcurrentMinions || formData.value.maxConcurrentMinions < 1) {
+    errors.value.maxConcurrentMinions = 'Max concurrent minions must be at least 1'
+    isValid = false
+  }
+
   return isValid
 }
 
@@ -183,7 +204,8 @@ async function handleSubmit() {
     // Create project (all projects support minions - issue #313)
     const project = await projectStore.createProject(
       formData.value.name,
-      formData.value.workingDirectory
+      formData.value.workingDirectory,
+      { max_concurrent_minions: formData.value.maxConcurrentMinions }
     )
 
     // Create initial session/minion if requested
@@ -223,7 +245,8 @@ function resetForm() {
     name: '',
     workingDirectory: '',
     createSession: true,
-    sessionName: 'main'
+    sessionName: 'main',
+    maxConcurrentMinions: 20
   }
   errors.value = {}
   errorMessage.value = ''

--- a/frontend/src/components/project/ProjectEditModal.vue
+++ b/frontend/src/components/project/ProjectEditModal.vue
@@ -43,6 +43,20 @@
               </div>
             </div>
 
+            <div class="mb-3">
+              <label for="editMaxConcurrentMinions" class="form-label">Max Concurrent Minions</label>
+              <input
+                type="number"
+                class="form-control"
+                id="editMaxConcurrentMinions"
+                v-model.number="formData.maxConcurrentMinions"
+                :class="{ 'is-invalid': errors.maxConcurrentMinions }"
+                min="1"
+              />
+              <div class="invalid-feedback" v-if="errors.maxConcurrentMinions">{{ errors.maxConcurrentMinions }}</div>
+              <div class="form-text">Maximum minions that can run simultaneously in this project.</div>
+            </div>
+
             <div v-if="errorMessage" class="alert alert-danger" role="alert">
               {{ errorMessage }}
             </div>
@@ -123,10 +137,12 @@ const uiStore = useUIStore()
 // State
 const project = ref(null)
 const formData = ref({
-  name: ''
+  name: '',
+  maxConcurrentMinions: 20
 })
 const errors = ref({
-  name: ''
+  name: '',
+  maxConcurrentMinions: ''
 })
 const isSubmitting = ref(false)
 const isDeleting = ref(false)
@@ -150,6 +166,11 @@ function validate() {
     isValid = false
   }
 
+  if (!formData.value.maxConcurrentMinions || formData.value.maxConcurrentMinions < 1) {
+    errors.value.maxConcurrentMinions = 'Max concurrent minions must be at least 1'
+    isValid = false
+  }
+
   return isValid
 }
 
@@ -164,7 +185,8 @@ async function handleSubmit() {
 
   try {
     await projectStore.updateProject(project.value.project_id, {
-      name: formData.value.name
+      name: formData.value.name,
+      max_concurrent_minions: formData.value.maxConcurrentMinions
     })
 
     // Close modal
@@ -204,7 +226,8 @@ async function handleDelete() {
 // Reset form
 function resetForm() {
   formData.value = {
-    name: ''
+    name: '',
+    maxConcurrentMinions: 20
   }
   errors.value = {}
   errorMessage.value = ''
@@ -237,6 +260,7 @@ watch(
       project.value = data.project
       if (project.value) {
         formData.value.name = project.value.name
+        formData.value.maxConcurrentMinions = project.value.max_concurrent_minions ?? 20
       }
       modalInstance.show()
     }

--- a/frontend/src/stores/project.js
+++ b/frontend/src/stores/project.js
@@ -52,11 +52,12 @@ export const useProjectStore = defineStore('project', () => {
   /**
    * Create a new project
    */
-  async function createProject(name, workingDirectory) {
+  async function createProject(name, workingDirectory, options = {}) {
     try {
       const response = await api.post('/api/projects', {
         name,
-        working_directory: workingDirectory
+        working_directory: workingDirectory,
+        ...options
       })
 
       const project = response.project

--- a/src/project_manager.py
+++ b/src/project_manager.py
@@ -196,7 +196,8 @@ class ProjectManager:
         project_id: str,
         name: str | None = None,
         is_expanded: bool | None = None,
-        order: int | None = None
+        order: int | None = None,
+        max_concurrent_minions: int | None = None
     ) -> bool:
         """Update project metadata (name, expansion state, order only - path is immutable)"""
         async with self._get_project_lock(project_id):
@@ -213,6 +214,8 @@ class ProjectManager:
                     project.is_expanded = is_expanded
                 if order is not None:
                     project.order = order
+                if max_concurrent_minions is not None:
+                    project.max_concurrent_minions = max_concurrent_minions
 
                 project.updated_at = datetime.now(UTC)
                 await self._persist_project_state(project_id)

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -26,7 +26,7 @@ from fastapi import (
 )
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from .application_service import ApplicationService
@@ -153,6 +153,7 @@ class PermissionPreviewRequest(BaseModel):
 class ProjectUpdateRequest(BaseModel):
     name: str | None = None
     is_expanded: bool | None = None
+    max_concurrent_minions: int | None = Field(None, ge=1)
 
 
 class ProjectReorderRequest(BaseModel):
@@ -885,6 +886,7 @@ class ClaudeWebUI:
                 project_id,
                 name=request.name,
                 is_expanded=request.is_expanded,
+                max_concurrent_minions=request.max_concurrent_minions,
             )
             if not result:
                 raise HTTPException(status_code=404, detail="Project not found")


### PR DESCRIPTION
## Summary

- Add `max_concurrent_minions` field to `ProjectUpdateRequest` (with `ge=1` validation via Pydantic `Field`)
- Propagate the field through the `update_project` handler in `web_server.py` and `project_manager.py`
- Add a \"Max Concurrent Minions\" number input (min=1, default=20) to both `ProjectCreateModal.vue` and `ProjectEditModal.vue`, with inline validation error messages and helper text
- Update the project store's `createProject` to accept extra options so the value is sent on creation

## Test plan

- [ ] Create a new project with a custom max concurrent minions value (e.g. 5) and verify it is persisted
- [ ] Edit an existing project, change the max concurrent minions value, save, and verify the updated value is reflected
- [ ] Attempt to set max concurrent minions to 0 or a negative number and confirm the inline validation error appears and the form cannot be submitted
- [ ] Verify that the field defaults to 20 when creating a new project
- [ ] Verify that editing a project pre-populates the field with the project's current value

🤖 Generated with [Claude Code](https://claude.com/claude-code)