### PR TITLE
fix: proxy sidecar sessions always fail when credentials are configured

### DIFF
--- a/src/docker/claude-docker
+++ b/src/docker/claude-docker
@@ -247,6 +247,14 @@ if [ -n "$PROXY_IMAGE" ]; then
     fi
     echo "[claude-docker] Proxy ready (${PROXY_WAIT}s), CA cert: $PROXY_CA" >&2
 
+    # Verify the proxy container is still running after .ready was detected.
+    # Catches the race where mitmdump crashes between .ready and agent startup.
+    if ! docker inspect --format='{{.State.Running}}' "$PROXY_NAME" 2>/dev/null | grep -q true; then
+        echo "Error: Proxy container $PROXY_NAME exited after signalling ready. Logs:" >&2
+        docker logs "$PROXY_NAME" >&2 2>&1 || true
+        exit 1
+    fi
+
     # Join proxy network namespace — transparent DNAT + CoreDNS filtering.
     PROXY_FLAGS="$PROXY_FLAGS --network container:$PROXY_NAME"
     PROXY_FLAGS="$PROXY_FLAGS -v ${PROXY_RESOLV}:/etc/resolv.conf:ro"

--- a/src/docker/proxy/entrypoint.sh
+++ b/src/docker/proxy/entrypoint.sh
@@ -252,6 +252,16 @@ fi
 # before iptables setup and mitmdump startup. The .ready marker is written here,
 # after all three are complete, so the host-side poll starts the agent at the
 # right time.
+# Verify mitmdump survived startup before signalling ready.
+# A short sleep gives it time to parse the addon, read credentials, and bind :8080.
+# If it crashes during that window (bad addon, unreadable files, port conflict),
+# kill -0 will fail and we exit with a diagnostic message.
+sleep 2
+if ! kill -0 "$MITM_PID" 2>/dev/null; then
+    echo "ERROR: mitmdump (PID $MITM_PID) exited during startup." >&2
+    wait "$MITM_PID" 2>/dev/null
+    exit 1
+fi
 touch "$CERTS_DIR/.ready"
 
 # Forward signals to child processes so Docker stop works cleanly.

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -1086,9 +1086,12 @@ class SessionCoordinator:
                                 extra_mounts.append(f"{host_file}:{file_path}:ro")
 
                     # Write sidecar credentials.json (placeholder + injection, no plaintext secrets)
+                    # Use 0o644 (world-readable) so mitmdump running as uid 9999 inside the
+                    # sidecar container can read this bind-mounted file. The file contains only
+                    # placeholder strings and injection metadata — no actual secret content.
                     creds_path = tmp_dir / "credentials.json"
                     creds_path.write_text(json.dumps({"credentials": sidecar_entries}))
-                    os.chmod(creds_path, 0o600)
+                    os.chmod(creds_path, 0o644)
                     proxy_credentials_file = str(creds_path)
 
                     # Write delivery env file if any env deliveries configured

--- a/src/tests/test_session_coordinator.py
+++ b/src/tests/test_session_coordinator.py
@@ -910,3 +910,87 @@ class TestIssue820TmpMount:
             success = await coordinator.terminate_session(session_id)
 
         assert success is True
+
+
+class TestIssue1088CredFilePermissions:
+    """Regression tests for issue #1088 — proxy sidecar credentials.json must be world-readable."""
+
+    @pytest.mark.asyncio
+    async def test_issue_1088_creds_path_is_world_readable(self, temp_coordinator):
+        """credentials.json must use 0o644 so mitmdump (uid 9999) can read it.
+
+        Delivery files (host_file) with actual secret content must still use 0o600.
+        """
+        import stat
+        import uuid
+
+        coordinator = temp_coordinator
+
+        project = await coordinator.project_manager.create_project(
+            name="Test Project",
+            working_directory="/test/project",
+        )
+
+        session_id = str(uuid.uuid4())
+        await coordinator.create_session(
+            session_id=session_id,
+            project_id=project.project_id,
+            config=SessionConfig(
+                docker_enabled=True,
+                docker_image="claude-code:local",
+                docker_proxy_enabled=True,
+                docker_proxy_credentials=[
+                    {
+                        "name": "github_token",
+                        "host_pattern": "api.github.com",
+                        "delivery": {"type": "file", "path": "/run/secrets/gh_token",
+                                     "content_template": "{placeholder}"},
+                        "injection": {"header": "Authorization", "format": "Bearer {value}",
+                                      "real_value": "ghp_real"},
+                    }
+                ],
+            ),
+        )
+
+        # Locate the session tmp dir that will hold credentials.json
+        session_dir = coordinator.session_manager.sessions_dir / session_id
+        tmp_dir = session_dir / "tmp"
+
+        written_files: list = []
+
+        def fake_resolve(docker_image, docker_extra_mounts, workspace,
+                         session_data_dir, docker_home_directory,
+                         proxy_credentials_file=None, delivery_env_file=None, **kwargs):
+            # Capture all files written into tmp_dir at call time
+            if tmp_dir.exists():
+                written_files.extend(list(tmp_dir.iterdir()))
+            return "/usr/bin/docker", {}
+
+        mock_sdk = AsyncMock()
+        mock_sdk.start.return_value = True
+        mock_sdk.is_running.return_value = False
+        coordinator.set_sdk_factory(Mock(return_value=mock_sdk))
+
+        with patch("src.docker_utils.resolve_docker_cli_path", fake_resolve):
+            with patch("src.skill_manager.NEW_GLOBAL_SKILLS_DIR") as mock_skills_dir:
+                mock_skills_dir.exists.return_value = False
+                await coordinator.start_session(session_id)
+
+        # Find credentials.json and delivery files
+        creds_file = tmp_dir / "credentials.json"
+        assert creds_file.exists(), "credentials.json must be written to session tmp dir"
+
+        creds_mode = stat.S_IMODE(creds_file.stat().st_mode)
+        assert creds_mode == 0o644, (
+            f"credentials.json must be 0o644 (world-readable for sidecar uid 9999), "
+            f"got {oct(creds_mode)}"
+        )
+
+        # Delivery files (contain placeholder — same-uid access only) must remain 0o600
+        delivery_files = [f for f in tmp_dir.iterdir() if f.name.startswith("delivery_")]
+        assert delivery_files, "At least one delivery file must be written for file delivery type"
+        for delivery_file in delivery_files:
+            delivery_mode = stat.S_IMODE(delivery_file.stat().st_mode)
+            assert delivery_mode == 0o600, (
+                f"{delivery_file.name} must remain 0o600, got {oct(delivery_mode)}"
+            )


### PR DESCRIPTION
## Summary
Resolves #1088

Two interacting bugs prevented proxy-mode sessions with credentials from starting. Together they form a silent failure: mitmdump crashes on startup (unreadable credentials), but `.ready` is already written so `claude-docker` starts the agent anyway — against a dead proxy.

## Changes Made

- **`src/session_coordinator.py`** — change `os.chmod(creds_path, 0o600)` → `0o644`
  The sidecar's mitmdump process runs as uid 9999 (not the host user). With `0o600` it cannot read the bind-mounted `credentials.json`, logs a `PermissionError`, and aborts. The file contains only placeholder strings and injection metadata — no actual secret content — so world-readable is safe.

- **`src/docker/proxy/entrypoint.sh`** — add `sleep 2` + `kill -0 $MITM_PID` liveness check before `touch .ready`
  Previously `.ready` was written immediately after `mitmdump &`, before verifying the process survived startup. Now the container waits 2 seconds and confirms mitmdump is alive before writing `.ready`. If it has already exited, the container exits with code 1 and prints a diagnostic, allowing `claude-docker` to surface the failure via its 30s timeout.

- **`src/docker/claude-docker`** — add `docker inspect` liveness check after `.ready` is detected
  Defense-in-depth: catches the race where mitmdump crashes between `.ready` and agent startup. Prints proxy container logs before exiting.

- **`src/tests/test_session_coordinator.py`** — add `test_issue_1088_creds_path_is_world_readable`
  Regression test asserting `credentials.json` uses `0o644` and delivery files (actual secret content) still use `0o600`.

## ⚠️ Rebuild Required

`entrypoint.sh` and `claude-docker` are baked into the proxy image at build time. After merging, rebuild the proxy image:

```bash
docker build -t claude-proxy:local src/docker/proxy/
```

Without rebuilding, the entrypoint.sh liveness fix will not take effect (the permissions fix in `session_coordinator.py` is host-side and takes effect immediately).

## Testing

- New pytest regression: `uv run pytest src/tests/test_session_coordinator.py::TestIssue1088CredFilePermissions -v` — passes
- Manual: start a proxy session with credentials configured; mitmdump now reads `credentials.json` successfully and the sidecar remains running

🤖 Generated with [Claude Code](https://claude.com/claude-code)