### PR TITLE
feat: add queue_task MCP tool to Legion for deferred prompt delivery

### DIFF
--- a/src/legion/mcp/legion_mcp_tools.py
+++ b/src/legion/mcp/legion_mcp_tools.py
@@ -384,6 +384,33 @@ class LegionMCPTools:
             args["_from_minion_id"] = session_id
             return await self._handle_restart_session(args)
 
+        # ── Deferred task delivery (Issue #1114) ──
+
+        @tool(
+            "queue_task",
+            "Enqueue a prompt for deferred delivery to another session. Unlike send_comm "
+            "(which delivers immediately), the item is held until the target session is idle, "
+            "then delivered automatically — including auto-starting a terminated session.\n\n"
+            "Use this for handoffs where you do not want to interrupt in-progress work.\n\n"
+            "Parameters:\n"
+            "- session_id (required): Target session to receive the prompt.\n"
+            "- content (required): Prompt text to deliver.\n"
+            "- reset_session (optional, default false): If true, the session is reset "
+            "before the prompt is delivered.\n\n"
+            "Returns queue_id and position for your own bookkeeping.\n\n"
+            "Note: queue_task is not hierarchy-scoped — you may queue into any session "
+            "whose ID you know, not just your own children.",
+            {
+                "session_id": str,
+                "content": str,
+                "reset_session": bool,
+            }
+        )
+        async def queue_task_tool(args: dict[str, Any]) -> dict[str, Any]:
+            """Enqueue a prompt for deferred delivery to a session."""
+            args["_from_minion_id"] = session_id
+            return await self._handle_queue_task(args)
+
         # Create and return MCP server with all tools
         return create_sdk_mcp_server(
             name="legion",
@@ -404,6 +431,7 @@ class LegionMCPTools:
                 resume_schedule_tool,
                 cancel_schedule_tool,
                 restart_session_tool,
+                queue_task_tool,
             ]
         )
 
@@ -2438,3 +2466,51 @@ class LegionMCPTools:
             })
         finally:
             self._pending_restarts.discard(session_id)
+
+    # ── Deferred Task Delivery Handler (Issue #1114) ──
+
+    async def _handle_queue_task(self, args: dict[str, Any]) -> dict[str, Any]:
+        """Handle queue_task tool call — enqueue a prompt for deferred delivery."""
+        session_id = args.get("session_id", "").strip()
+        content = args.get("content", "").strip()
+        reset_session = bool(args.get("reset_session", False))
+
+        if not session_id:
+            return {
+                "content": [{"type": "text", "text": "Error: session_id is required"}],
+                "is_error": True,
+            }
+        if not content:
+            return {
+                "content": [{"type": "text", "text": "Error: content is required"}],
+                "is_error": True,
+            }
+
+        try:
+            item = await self.system.session_coordinator.enqueue_message(
+                session_id=session_id,
+                content=content,
+                reset_session=reset_session,
+            )
+            queue_id = item["queue_id"]
+            position = item["position"]
+            return {
+                "content": [{
+                    "type": "text",
+                    "text": f"Task queued for session {session_id} (queue_id={queue_id}, position={position})",
+                }],
+                "queue_id": queue_id,
+                "position": position,
+                "is_error": False,
+            }
+        except ValueError as e:
+            return {
+                "content": [{"type": "text", "text": f"Error: {e}"}],
+                "is_error": True,
+            }
+        except Exception as e:
+            logger.exception(f"Unexpected error in queue_task for session {session_id}: {e}")
+            return {
+                "content": [{"type": "text", "text": f"Unexpected error queuing task: {e}"}],
+                "is_error": True,
+            }

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -239,6 +239,8 @@ class SessionCoordinator:
         # Callback for broadcasting resource_registered events will be set by web_server
         from src.mcp.resource_mcp_tools import ResourceMCPTools
         self._resource_broadcast_callback: Callable[[str, dict], None] | None = None
+        # Callback for broadcasting queue_update events (enqueued) will be set by web_server
+        self._enqueue_broadcast_callback: Callable[[str, str, dict], Any] | None = None
         self.resource_mcp_tools = ResourceMCPTools(
             session_coordinator=self,
             broadcast_callback=self._broadcast_resource_registered
@@ -454,7 +456,16 @@ class SessionCoordinator:
         if not queue_paused:
             self.queue_processor.ensure_running(session_id)
 
-        return item.to_dict()
+        item_dict = item.to_dict()
+        if self._enqueue_broadcast_callback:
+            try:
+                if asyncio.iscoroutinefunction(self._enqueue_broadcast_callback):
+                    await self._enqueue_broadcast_callback(session_id, "enqueued", item_dict)
+                else:
+                    self._enqueue_broadcast_callback(session_id, "enqueued", item_dict)
+            except Exception:
+                logger.exception(f"Failed to broadcast queue enqueued for {session_id}")
+        return item_dict
 
     async def cancel_queue_item(self, session_id: str, queue_id: str) -> dict | None:
         """Cancel a pending queue item. Returns the item dict or None."""
@@ -883,6 +894,11 @@ class SessionCoordinator:
     def set_image_broadcast_callback(self, callback: Callable[[str, dict], None]) -> None:
         """Deprecated: Use set_resource_broadcast_callback instead."""
         self.set_resource_broadcast_callback(callback)
+
+    def set_enqueue_broadcast_callback(self, callback: Callable[[str, str, dict], Any]) -> None:
+        """Set the callback for broadcasting queue_update (enqueued) events."""
+        self._enqueue_broadcast_callback = callback
+        coord_logger.info("Enqueue broadcast callback registered in SessionCoordinator")
 
     async def _broadcast_resource_registered(self, session_id: str, resource_metadata: dict) -> None:
         """

--- a/src/tests/test_legion_mcp_tools.py
+++ b/src/tests/test_legion_mcp_tools.py
@@ -57,6 +57,7 @@ def test_tool_handler_methods_exist(mcp_tools):
         '_handle_search_capability',
         '_handle_list_minions',
         '_handle_get_minion_info',
+        '_handle_queue_task',
     ]
 
     for method_name in handler_methods:
@@ -469,3 +470,120 @@ async def test_issue_824_non_tmp_path_not_translated(tmp_path):
     )
     # The result should be an error (file doesn't exist)
     assert result.get("is_error") is True
+
+
+# ── queue_task handler tests (Issue #1114) ──
+
+
+def _make_queue_task_tools(enqueue_side_effect=None, enqueue_return=None):
+    """Build LegionMCPTools with a mocked session_coordinator.enqueue_message."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from src.legion.mcp.legion_mcp_tools import LegionMCPTools
+
+    coordinator = MagicMock()
+    if enqueue_side_effect is not None:
+        coordinator.enqueue_message = AsyncMock(side_effect=enqueue_side_effect)
+    else:
+        coordinator.enqueue_message = AsyncMock(return_value=enqueue_return or {
+            "queue_id": "q1",
+            "position": 0,
+            "content": "hello",
+            "status": "pending",
+        })
+
+    mock_system = MagicMock()
+    mock_system.session_coordinator = coordinator
+    return LegionMCPTools(mock_system), coordinator
+
+
+@pytest.mark.asyncio
+async def test_issue_1114_queue_task_handler_enqueues():
+    """Issue #1114: happy path — enqueues and returns queue_id + position."""
+    tools, coordinator = _make_queue_task_tools(enqueue_return={
+        "queue_id": "q1",
+        "position": 0,
+        "content": "hello",
+        "status": "pending",
+    })
+
+    result = await tools._handle_queue_task({
+        "session_id": "sess-abc",
+        "content": "do the thing",
+        "reset_session": False,
+    })
+
+    assert result.get("is_error") is False
+    assert result["queue_id"] == "q1"
+    assert result["position"] == 0
+    assert "q1" in result["content"][0]["text"]
+    coordinator.enqueue_message.assert_awaited_once_with(
+        session_id="sess-abc",
+        content="do the thing",
+        reset_session=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_issue_1114_queue_task_handler_missing_session_id():
+    """Issue #1114: empty session_id returns is_error=True, nothing enqueued."""
+    tools, coordinator = _make_queue_task_tools()
+
+    result = await tools._handle_queue_task({"session_id": "", "content": "hello"})
+
+    assert result.get("is_error") is True
+    assert "session_id" in result["content"][0]["text"].lower()
+    coordinator.enqueue_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_issue_1114_queue_task_handler_missing_content():
+    """Issue #1114: empty content returns is_error=True, nothing enqueued."""
+    tools, coordinator = _make_queue_task_tools()
+
+    result = await tools._handle_queue_task({"session_id": "sess-abc", "content": ""})
+
+    assert result.get("is_error") is True
+    assert "content" in result["content"][0]["text"].lower()
+    coordinator.enqueue_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_issue_1114_queue_task_handler_unknown_session():
+    """Issue #1114: ValueError from enqueue_message surfaces as is_error=True."""
+    tools, coordinator = _make_queue_task_tools(
+        enqueue_side_effect=ValueError("Session foo not found")
+    )
+
+    result = await tools._handle_queue_task({
+        "session_id": "foo",
+        "content": "do work",
+    })
+
+    assert result.get("is_error") is True
+    assert "Session foo not found" in result["content"][0]["text"]
+    coordinator.enqueue_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_issue_1114_queue_task_handler_passes_reset_session():
+    """Issue #1114: reset_session=True is forwarded to enqueue_message."""
+    tools, coordinator = _make_queue_task_tools(enqueue_return={
+        "queue_id": "q2",
+        "position": 1,
+        "content": "reset and do",
+        "status": "pending",
+    })
+
+    result = await tools._handle_queue_task({
+        "session_id": "sess-xyz",
+        "content": "reset and do",
+        "reset_session": True,
+    })
+
+    assert result.get("is_error") is False
+    coordinator.enqueue_message.assert_awaited_once_with(
+        session_id="sess-xyz",
+        content="reset and do",
+        reset_session=True,
+    )

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -729,6 +729,9 @@ class ClaudeWebUI:
 
         # Issue #500: Wire queue processor broadcast callback
         self.coordinator.queue_processor.set_broadcast_callback(self._broadcast_queue_update)
+        # Issue #1114: Wire enqueue broadcast callback so MCP queue_task (and other internal
+        # callers of enqueue_message) emit real-time queue_update events to the WebUI.
+        self.coordinator.set_enqueue_broadcast_callback(self._broadcast_queue_update)
 
         # Issue #1050: Best-effort proxy image check on startup (informational only)
         from .config_manager import load_config
@@ -2231,9 +2234,6 @@ class ClaudeWebUI:
                 reset_session=data.get("reset_session"),
                 metadata=data.get("metadata"),
             )
-
-            # Append queue update to session poll queue
-            await self._broadcast_queue_update(session_id, "enqueued", item)
 
             return {
                 "queue_id": item["queue_id"],


### PR DESCRIPTION
## Summary
Resolves #1114

Adds `queue_task` MCP tool to Legion so minions can enqueue a prompt into any session for deferred delivery when the target is next idle (including auto-starting terminated sessions). Unlike `send_comm`, the prompt is held until the target session is idle, making it suitable for non-interrupting handoffs.

## Changes Made
- **`src/legion/mcp/legion_mcp_tools.py`**: Add `queue_task` `@tool` definition in `create_mcp_server_for_session()`, register in tools list, implement `_handle_queue_task()` handler. Validates inputs, delegates to `coordinator.enqueue_message()`, surfaces `ValueError` (unknown session, queue full) as `is_error: true`.
- **`src/session_coordinator.py`**: Add `_enqueue_broadcast_callback` field, `set_enqueue_broadcast_callback()` setter, and invocation at end of `enqueue_message()`. Mirrors the resource broadcast pattern — MCP tool, scheduler, and restart monitor all now emit real-time queue panel updates.
- **`src/web_server.py`**: Wire `coordinator.set_enqueue_broadcast_callback(_broadcast_queue_update)` in `initialize()`. Remove now-redundant inline broadcast from enqueue REST endpoint to eliminate double-broadcast.
- **`src/tests/test_legion_mcp_tools.py`**: Add 5 unit tests (`test_issue_1114_*`) covering happy path, missing session_id, missing content, unknown session ValueError, and reset_session forwarding. Add `_handle_queue_task` to `test_tool_handler_methods_exist`.

## Testing
- 5 new unit tests all pass: `uv run pytest src/tests/test_legion_mcp_tools.py -v`
- No regressions in `src/tests/test_queue_processor.py`
- Ruff linting passes with zero violations
- 2 pre-existing test failures confirmed unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)