### PR TITLE
feat: block SendMessage and background Agent in Legion sessions

### DIFF
--- a/src/claude_sdk.py
+++ b/src/claude_sdk.py
@@ -1184,6 +1184,16 @@ class ClaudeSDK:
         perm_logger.info(f"Context suggestions: {getattr(context, 'suggestions', [])}")
         perm_logger.info("=======================================")
 
+        # Issue #1133: Block SendMessage and background Agent in Legion sessions
+        # Must run before evaluate_suggestions — the CLI may emit allow-suggestions
+        # for these tools that would otherwise let the call through.
+        if self.permission_handler:
+            result = self.permission_handler.evaluate_tool_block(tool_name, input_params)
+            if result is not None:
+                decision, reason = result
+                perm_logger.info(f"Auto-denied via tool block: {reason}")
+                return PermissionResultDeny(message=reason)
+
         # Check CLI suggestions against internal rules (issue #707)
         if self.permission_handler and hasattr(context, "suggestions") and context.suggestions:
             result = self.permission_handler.evaluate_suggestions(

--- a/src/hooks/pretooluse_handler.py
+++ b/src/hooks/pretooluse_handler.py
@@ -22,6 +22,17 @@ PermissionDecision = Literal["allow", "deny"]
 
 _RESOLVE_CACHE: dict[str, str] = {}
 
+# Issue #1133: Reason strings for Legion tool blocks.
+# Tool names are hardcoded constants — if the SDK renames them, update here.
+_SENDMESSAGE_REDIRECT_REASON = (
+    "SendMessage is not available in Legion sessions. "
+    "Use mcp__legion__send_comm to route communications to other minions."
+)
+_BACKGROUND_AGENT_REDIRECT_REASON = (
+    "Agent with run_in_background=true is not available in Legion sessions. "
+    "Use mcp__legion__spawn_minion to create observable child agents."
+)
+
 # Dangerous Bash command patterns that must never be silently auto-approved.
 # The CLI may misclassify destructive Bash commands (e.g., `rm -rf ~/.claude/skills/`)
 # as benign file reads, causing them to match internal allow rules. This deny list
@@ -129,8 +140,10 @@ class InternalPermissionHandler:
         memory_dir: Path | None = None,
         skill_creating_enabled: bool = False,
         working_directory: Path | None = None,
+        is_legion: bool = False,
     ):
         self._skill_creating_enabled = skill_creating_enabled
+        self._is_legion = is_legion
         self._rules = self._build_rules(
             session_data_dir, plans_dir, knowledge_mgmt_enabled, memory_dir,
             skill_creating_enabled, working_directory,
@@ -328,6 +341,27 @@ class InternalPermissionHandler:
             )
             return (rule.decision, rule.reason)
 
+        return None
+
+    def evaluate_tool_block(
+        self,
+        tool_name: str,
+        tool_input: dict[str, Any] | None,
+    ) -> tuple[PermissionDecision, str] | None:
+        """Block specific tools unconditionally in Legion sessions (issue #1133).
+
+        Returns (decision, reason) if the tool is blocked, None otherwise.
+        Only active when is_legion=True — non-Legion sessions are unaffected.
+
+        Checks run_in_background with `is True` (not truthiness) to avoid blocking
+        foreground Agent calls that pass False, 0, or a truthy string.
+        """
+        if not self._is_legion:
+            return None
+        if tool_name == "SendMessage":
+            return ("deny", _SENDMESSAGE_REDIRECT_REASON)
+        if tool_name == "Agent" and tool_input and tool_input.get("run_in_background") is True:
+            return ("deny", _BACKGROUND_AGENT_REDIRECT_REASON)
         return None
 
     def evaluate_suggestions(

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -1330,6 +1330,7 @@ class SessionCoordinator:
                 session_dir, effective_config.history_distillation_enabled, effective_config.auto_memory_mode,
                 skill_creating_enabled=effective_config.skill_creating_enabled,
                 working_directory=Path(session_info.working_directory),
+                is_legion=("legion" in mcp_servers),
             )
 
             sdk = self._sdk_factory(
@@ -3671,6 +3672,7 @@ class SessionCoordinator:
         auto_memory_mode: str = "claude",
         skill_creating_enabled: bool = False,
         working_directory: Path | None = None,
+        is_legion: bool = False,
     ) -> InternalPermissionHandler:
         """Build internal permission handler with consistent path configuration (issue #707)."""
         memory_dir = session_dir / "memory" if auto_memory_mode == "session" else None
@@ -3681,6 +3683,7 @@ class SessionCoordinator:
             memory_dir=memory_dir,
             skill_creating_enabled=skill_creating_enabled,
             working_directory=working_directory,
+            is_legion=is_legion,
         )
 
     def _resolve_default_proxy_image(self) -> str:

--- a/src/tests/test_pretooluse_handler.py
+++ b/src/tests/test_pretooluse_handler.py
@@ -568,3 +568,80 @@ class TestBashDenyPatternGuard:
             tool_input={"command": f"chmod -R 777 {memory_dir}"},
         )
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Issue #1133: TestToolBlock — evaluate_tool_block matrix
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def handler_legion(tmp_dirs):
+    """Handler configured for a Legion session (is_legion=True)."""
+    return InternalPermissionHandler(
+        session_data_dir=tmp_dirs["session_dir"],
+        plans_dir=tmp_dirs["plans_dir"],
+        knowledge_mgmt_enabled=False,
+        is_legion=True,
+    )
+
+
+@pytest.fixture
+def handler_non_legion(tmp_dirs):
+    """Handler configured for a non-Legion session (is_legion=False)."""
+    return InternalPermissionHandler(
+        session_data_dir=tmp_dirs["session_dir"],
+        plans_dir=tmp_dirs["plans_dir"],
+        knowledge_mgmt_enabled=False,
+        is_legion=False,
+    )
+
+
+class TestToolBlock:
+    """Tests for evaluate_tool_block — the Legion-scoped tool deny list (issue #1133)."""
+
+    def test_sendmessage_denied_in_legion(self, handler_legion):
+        """SendMessage is denied in Legion sessions and reason mentions send_comm."""
+        result = handler_legion.evaluate_tool_block("SendMessage", {})
+        assert result is not None
+        decision, reason = result
+        assert decision == "deny"
+        assert "mcp__legion__send_comm" in reason
+
+    def test_sendmessage_not_blocked_outside_legion(self, handler_non_legion):
+        """SendMessage passes through (returns None) in non-Legion sessions."""
+        result = handler_non_legion.evaluate_tool_block("SendMessage", {})
+        assert result is None
+
+    def test_agent_background_true_denied_in_legion(self, handler_legion):
+        """Agent with run_in_background=True is denied in Legion sessions."""
+        result = handler_legion.evaluate_tool_block("Agent", {"run_in_background": True})
+        assert result is not None
+        decision, reason = result
+        assert decision == "deny"
+        assert "mcp__legion__spawn_minion" in reason
+
+    def test_agent_background_false_not_blocked(self, handler_legion):
+        """Agent with run_in_background=False is NOT blocked (foreground call)."""
+        result = handler_legion.evaluate_tool_block("Agent", {"run_in_background": False})
+        assert result is None
+
+    def test_agent_background_absent_not_blocked(self, handler_legion):
+        """Agent with no run_in_background key is NOT blocked (foreground call)."""
+        result = handler_legion.evaluate_tool_block("Agent", {"prompt": "do something"})
+        assert result is None
+
+    def test_agent_background_truthy_string_not_blocked(self, handler_legion):
+        """Agent with run_in_background='true' (string) is NOT blocked — strict is True check."""
+        result = handler_legion.evaluate_tool_block("Agent", {"run_in_background": "true"})
+        assert result is None
+
+    def test_agent_not_blocked_outside_legion_even_with_background(self, handler_non_legion):
+        """Background Agent in non-Legion session returns None (passes to normal flow)."""
+        result = handler_non_legion.evaluate_tool_block("Agent", {"run_in_background": True})
+        assert result is None
+
+    def test_other_tools_pass_through(self, handler_legion):
+        """Read, Write, Bash with arbitrary inputs return None in Legion session."""
+        assert handler_legion.evaluate_tool_block("Read", {"file_path": "/some/file"}) is None
+        assert handler_legion.evaluate_tool_block("Write", {"file_path": "/out", "content": "x"}) is None
+        assert handler_legion.evaluate_tool_block("Bash", {"command": "ls"}) is None


### PR DESCRIPTION
## Summary
Resolves #1133

Block two problematic Claude Code built-in tools in Legion sessions that cause silent failures: `SendMessage` (causes deadlocks when called instead of `mcp__legion__send_comm`) and `Agent` with `run_in_background=true` (spawns invisible subagents that bypass the WebUI).

## Changes Made
- `src/hooks/pretooluse_handler.py`: Add `is_legion` constructor param (default `False`) and `evaluate_tool_block()` method returning deny for `SendMessage` and background `Agent` when in Legion context; module-level reason constants redirect minions to the correct MCP tools
- `src/claude_sdk.py`: Wire `evaluate_tool_block()` into `_can_use_tool_callback` BEFORE `evaluate_suggestions` so CLI allow-suggestions cannot override the block
- `src/session_coordinator.py`: Pass `is_legion=("legion" in mcp_servers)` through `_build_permission_handler` to the handler constructor
- `src/tests/test_pretooluse_handler.py`: Add `TestToolBlock` class with 8 cases covering the full matrix (SendMessage, background True/False/absent/truthy-string, non-Legion gating, other tools)

## Testing
- 60/60 unit tests pass (52 pre-existing + 8 new `TestToolBlock` cases)
- `uv run ruff check src/` → zero violations
- Foreground `Agent` calls confirmed unblocked (`run_in_background` absent, `False`, or non-bool string all return `None`)
- Non-Legion sessions unaffected (`is_legion=False` gates the entire block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)