### PR TITLE
refactor: extract slugify util (#1080) + deduplicate config resolution (#1081)

### DIFF
--- a/src/config_resolution.py
+++ b/src/config_resolution.py
@@ -79,6 +79,20 @@ assert set(FIELD_TO_AREA.keys()) == CONFIG_FIELDS, (
 )
 
 
+async def _load_profile_cached(
+    profile_id: str,
+    profile_manager: "ProfileManager | None",
+    cache: dict[str, object],
+) -> object:
+    """Fetch a profile, using *cache* to avoid repeated lookups within one resolution."""
+    if profile_id not in cache:
+        if profile_manager:
+            cache[profile_id] = await profile_manager.get_profile(profile_id)
+        else:
+            cache[profile_id] = None
+    return cache[profile_id]
+
+
 async def resolve_effective_config(
     session_info: SessionInfo,
     template_manager: TemplateManager,
@@ -107,43 +121,14 @@ async def resolve_effective_config(
         # Template was deleted after session creation — fall back to flat fields
         return _config_from_session_info(session_info)
 
-    # --- 3-tier resolution (issue #1062) ---
-    # Cache profile lookups within a single resolution call (load each profile once).
-    profile_cache: dict[str, object] = {}
+    # Get base config from template + profiles (reuse resolve_template_config)
+    config_data = await resolve_template_config(template, profile_manager)
 
-    async def _get_profile(profile_id: str):
-        """Fetch profile from cache or profile_manager."""
-        if profile_id not in profile_cache:
-            if profile_manager:
-                profile_cache[profile_id] = await profile_manager.get_profile(profile_id)
-            else:
-                profile_cache[profile_id] = None
-        return profile_cache[profile_id]
-
-    config_data: dict = {}
-    template_profile_ids = template.profile_ids or {}
-    template_overrides_dict = template.template_overrides or {}
+    # Apply session_overrides (highest priority)
     session_overrides = session_info.session_overrides or {}
-
-    for field in CONFIG_FIELDS:
-        # Step 1: Base value from template flat field (backward compat)
-        if hasattr(template, field):
-            config_data[field] = getattr(template, field)
-
-        # Step 2: If template has a profile assigned for this field's area, use profile value
-        area = FIELD_TO_AREA.get(field)
-        if area and area in template_profile_ids and profile_manager:
-            profile = await _get_profile(template_profile_ids[area])
-            if profile is not None and field in profile.config:
-                config_data[field] = profile.config[field]
-
-        # Step 3: template_overrides win over profile values
-        if field in template_overrides_dict:
-            config_data[field] = template_overrides_dict[field]
-
-        # Step 4: session_overrides win over everything (highest priority)
-        if field in session_overrides:
-            config_data[field] = session_overrides[field]
+    for field_name in CONFIG_FIELDS:
+        if field_name in session_overrides:
+            config_data[field_name] = session_overrides[field_name]
 
     # Carry template_id through for downstream reference
     config_data["template_id"] = session_info.template_id
@@ -163,31 +148,24 @@ async def resolve_template_config(
     Priority (high to low): template_overrides > profile values > template flat fields
     """
     profile_cache: dict[str, object] = {}
-
-    async def _get_profile(profile_id: str):
-        if profile_id not in profile_cache:
-            if profile_manager:
-                profile_cache[profile_id] = await profile_manager.get_profile(profile_id)
-            else:
-                profile_cache[profile_id] = None
-        return profile_cache[profile_id]
-
     config_data: dict = {}
     template_profile_ids = template.profile_ids or {}
     template_overrides_dict = template.template_overrides or {}
 
-    for field in CONFIG_FIELDS:
-        if hasattr(template, field):
-            config_data[field] = getattr(template, field)
+    for field_name in CONFIG_FIELDS:
+        if hasattr(template, field_name):
+            config_data[field_name] = getattr(template, field_name)
 
-        area = FIELD_TO_AREA.get(field)
+        area = FIELD_TO_AREA.get(field_name)
         if area and area in template_profile_ids and profile_manager:
-            profile = await _get_profile(template_profile_ids[area])
-            if profile is not None and field in profile.config:
-                config_data[field] = profile.config[field]
+            profile = await _load_profile_cached(
+                template_profile_ids[area], profile_manager, profile_cache
+            )
+            if profile is not None and field_name in profile.config:
+                config_data[field_name] = profile.config[field_name]
 
-        if field in template_overrides_dict:
-            config_data[field] = template_overrides_dict[field]
+        if field_name in template_overrides_dict:
+            config_data[field_name] = template_overrides_dict[field_name]
 
     return config_data
 

--- a/src/legion/mcp/legion_mcp_tools.py
+++ b/src/legion/mcp/legion_mcp_tools.py
@@ -1228,7 +1228,7 @@ class LegionMCPTools:
                 }
 
             # Check direct children first (fast path)
-            from src.session_manager import slugify_name as _slugify
+            from src.slug_utils import slugify_name as _slugify
             target_slug = _slugify(minion_name)
             effective_parent_id = parent_overseer_id  # default: caller is the parent
 

--- a/src/legion/overseer_controller.py
+++ b/src/legion/overseer_controller.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 
 from src.models.permission_mode import PermissionMode
 from src.session_config import SessionConfig
-from src.session_manager import slugify_name
+from src.slug_utils import slugify_name
 
 if TYPE_CHECKING:
     from src.legion_system import LegionSystem

--- a/src/mcp_config_manager.py
+++ b/src/mcp_config_manager.py
@@ -9,7 +9,6 @@ Issue #676: Global MCP server configuration with per-session injection.
 
 import json
 import logging
-import re
 import uuid
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
@@ -18,6 +17,7 @@ from pathlib import Path
 from typing import Any
 
 from .logging_config import get_logger
+from .slug_utils import slugify as _slugify
 
 mcp_logger = get_logger('mcp_config', category='MCP_CONFIG')
 logger = logging.getLogger(__name__)
@@ -27,13 +27,6 @@ class McpServerType(str, Enum):
     STDIO = "stdio"
     SSE = "sse"
     HTTP = "http"
-
-
-def _slugify(name: str) -> str:
-    """Convert config name to a filesystem-safe slug."""
-    slug = name.strip().lower()
-    slug = re.sub(r'[^a-z0-9]+', '_', slug)
-    return slug.strip('_')
 
 
 @dataclass

--- a/src/profile_manager.py
+++ b/src/profile_manager.py
@@ -9,7 +9,6 @@ Storage format: data/profiles/{slug}.json
 
 import json
 import logging
-import re
 import uuid
 from datetime import UTC, datetime
 from pathlib import Path
@@ -23,6 +22,7 @@ if TYPE_CHECKING:
 from .config_resolution import PROFILE_AREAS
 from .logging_config import get_logger
 from .models.config_profile import ConfigProfile
+from .slug_utils import slugify as _slugify
 
 logger = logging.getLogger(__name__)
 profile_logger = get_logger("profile_manager", category="PROFILE_MANAGER")
@@ -41,13 +41,6 @@ class ProfileInUseError(Exception):
         super().__init__(
             f"Profile {profile_id} is referenced by {len(template_ids)} template(s): {names_preview}"
         )
-
-
-def _slugify(name: str) -> str:
-    """Convert profile name to a filesystem-safe slug."""
-    slug = name.strip().lower()
-    slug = re.sub(r"[^a-z0-9]+", "_", slug)
-    return slug.strip("_")
 
 
 class ProfileManager:

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -23,6 +23,7 @@ from src.docker_utils import cleanup_session_tmp
 from src.legion.minion_system_prompts import get_legion_guide_only
 
 from .claude_sdk import ClaudeSDK
+from .config_resolution import resolve_effective_config
 from .data_storage import DataStorageManager
 from .hooks.pretooluse_handler import InternalPermissionHandler
 from .logging_config import get_logger
@@ -43,7 +44,6 @@ from .project_manager import ProjectInfo, ProjectManager
 from .queue_manager import QueueManager
 from .queue_processor import QueueProcessor
 from .session_config import SessionConfig
-from .config_resolution import resolve_effective_config
 from .session_manager import STOPPED_STATES, SessionManager, SessionState
 from .task_utils import task_done_log_exception
 from .timestamp_utils import get_unix_timestamp

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -10,7 +10,6 @@ import gc
 import json
 import logging
 import os
-import re
 import shutil
 import subprocess
 import time
@@ -24,6 +23,7 @@ from typing import Any
 from .logging_config import get_logger
 from .models.permission_mode import PermissionMode
 from .session_config import SessionConfig
+from .slug_utils import slugify_name
 from .template_manager import TemplateManager
 
 # Get specialized logger for session manager actions
@@ -49,20 +49,6 @@ VALID_MODELS = {
 
 # Default model for new sessions
 DEFAULT_MODEL = "sonnet"
-
-
-def slugify_name(name: str) -> str:
-    """Convert a display name to a slug for MCP tool compatibility.
-
-    "Database Optimizer" -> "database-optimizer"
-    "frontend-dev" -> "frontend-dev"  (already slugified, no change)
-    """
-    slug = name.lower()
-    slug = slug.replace("_", "-").replace(" ", "-")
-    slug = re.sub(r'[^a-z0-9-]', '', slug)
-    slug = re.sub(r'-+', '-', slug)
-    slug = slug.strip('-')
-    return slug
 
 
 class SessionState(Enum):

--- a/src/slug_utils.py
+++ b/src/slug_utils.py
@@ -1,0 +1,33 @@
+"""
+Shared slug utilities.
+
+Provides filesystem-safe slug conversion used by profile_manager,
+template_manager, mcp_config_manager, and session_manager.
+"""
+
+import re
+
+
+def slugify(name: str) -> str:
+    """Convert a display name to a filesystem-safe underscore slug.
+
+    "Coding Minion" -> "coding_minion"
+    "Code Expert" -> "code_expert"
+    """
+    slug = name.strip().lower()
+    slug = re.sub(r"[^a-z0-9]+", "_", slug)
+    return slug.strip("_")
+
+
+def slugify_name(name: str) -> str:
+    """Convert a display name to a hyphen slug for MCP tool compatibility.
+
+    "Database Optimizer" -> "database-optimizer"
+    "frontend-dev" -> "frontend-dev"  (already slugified, no change)
+    """
+    slug = name.lower()
+    slug = slug.replace("_", "-").replace(" ", "-")
+    slug = re.sub(r"[^a-z0-9-]", "", slug)
+    slug = re.sub(r"-+", "-", slug)
+    slug = slug.strip("-")
+    return slug

--- a/src/template_manager.py
+++ b/src/template_manager.py
@@ -31,6 +31,7 @@ from .logging_config import get_logger
 from .models.minion_template import MinionTemplate
 from .models.permission_mode import PermissionMode
 from .session_config import SessionConfig
+from .slug_utils import slugify as _slugify
 
 # Fields set directly by create_template() — must not be overridden by config spread.
 # system_prompt exists on both SessionConfig and MinionTemplate; the direct param wins.
@@ -68,17 +69,6 @@ class TemplateInUseError(Exception):
 template_logger = get_logger('template_manager', category='TEMPLATE_MANAGER')
 # Keep standard logger for errors
 logger = logging.getLogger(__name__)
-
-
-def _slugify(name: str) -> str:
-    """Convert template name to a filesystem-safe slug.
-
-    "Coding Minion" -> "coding_minion"
-    "Code Expert" -> "code_expert"
-    """
-    slug = name.strip().lower()
-    slug = re.sub(r'[^a-z0-9]+', '_', slug)
-    return slug.strip('_')
 
 
 def _get_default_templates_dir() -> Path:

--- a/src/tests/test_overseer_controller.py
+++ b/src/tests/test_overseer_controller.py
@@ -9,7 +9,8 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from src.session_manager import SessionInfo, SessionState, slugify_name
+from src.session_manager import SessionInfo, SessionState
+from src.slug_utils import slugify_name
 
 
 def _make_session(session_id, name, project_id="legion-1", parent_id=None, children=None):

--- a/src/tests/test_slugify.py
+++ b/src/tests/test_slugify.py
@@ -3,7 +3,8 @@
 import json
 from datetime import UTC, datetime
 
-from ..session_manager import SessionInfo, SessionState, slugify_name
+from ..session_manager import SessionInfo, SessionState
+from ..slug_utils import slugify_name
 
 
 class TestSlugifyName:

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -38,10 +38,10 @@ from .message_parser import MessageParser, MessageProcessor
 from .models.permission_mode import PermissionMode
 from .permission_resolver import resolve_effective_permissions
 from .permission_service import PermissionService
+from .profile_manager import ProfileInUseError
 from .session_config import SessionConfig
 from .session_coordinator import SessionCoordinator
 from .session_manager import SessionState
-from .profile_manager import ProfileInUseError
 from .skill_manager import SkillManager
 from .task_utils import task_done_log_exception
 from .template_manager import TemplateConflictError, TemplateInUseError


### PR DESCRIPTION
## Summary

Resolves #1080
Resolves #1081

Extract the duplicated `_slugify` function into a shared utility module and eliminate the duplicated inner loop in `config_resolution.py`.

## Changes Made

**Issue #1080 — Extract slugify to shared util:**
- Create `src/slug_utils.py` with `slugify()` and `slugify_name()` functions
- Remove duplicate `_slugify` from `profile_manager.py`, `template_manager.py`, `mcp_config_manager.py`
- Remove duplicate `slugify_name` from `session_manager.py`
- Update all import sites: `overseer_controller.py`, `legion_mcp_tools.py`, test files

**Issue #1081 — Deduplicate config resolution:**
- Extract `_load_profile_cached()` as a module-level async helper in `config_resolution.py`
- Refactor `resolve_effective_config()` to call `resolve_template_config()` for base config, then apply `session_overrides` on top
- Priority chain preserved: `session_overrides > template_overrides > profile values > template flat fields > defaults`
- `resolve_template_config()` signature unchanged (called from legion spawn path)

## Testing

- `uv run pytest src/tests/ -q` — 989 passed, 5 pre-existing failures confirmed on main before changes
- `uv run ruff check src/` — zero violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)