### PR TITLE
fix: wire 8 missing SessionConfig fields through TemplateUpdateRequest

### DIFF
--- a/src/models/minion_template.py
+++ b/src/models/minion_template.py
@@ -47,6 +47,7 @@ class MinionTemplate:
     docker_enabled: bool = False
     docker_image: str | None = None
     docker_extra_mounts: list[str] | None = None
+    docker_home_directory: str | None = None
     # Issue #1053: Named credentials + extra allowed domains for proxy mode
     docker_proxy_enabled: bool = False
     docker_proxy_image: str | None = None
@@ -69,6 +70,10 @@ class MinionTemplate:
     # MCP toggle configuration (issue #786)
     enable_claudeai_mcp_servers: bool = True
     strict_mcp_config: bool = False
+    # Runtime feature flags (issue #1116)
+    setting_sources: list[str] | None = None
+    bare_mode: bool = False
+    env_scrub_enabled: bool = False
     # Composable profiles (issue #1062): area -> profile_id mapping + template-level overrides
     profile_ids: dict[str, str] | None = None   # e.g. {"model": "<uuid>", "permissions": "<uuid>"}
     template_overrides: dict[str, Any] | None = None  # field -> value overrides above profile
@@ -124,6 +129,7 @@ class MinionTemplate:
         data.setdefault('docker_enabled', False)
         data.setdefault('docker_image', None)
         data.setdefault('docker_extra_mounts', None)
+        data.setdefault('docker_home_directory', None)
         data.setdefault('docker_proxy_enabled', False)
         data.setdefault('docker_proxy_image', None)
         data.setdefault('docker_proxy_credential_names', None)
@@ -151,6 +157,10 @@ class MinionTemplate:
         # MCP toggle configuration (issue #786)
         data.setdefault('enable_claudeai_mcp_servers', True)
         data.setdefault('strict_mcp_config', False)
+        # Runtime feature flags (issue #1116)
+        data.setdefault('setting_sources', None)
+        data.setdefault('bare_mode', False)
+        data.setdefault('env_scrub_enabled', False)
         # Composable profiles (issue #1062): migrate legacy unused placeholder field.
         # profile_id was never used in production; drop it and introduce the new fields.
         data.pop('profile_id', None)

--- a/src/template_manager.py
+++ b/src/template_manager.py
@@ -264,6 +264,12 @@ class TemplateManager:
         docker_enabled: bool | None = None,
         docker_image: str | None = None,
         docker_extra_mounts: list[str] | None = None,
+        # Docker proxy configuration (issue #1116)
+        docker_home_directory: str | None = None,
+        docker_proxy_enabled: bool | None = None,
+        docker_proxy_image: str | None = None,
+        docker_proxy_credential_names: list[str] | None = None,
+        docker_proxy_allowlist_domains: list[str] | None = None,
         # Thinking and effort configuration (issue #580)
         thinking_mode: str | None = None,
         thinking_budget_tokens: int | None = None,
@@ -276,6 +282,10 @@ class TemplateManager:
         # MCP toggle configuration (issue #786)
         enable_claudeai_mcp_servers: bool | None = None,
         strict_mcp_config: bool | None = None,
+        # Runtime feature flags (issue #1116)
+        setting_sources: list[str] | None = None,
+        bare_mode: bool | None = None,
+        env_scrub_enabled: bool | None = None,
         # Composable profiles (issue #1062)
         profile_ids: dict[str, str] | None = None,
         template_overrides: dict[str, Any] | None = None,
@@ -342,6 +352,18 @@ class TemplateManager:
         if docker_extra_mounts is not None:
             template.docker_extra_mounts = docker_extra_mounts
 
+        # Docker proxy configuration (issue #1116)
+        if docker_home_directory is not None:
+            template.docker_home_directory = docker_home_directory
+        if docker_proxy_enabled is not None:
+            template.docker_proxy_enabled = docker_proxy_enabled
+        if docker_proxy_image is not None:
+            template.docker_proxy_image = docker_proxy_image
+        if docker_proxy_credential_names is not None:
+            template.docker_proxy_credential_names = docker_proxy_credential_names
+        if docker_proxy_allowlist_domains is not None:
+            template.docker_proxy_allowlist_domains = docker_proxy_allowlist_domains
+
         # Thinking and effort configuration (issue #580)
         if thinking_mode is not None:
             template.thinking_mode = thinking_mode
@@ -370,6 +392,14 @@ class TemplateManager:
 
         if strict_mcp_config is not None:
             template.strict_mcp_config = strict_mcp_config
+
+        # Runtime feature flags (issue #1116)
+        if setting_sources is not None:
+            template.setting_sources = setting_sources
+        if bare_mode is not None:
+            template.bare_mode = bare_mode
+        if env_scrub_enabled is not None:
+            template.env_scrub_enabled = env_scrub_enabled
 
         if profile_ids is not None:
             template.profile_ids = profile_ids

--- a/src/tests/integration/test_api_templates.py
+++ b/src/tests/integration/test_api_templates.py
@@ -1,0 +1,86 @@
+"""
+Integration tests for template CRUD API — issue #1116.
+
+Verifies that PUT /api/templates/{id} correctly persists all SessionConfig fields,
+particularly the 8 fields that were previously silently dropped by Pydantic
+because they were missing from TemplateUpdateRequest.
+"""
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_issue_1116_put_template_persists_docker_proxy_allowlist_domains(
+    api_integration_env,
+):
+    """PUT /api/templates/{id} must persist docker_proxy_allowlist_domains."""
+    client = api_integration_env["client"]
+
+    # Create template
+    create_resp = await client.post(
+        "/api/templates",
+        json={
+            "name": "Proxy Test Template",
+            "permission_mode": "default",
+        },
+    )
+    assert create_resp.status_code == 200, create_resp.text
+    template_id = create_resp.json()["template_id"]
+
+    # Update with docker proxy fields
+    update_resp = await client.put(
+        f"/api/templates/{template_id}",
+        json={
+            "docker_proxy_allowlist_domains": ["example.com", "api.example.com"],
+            "docker_proxy_credential_names": ["vault-cred-1"],
+            "docker_proxy_enabled": True,
+            "docker_proxy_image": "proxy:v2",
+            "docker_home_directory": "/home/agent",
+        },
+    )
+    assert update_resp.status_code == 200, update_resp.text
+
+    # Fetch and verify
+    get_resp = await client.get(f"/api/templates/{template_id}")
+    assert get_resp.status_code == 200, get_resp.text
+    t = get_resp.json()
+
+    assert t["docker_proxy_allowlist_domains"] == ["example.com", "api.example.com"]
+    assert t["docker_proxy_credential_names"] == ["vault-cred-1"]
+    assert t["docker_proxy_enabled"] is True
+    assert t["docker_proxy_image"] == "proxy:v2"
+    assert t["docker_home_directory"] == "/home/agent"
+
+
+@pytest.mark.asyncio
+async def test_issue_1116_put_template_persists_runtime_flags(api_integration_env):
+    """PUT /api/templates/{id} must persist setting_sources, bare_mode, env_scrub_enabled."""
+    client = api_integration_env["client"]
+
+    create_resp = await client.post(
+        "/api/templates",
+        json={
+            "name": "Runtime Flags Template",
+            "permission_mode": "default",
+        },
+    )
+    assert create_resp.status_code == 200, create_resp.text
+    template_id = create_resp.json()["template_id"]
+
+    update_resp = await client.put(
+        f"/api/templates/{template_id}",
+        json={
+            "setting_sources": ["user", "project"],
+            "bare_mode": True,
+            "env_scrub_enabled": True,
+        },
+    )
+    assert update_resp.status_code == 200, update_resp.text
+
+    get_resp = await client.get(f"/api/templates/{template_id}")
+    assert get_resp.status_code == 200, get_resp.text
+    t = get_resp.json()
+
+    assert t["setting_sources"] == ["user", "project"]
+    assert t["bare_mode"] is True
+    assert t["env_scrub_enabled"] is True

--- a/src/tests/test_template_manager.py
+++ b/src/tests/test_template_manager.py
@@ -282,6 +282,64 @@ class TestUpdateTemplate:
         assert updated.docker_enabled is True
         assert updated.cli_path == "/opt/claude"
 
+    @pytest.mark.asyncio
+    async def test_issue_1116_update_docker_proxy_fields(self, manager):
+        """Regression #1116: docker proxy fields must persist via update_template()."""
+        template = await manager.create_template(
+            name="Proxy Test",
+            config=SessionConfig(permission_mode="default"),
+        )
+
+        updated = await manager.update_template(
+            template.template_id,
+            docker_proxy_enabled=True,
+            docker_proxy_image="proxy:latest",
+            docker_proxy_credential_names=["cred-a", "cred-b"],
+            docker_proxy_allowlist_domains=["example.com", "api.example.com"],
+            docker_home_directory="/home/agent",
+        )
+
+        assert updated.docker_proxy_enabled is True
+        assert updated.docker_proxy_image == "proxy:latest"
+        assert updated.docker_proxy_credential_names == ["cred-a", "cred-b"]
+        assert updated.docker_proxy_allowlist_domains == ["example.com", "api.example.com"]
+        assert updated.docker_home_directory == "/home/agent"
+
+        # Verify persistence to disk
+        manager2 = TemplateManager(manager.templates_dir.parent)
+        await manager2.load_templates()
+        reloaded = await manager2.get_template(template.template_id)
+        assert reloaded.docker_proxy_allowlist_domains == ["example.com", "api.example.com"]
+        assert reloaded.docker_proxy_credential_names == ["cred-a", "cred-b"]
+        assert reloaded.docker_proxy_enabled is True
+
+    @pytest.mark.asyncio
+    async def test_issue_1116_update_runtime_flag_fields(self, manager):
+        """Regression #1116: setting_sources, bare_mode, env_scrub_enabled must persist."""
+        template = await manager.create_template(
+            name="Runtime Flags Test",
+            config=SessionConfig(permission_mode="default"),
+        )
+
+        updated = await manager.update_template(
+            template.template_id,
+            setting_sources=["user", "project"],
+            bare_mode=True,
+            env_scrub_enabled=True,
+        )
+
+        assert updated.setting_sources == ["user", "project"]
+        assert updated.bare_mode is True
+        assert updated.env_scrub_enabled is True
+
+        # Verify persistence to disk
+        manager2 = TemplateManager(manager.templates_dir.parent)
+        await manager2.load_templates()
+        reloaded = await manager2.get_template(template.template_id)
+        assert reloaded.setting_sources == ["user", "project"]
+        assert reloaded.bare_mode is True
+        assert reloaded.env_scrub_enabled is True
+
 
 # --- Signature parity test ---
 

--- a/src/tests/test_template_update_request_coverage.py
+++ b/src/tests/test_template_update_request_coverage.py
@@ -1,0 +1,47 @@
+"""
+Regression guard: TemplateUpdateRequest must declare every SessionConfig field
+that is applicable to templates.
+
+If a field is added to SessionConfig but not to TemplateUpdateRequest, Pydantic's
+extra="ignore" (the default) silently drops it from PUT /api/templates/{id} payloads,
+causing saves to appear successful while the field change is never persisted.
+
+This test fails immediately when such a gap is introduced, making the regression
+impossible to ship undetected.
+"""
+
+
+from src.session_config import SessionConfig
+from src.web_server import TemplateUpdateRequest
+
+# Fields that are intentionally NOT editable via TemplateUpdateRequest.
+# Each exclusion must be justified:
+#   working_directory  — session-runtime field; templates don't own a working directory
+#   template_id        — template primary key; not a per-session config value on the request
+#   system_prompt      — TemplateUpdateRequest already declares system_prompt explicitly;
+#                        no gap here, but SessionConfig also has it — exclude from diff check
+#                        because it IS present in TemplateUpdateRequest
+_SESSION_ONLY_FIELDS = {
+    "working_directory",  # not applicable to templates
+    "template_id",        # template PK, not a config field in the request
+}
+
+
+def test_issue_1116_template_update_request_covers_all_session_config_fields():
+    """Every SessionConfig field (minus session-only exclusions) must appear in TemplateUpdateRequest.
+
+    Failure means a field was added to SessionConfig but not wired through
+    TemplateUpdateRequest, which causes silent data loss on template saves.
+    """
+    session_config_fields = set(SessionConfig.model_fields.keys())
+    update_request_fields = set(TemplateUpdateRequest.model_fields.keys())
+
+    applicable = session_config_fields - _SESSION_ONLY_FIELDS
+    missing = applicable - update_request_fields
+
+    assert missing == set(), (
+        f"SessionConfig fields missing from TemplateUpdateRequest "
+        f"(will be silently dropped on template save): {sorted(missing)}\n"
+        f"Add them to TemplateUpdateRequest in src/web_server.py, wire through "
+        f"the update_template endpoint handler, and add to TemplateManager.update_template()."
+    )

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -303,6 +303,12 @@ class TemplateUpdateRequest(BaseModel):
     docker_enabled: bool | None = None
     docker_image: str | None = None
     docker_extra_mounts: list[str] | None = None
+    # Docker proxy configuration (issue #1116)
+    docker_home_directory: str | None = None
+    docker_proxy_enabled: bool | None = None
+    docker_proxy_image: str | None = None
+    docker_proxy_credential_names: list[str] | None = None
+    docker_proxy_allowlist_domains: list[str] | None = None
     # Thinking and effort configuration (issue #580)
     thinking_mode: str | None = None
     thinking_budget_tokens: int | None = None
@@ -320,6 +326,10 @@ class TemplateUpdateRequest(BaseModel):
     # MCP toggle configuration (issue #786)
     enable_claudeai_mcp_servers: bool | None = None
     strict_mcp_config: bool | None = None
+    # Runtime feature flags (issue #1116)
+    setting_sources: list[str] | None = None
+    bare_mode: bool | None = None
+    env_scrub_enabled: bool | None = None
     # Composable profiles (issue #1062)
     profile_ids: dict[str, str] | None = None
     template_overrides: dict | None = None
@@ -3317,6 +3327,12 @@ class ClaudeWebUI:
                 docker_enabled=request.docker_enabled,
                 docker_image=request.docker_image,
                 docker_extra_mounts=request.docker_extra_mounts,
+                # Docker proxy configuration (issue #1116)
+                docker_home_directory=request.docker_home_directory,
+                docker_proxy_enabled=request.docker_proxy_enabled,
+                docker_proxy_image=request.docker_proxy_image,
+                docker_proxy_credential_names=request.docker_proxy_credential_names,
+                docker_proxy_allowlist_domains=request.docker_proxy_allowlist_domains,
                 # Thinking and effort configuration (issue #580)
                 thinking_mode=request.thinking_mode,
                 thinking_budget_tokens=request.thinking_budget_tokens,
@@ -3328,6 +3344,10 @@ class ClaudeWebUI:
                 mcp_server_ids=request.mcp_server_ids,
                 enable_claudeai_mcp_servers=request.enable_claudeai_mcp_servers,
                 strict_mcp_config=request.strict_mcp_config,
+                # Runtime feature flags (issue #1116)
+                setting_sources=request.setting_sources,
+                bare_mode=request.bare_mode,
+                env_scrub_enabled=request.env_scrub_enabled,
                 profile_ids=request.profile_ids,
                 template_overrides=request.template_overrides,
             )


### PR DESCRIPTION
## Summary
Resolves #1116

`TemplateUpdateRequest` was missing 8 `SessionConfig` fields. Pydantic's default `extra="ignore"` silently dropped them from `PUT /api/templates/{id}` payloads, so template saves appeared successful but field changes (e.g. `docker_proxy_allowlist_domains`) were never persisted. The bug was backend-only; the frontend fix shipped in PR #1101.

## Changes Made
- **`src/models/minion_template.py`**: Add 4 missing fields (`docker_home_directory`, `setting_sources`, `bare_mode`, `env_scrub_enabled`) with backward-compat `from_dict()` defaults
- **`src/web_server.py`**: Add all 8 missing fields to `TemplateUpdateRequest`; wire them through the `PUT /api/templates/{id}` endpoint handler
- **`src/template_manager.py`**: Add 8 new parameters to `update_template()` with corresponding `if x is not None: template.x = x` blocks

## Testing
- `src/tests/test_template_manager.py`: Two new unit tests verifying docker proxy fields and runtime flag fields persist to disk via `update_template()`
- `src/tests/integration/test_api_templates.py`: Two HTTP round-trip tests via `PUT` + `GET /api/templates/{id}` asserting all newly wired fields persist
- `src/tests/test_template_update_request_coverage.py`: Regression guard — asserts `SessionConfig` fields ⊆ `TemplateUpdateRequest` fields; fails immediately if a future `SessionConfig` field is not wired through

All 34 targeted tests pass; Ruff reports zero violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)