### PR TITLE
feat: #1059 phase1 — add template_id/session_overrides/profile_id schema fields

### DIFF
--- a/src/legion/mcp/legion_mcp_tools.py
+++ b/src/legion/mcp/legion_mcp_tools.py
@@ -1088,6 +1088,7 @@ class LegionMCPTools:
                 mcp_server_ids=mcp_server_ids,
                 enable_claudeai_mcp_servers=enable_claudeai_mcp_servers,
                 strict_mcp_config=strict_mcp_config,
+                template_id=template_applied.template_id if template_applied else None,
             )
             spawn_result = await self.system.overseer_controller.spawn_minion(
                 parent_overseer_id=parent_overseer_id,

--- a/src/models/minion_template.py
+++ b/src/models/minion_template.py
@@ -54,6 +54,8 @@ class MinionTemplate:
     # MCP toggle configuration (issue #786)
     enable_claudeai_mcp_servers: bool = True
     strict_mcp_config: bool = False
+    # Composable profile placeholder (issue #1062)
+    profile_id: str | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None
 
@@ -121,6 +123,8 @@ class MinionTemplate:
         # MCP toggle configuration (issue #786)
         data.setdefault('enable_claudeai_mcp_servers', True)
         data.setdefault('strict_mcp_config', False)
+        # Composable profile placeholder (issue #1062)
+        data.setdefault('profile_id', None)
         # Backward-compat renames (issue #731)
         if 'default_role' in data:
             data.setdefault('role', data.pop('default_role'))

--- a/src/session_config.py
+++ b/src/session_config.py
@@ -71,3 +71,6 @@ class SessionConfig(BaseModel):
     strict_mcp_config: bool = False  # Pass --strict-mcp-config to disable local .mcp.json
     bare_mode: bool = False  # Pass --bare to skip hooks, LSP, plugin sync, skill walks
     env_scrub_enabled: bool = False  # Issue #957: Strip credentials from subprocess envs
+
+    # Template linkage (issue #1059)
+    template_id: str | None = None

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -176,6 +176,10 @@ class SessionInfo:
     bare_mode: bool = False  # Pass --bare to skip hooks, LSP, plugin sync, skill walks
     env_scrub_enabled: bool = False  # Issue #957: Strip credentials from subprocess envs
 
+    # Template linkage (issue #1059)
+    template_id: str | None = None
+    session_overrides: dict[str, Any] | None = None
+
     def __post_init__(self):
         if self.additional_directories is None:
             self.additional_directories = []
@@ -191,6 +195,8 @@ class SessionInfo:
             self.docker_extra_mounts = []
         if self.mcp_server_ids is None:
             self.mcp_server_ids = []
+        if self.session_overrides is None:
+            self.session_overrides = {}
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for JSON serialization"""
@@ -268,6 +274,8 @@ class SessionInfo:
         data.setdefault('strict_mcp_config', False)
         data.setdefault('bare_mode', False)
         data.setdefault('env_scrub_enabled', False)
+        data.setdefault('template_id', None)
+        data.setdefault('session_overrides', None)
         return cls(**data)
 
 
@@ -446,6 +454,7 @@ class SessionManager:
             strict_mcp_config=config.strict_mcp_config,
             bare_mode=config.bare_mode,
             env_scrub_enabled=config.env_scrub_enabled,
+            template_id=config.template_id,
         )
 
         try:

--- a/src/template_manager.py
+++ b/src/template_manager.py
@@ -171,6 +171,7 @@ class TemplateManager:
         system_prompt: str | None = None,
         description: str | None = None,
         capabilities: list[str] | None = None,
+        profile_id: str | None = None,
     ) -> MinionTemplate:
         """Create a new template.
 
@@ -206,6 +207,7 @@ class TemplateManager:
             system_prompt=system_prompt,
             description=description,
             capabilities=capabilities if capabilities is not None else [],
+            profile_id=profile_id,
             **config_data,
         )
 
@@ -263,6 +265,8 @@ class TemplateManager:
         # MCP toggle configuration (issue #786)
         enable_claudeai_mcp_servers: bool | None = None,
         strict_mcp_config: bool | None = None,
+        # Composable profile placeholder (issue #1062)
+        profile_id: str | None = None,
     ) -> MinionTemplate:
         """Update existing template."""
         template = self.templates.get(template_id)
@@ -354,6 +358,9 @@ class TemplateManager:
 
         if strict_mcp_config is not None:
             template.strict_mcp_config = strict_mcp_config
+
+        if profile_id is not None:
+            template.profile_id = profile_id
 
         template.updated_at = datetime.now(UTC)
 

--- a/src/tests/test_minion_template.py
+++ b/src/tests/test_minion_template.py
@@ -1,0 +1,40 @@
+"""Tests for MinionTemplate data model (issue #1059 schema additions)."""
+
+
+from ..models.minion_template import MinionTemplate
+
+
+class TestMinionTemplateProfileId:
+    """Tests for profile_id field added in issue #1059."""
+
+    def test_minion_template_profile_id_default(self):
+        """profile_id defaults to None when not provided."""
+        template = MinionTemplate(
+            template_id="tmpl-001",
+            name="Test Template",
+            permission_mode="acceptEdits",
+        )
+        assert template.profile_id is None
+
+    def test_minion_template_from_dict_backward_compat(self):
+        """from_dict with missing profile_id defaults to None."""
+        data = {
+            "template_id": "tmpl-002",
+            "name": "Legacy Template",
+            "permission_mode": "default",
+            "created_at": "2025-01-01T00:00:00+00:00",
+            "updated_at": "2025-01-01T00:00:00+00:00",
+        }
+        template = MinionTemplate.from_dict(data)
+        assert template.profile_id is None
+
+    def test_minion_template_round_trip_profile_id(self):
+        """to_dict() → from_dict() preserves profile_id."""
+        template = MinionTemplate(
+            template_id="tmpl-003",
+            name="Profile Template",
+            permission_mode="acceptEdits",
+            profile_id="profile-xyz",
+        )
+        restored = MinionTemplate.from_dict(template.to_dict())
+        assert restored.profile_id == "profile-xyz"

--- a/src/tests/test_session_manager.py
+++ b/src/tests/test_session_manager.py
@@ -131,6 +131,88 @@ class TestSessionInfo:
         info = SessionInfo.from_dict(data)
         assert info.bare_mode is False
 
+    # --- Issue #1059: template_id / session_overrides schema tests ---
+
+    def test_session_info_template_id_default(self):
+        """template_id defaults to None when not provided."""
+        now = datetime.now(UTC)
+        info = SessionInfo(
+            session_id="test-tmpl-default",
+            state=SessionState.CREATED,
+            created_at=now,
+            updated_at=now,
+        )
+        assert info.template_id is None
+
+    def test_session_info_session_overrides_default(self):
+        """session_overrides defaults to {} via __post_init__ when not provided."""
+        now = datetime.now(UTC)
+        info = SessionInfo(
+            session_id="test-overrides-default",
+            state=SessionState.CREATED,
+            created_at=now,
+            updated_at=now,
+        )
+        assert info.session_overrides == {}
+
+    def test_session_info_to_dict_template_fields(self):
+        """to_dict includes template_id and session_overrides."""
+        now = datetime.now(UTC)
+        info = SessionInfo(
+            session_id="test-tmpl-dict",
+            state=SessionState.CREATED,
+            created_at=now,
+            updated_at=now,
+            template_id="tmpl-1",
+            session_overrides={"model": "opus"},
+        )
+        data = info.to_dict()
+        assert data["template_id"] == "tmpl-1"
+        assert data["session_overrides"] == {"model": "opus"}
+
+    def test_session_info_from_dict_backward_compat(self):
+        """from_dict with missing template fields defaults to None / {}."""
+        now = datetime.now(UTC)
+        data = {
+            "session_id": "test-backward-compat",
+            "state": "created",
+            "created_at": now.isoformat(),
+            "updated_at": now.isoformat(),
+        }
+        info = SessionInfo.from_dict(data)
+        assert info.template_id is None
+        assert info.session_overrides == {}
+
+    def test_session_info_from_dict_with_template_fields(self):
+        """from_dict preserves explicit template_id and session_overrides."""
+        now = datetime.now(UTC)
+        data = {
+            "session_id": "test-from-dict-tmpl",
+            "state": "created",
+            "created_at": now.isoformat(),
+            "updated_at": now.isoformat(),
+            "template_id": "tmpl-42",
+            "session_overrides": {"effort": "high"},
+        }
+        info = SessionInfo.from_dict(data)
+        assert info.template_id == "tmpl-42"
+        assert info.session_overrides == {"effort": "high"}
+
+    def test_session_info_round_trip_template_fields(self):
+        """to_dict() → from_dict() round-trip preserves template_id and session_overrides."""
+        now = datetime.now(UTC)
+        info = SessionInfo(
+            session_id="test-round-trip",
+            state=SessionState.CREATED,
+            created_at=now,
+            updated_at=now,
+            template_id="tmpl-rt",
+            session_overrides={"model": "haiku", "thinking_mode": "adaptive"},
+        )
+        restored = SessionInfo.from_dict(info.to_dict())
+        assert restored.template_id == "tmpl-rt"
+        assert restored.session_overrides == {"model": "haiku", "thinking_mode": "adaptive"}
+
 
 class TestSessionManager:
     """Test SessionManager functionality."""

--- a/src/tests/test_template_manager.py
+++ b/src/tests/test_template_manager.py
@@ -528,6 +528,9 @@ class TestImportFieldPreservation:
         template_fields = {f.name for f in dataclasses.fields(MinionTemplateModel)}
         config_fields = set(SessionConfig.model_fields.keys())
         shared = template_fields & config_fields
+        # template_id in SessionConfig is a session→template link; in MinionTemplate it is the
+        # template's own primary key (intentionally regenerated on import).  Exclude it.
+        shared -= {"template_id"}
 
         # Build a config with non-default values for all shared fields
         config = SessionConfig(


### PR DESCRIPTION
Part of #1059

## Summary

Phase 1 schema-only data model additions. Zero behavioral changes — all new fields have safe defaults and no existing logic reads them yet.

- `SessionConfig.template_id: str | None = None` — session→template link
- `SessionInfo.template_id` + `session_overrides: dict` — persisted in state.json; backward-compat `from_dict` setdefaults; wired in `create_session()`
- `MinionTemplate.profile_id: str | None = None` — composable profile placeholder (issue #1062)
- `legion_mcp_tools`: populates `template_id` on `SessionConfig` at spawn time
- `template_manager`: adds `profile_id` param to `create_template`/`update_template` to satisfy field-coverage parity tests

## Tests

- 9 new tests (6 `SessionInfo`, 3 `MinionTemplate`)
- 925 passing; 2 pre-existing failures unrelated to this change

## Test plan

- [x] `uv run pytest src/tests/` — 925 passed, 2 pre-existing failures
- [x] Ruff linting — zero violations on all modified files
- [x] Backend health check — server starts cleanly on port 8059

🤖 Generated with [Claude Code](https://claude.com/claude-code)