### PR TITLE
feat: suppress unnecessary SDK background calls via global config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,52 @@ Enable this for multi-agent (Legion) workflows or any session where isolated con
 Built-in memory is fine for single-agent, single-session use where no archival,
 multi-agent isolation, or cross-reset persistence is needed.
 
+# Environment Configuration - Background Call Suppression
+
+The Claude Agent SDK and Claude Code CLI honor a number of environment variables that suppress
+ambient/background API calls. Claude WebUI applies these at session-launch time based on the
+`background_calls` section of `~/.config/cc_webui/config.json`.
+
+## Defaults (fleet-mode)
+
+All flags default to ON (suppression enabled) except `dont_inherit_env` (off — breaks Docker/proxy flows).
+
+| Config Field                  | Env Var                                  | Default | Effect                                       |
+|-------------------------------|------------------------------------------|---------|----------------------------------------------|
+| `disable_auto_memory`         | `CLAUDE_CODE_DISABLE_AUTO_MEMORY`        | true    | Suppress working-directory auto-memory       |
+| `disable_claudeai_mcp_servers`| `ENABLE_CLAUDEAI_MCP_SERVERS=false`      | true    | Disable built-in Claude AI MCP polling       |
+| `disable_background_tasks`    | `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS`   | true    | Suppress CLI background ambient operations   |
+| `disable_nonessential_traffic`| `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` | true  | Block ambient telemetry/metrics              |
+| `disable_cron`                | `CLAUDE_CODE_DISABLE_CRON`               | true    | Disable CLI's bundled cron (≠ our scheduler) |
+| `disable_feedback_survey`     | `CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY`    | true    | Suppress survey prompts                      |
+| `disable_telemetry`           | `CLAUDE_CODE_ENABLE_TELEMETRY=0`         | true    | Explicitly opt out of telemetry              |
+| `subprocess_env_scrub`        | `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB`       | true    | Strip credentials from spawned subprocesses  |
+| `skip_version_check`          | `CLAUDE_AGENT_SDK_SKIP_VERSION_CHECK`    | true    | Skip CLI version check (latency)             |
+| `dont_inherit_env`            | `CLAUDE_CODE_DONT_INHERIT_ENV`           | false   | Block env inheritance (breaks Docker/proxy)  |
+
+## Per-Session Override
+
+Session config and templates retain their existing override fields:
+- `auto_memory_mode = "claude"` → re-enables auto-memory for that session
+- `enable_claudeai_mcp_servers = True` → re-enables Claude AI MCP for that session
+- `env_scrub_enabled = True` → forces scrubbing (additive with global default)
+
+For other suppression flags, per-session `extra_env` has the highest priority
+and can set or unset any env var.
+
+## Verifying Configuration
+
+The injected env dict is logged at debug level by `claude_sdk.py` when `--debug-sdk` is enabled.
+Inspect `data/logs/sdk_debug.log` for the `ClaudeAgentOptions: ...` line to see the final env
+dict for each session.
+
+## Auditing Future SDK Versions
+
+When upgrading `claude-agent-sdk`, check for new env vars by:
+1. Grepping the installed package for `os.environ`, `os.getenv`, `CLAUDE_*`, `ANTHROPIC_*`.
+2. Checking the bundled CLI binary for new `CLAUDE_CODE_DISABLE_*` flags.
+3. Updating `_BACKGROUND_CALL_ENV_MAP` in `src/claude_sdk.py` and `BackgroundCallsConfig` in `src/config_manager.py`.
+
 # Frontend Architecture - Vue 3 + Pinia + Vite (PRODUCTION)
 
 ## Current Status

--- a/src/claude_sdk.py
+++ b/src/claude_sdk.py
@@ -56,6 +56,21 @@ except ImportError:
     TaskNotificationMessage = None
     TextBlock = None
 
+# Issue #1126: Mapping from BackgroundCallsConfig fields to SDK env vars.
+# Each entry: config_attr -> (env_var_name, value_when_true)
+_BACKGROUND_CALL_ENV_MAP: dict[str, tuple[str, str]] = {
+    "disable_auto_memory":          ("CLAUDE_CODE_DISABLE_AUTO_MEMORY",            "1"),
+    "disable_claudeai_mcp_servers": ("ENABLE_CLAUDEAI_MCP_SERVERS",                "false"),
+    "disable_background_tasks":     ("CLAUDE_CODE_DISABLE_BACKGROUND_TASKS",       "1"),
+    "disable_nonessential_traffic": ("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",   "1"),
+    "disable_cron":                 ("CLAUDE_CODE_DISABLE_CRON",                   "1"),
+    "disable_feedback_survey":      ("CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY",        "1"),
+    "disable_telemetry":            ("CLAUDE_CODE_ENABLE_TELEMETRY",               "0"),
+    "subprocess_env_scrub":         ("CLAUDE_CODE_SUBPROCESS_ENV_SCRUB",           "1"),
+    "skip_version_check":           ("CLAUDE_AGENT_SDK_SKIP_VERSION_CHECK",        "1"),
+    "dont_inherit_env":             ("CLAUDE_CODE_DONT_INHERIT_ENV",               "1"),
+}
+
 # Get specialized loggers for SDK debugging
 sdk_logger = get_logger('sdk_debug', category='SDK')
 perm_logger = get_logger('sdk_debug', category='PERMISSIONS')
@@ -946,26 +961,7 @@ class ClaudeSDK:
         # (e.g., Chrome DevTools screenshots/snapshots). SDK default is 1MB which is too small.
         options_kwargs["max_buffer_size"] = 10 * 1024 * 1024
 
-        # Enable native Tasks system (Claude Code 2.1+)
-        env_vars = {"CLAUDE_CODE_ENABLE_TASKS": "true"}
-        # Issue #411: Enable Agent Teams when experimental flag is set
-        if self.experimental:
-            env_vars["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"] = "1"
-            sdk_logger.info(f"Experimental Agent Teams enabled for session {self.session_id}")
-        # Issue #709: Disable Claude auto-memory for session and disabled modes
-        # Issue #906: "native" mode uses SDK built-in auto-memory with custom directory — do NOT disable
-        if self.auto_memory_mode in ("session", "disabled"):
-            env_vars["CLAUDE_CODE_DISABLE_AUTO_MEMORY"] = "1"
-        # Issue #676: Disable Claude AI MCP servers when toggled off
-        if not self.enable_claudeai_mcp_servers:
-            env_vars["ENABLE_CLAUDEAI_MCP_SERVERS"] = "false"
-        # Issue #957: Scrub subprocess credentials
-        if self.env_scrub_enabled:
-            env_vars["CLAUDE_CODE_SUBPROCESS_ENV_SCRUB"] = "1"
-        # Issue #496: Merge extra env vars (e.g., Docker wrapper config like CLAUDE_DOCKER_*)
-        if self.extra_env:
-            env_vars.update(self.extra_env)
-        options_kwargs["env"] = env_vars
+        options_kwargs["env"] = self._resolve_env_vars()
 
         # Add stderr handler to capture SDK CLI errors (issue #517)
         def stderr_handler(output: str) -> None:
@@ -991,6 +987,50 @@ class ClaudeSDK:
         sdk_logger.debug(f"stderr callback included: {'stderr' in options_kwargs}")
         sdk_logger.debug(f"ClaudeAgentOptions: {options_kwargs}")
         return ClaudeAgentOptions(**options_kwargs)
+
+    def _resolve_env_vars(self) -> dict[str, str]:
+        """Build the env dict for ClaudeAgentOptions.
+
+        Merge order (highest priority wins):
+          global BackgroundCallsConfig → per-session opt-back-in → extra_env
+        """
+        # Always-on
+        env_vars: dict[str, str] = {"CLAUDE_CODE_ENABLE_TASKS": "true"}
+
+        # Issue #411: Enable Agent Teams when experimental flag is set
+        if self.experimental:
+            env_vars["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"] = "1"
+            sdk_logger.info(f"Experimental Agent Teams enabled for session {self.session_id}")
+
+        # Issue #1126: Apply global background-call suppression as the floor
+        from .config_manager import load_config
+        bg_cfg = load_config().background_calls
+        for attr, (var, value) in _BACKGROUND_CALL_ENV_MAP.items():
+            if getattr(bg_cfg, attr):
+                env_vars[var] = value
+
+        # Per-session opt-back-in: remove suppression keys when session expresses preference
+        # Issues #709, #906: auto-memory
+        if self.auto_memory_mode == "claude":
+            env_vars.pop("CLAUDE_CODE_DISABLE_AUTO_MEMORY", None)
+        elif self.auto_memory_mode in ("session", "disabled"):
+            env_vars["CLAUDE_CODE_DISABLE_AUTO_MEMORY"] = "1"
+
+        # Issue #676: Claude AI MCP servers
+        if self.enable_claudeai_mcp_servers:
+            env_vars.pop("ENABLE_CLAUDEAI_MCP_SERVERS", None)
+        else:
+            env_vars["ENABLE_CLAUDEAI_MCP_SERVERS"] = "false"
+
+        # Issue #957: subprocess env scrub — only additive (no session-level opt-out)
+        if self.env_scrub_enabled:
+            env_vars["CLAUDE_CODE_SUBPROCESS_ENV_SCRUB"] = "1"
+
+        # Issue #496: Merge extra env vars (highest priority; e.g., CLAUDE_DOCKER_*)
+        if self.extra_env:
+            env_vars.update(self.extra_env)
+
+        return env_vars
 
     async def _process_sdk_message(self, sdk_message: Any):
         """Process a single message from the SDK stream."""

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -41,11 +41,32 @@ class LegionConfig:
 
 
 @dataclass
+class BackgroundCallsConfig:
+    """Suppression flags for ambient/background SDK calls.
+
+    Defaults match a self-hosted/fleet deployment posture: minimize
+    incidental API traffic. Per-session config can opt back in.
+    """
+
+    disable_auto_memory: bool = True
+    disable_claudeai_mcp_servers: bool = True
+    disable_background_tasks: bool = True
+    disable_nonessential_traffic: bool = True
+    disable_cron: bool = True
+    disable_feedback_survey: bool = True
+    disable_telemetry: bool = True
+    subprocess_env_scrub: bool = True
+    skip_version_check: bool = True
+    dont_inherit_env: bool = False  # leaving off — breaks Docker/proxy flows
+
+
+@dataclass
 class AppConfig:
     networking: NetworkingConfig = field(default_factory=NetworkingConfig)
     features: FeaturesConfig = field(default_factory=FeaturesConfig)
     proxy: ProxyConfig = field(default_factory=ProxyConfig)
     legion: LegionConfig = field(default_factory=LegionConfig)
+    background_calls: BackgroundCallsConfig = field(default_factory=BackgroundCallsConfig)
 
     @classmethod
     def from_dict(cls, data: dict) -> "AppConfig":
@@ -66,7 +87,26 @@ class AppConfig:
         legion = LegionConfig(
             max_concurrent_minions=legion_data.get("max_concurrent_minions", 20),
         )
-        return cls(networking=networking, features=features, proxy=proxy, legion=legion)
+        bg_data = data.get("background_calls", {})
+        background_calls = BackgroundCallsConfig(
+            disable_auto_memory=bg_data.get("disable_auto_memory", True),
+            disable_claudeai_mcp_servers=bg_data.get("disable_claudeai_mcp_servers", True),
+            disable_background_tasks=bg_data.get("disable_background_tasks", True),
+            disable_nonessential_traffic=bg_data.get("disable_nonessential_traffic", True),
+            disable_cron=bg_data.get("disable_cron", True),
+            disable_feedback_survey=bg_data.get("disable_feedback_survey", True),
+            disable_telemetry=bg_data.get("disable_telemetry", True),
+            subprocess_env_scrub=bg_data.get("subprocess_env_scrub", True),
+            skip_version_check=bg_data.get("skip_version_check", True),
+            dont_inherit_env=bg_data.get("dont_inherit_env", False),
+        )
+        return cls(
+            networking=networking,
+            features=features,
+            proxy=proxy,
+            legion=legion,
+            background_calls=background_calls,
+        )
 
     def to_dict(self) -> dict:
         return {
@@ -86,6 +126,24 @@ class AppConfig:
             },
             "legion": {
                 "max_concurrent_minions": self.legion.max_concurrent_minions,
+            },
+            "background_calls": {
+                "_comment": (
+                    "Suppress ambient/background SDK API calls. All flags default ON"
+                    " (suppression enabled) except dont_inherit_env (breaks Docker/proxy)."
+                    " Per-session config can opt back in via auto_memory_mode, enable_claudeai_mcp_servers,"
+                    " or extra_env."
+                ),
+                "disable_auto_memory": self.background_calls.disable_auto_memory,
+                "disable_claudeai_mcp_servers": self.background_calls.disable_claudeai_mcp_servers,
+                "disable_background_tasks": self.background_calls.disable_background_tasks,
+                "disable_nonessential_traffic": self.background_calls.disable_nonessential_traffic,
+                "disable_cron": self.background_calls.disable_cron,
+                "disable_feedback_survey": self.background_calls.disable_feedback_survey,
+                "disable_telemetry": self.background_calls.disable_telemetry,
+                "subprocess_env_scrub": self.background_calls.subprocess_env_scrub,
+                "skip_version_check": self.background_calls.skip_version_check,
+                "dont_inherit_env": self.background_calls.dont_inherit_env,
             },
         }
 

--- a/src/tests/test_claude_sdk_env.py
+++ b/src/tests/test_claude_sdk_env.py
@@ -1,0 +1,110 @@
+"""Tests for ClaudeSDK._resolve_env_vars() — issue #1126."""
+
+import tempfile
+from unittest.mock import patch
+
+from src.claude_sdk import ClaudeSDK
+from src.config_manager import AppConfig, BackgroundCallsConfig
+from src.session_config import SessionConfig
+
+
+def _make_sdk(config: SessionConfig | None = None, experimental: bool = False, extra_env: dict | None = None) -> ClaudeSDK:
+    """Build a minimal ClaudeSDK instance for env-var testing."""
+    with tempfile.TemporaryDirectory() as tmp:
+        return ClaudeSDK(
+            session_id="test-env-session",
+            working_directory=tmp,
+            config=config or SessionConfig(),
+            experimental=experimental,
+            extra_env=extra_env or {},
+        )
+
+
+def _all_suppressed_config() -> AppConfig:
+    """AppConfig with all suppression flags ON."""
+    return AppConfig(background_calls=BackgroundCallsConfig())
+
+
+def _suppression_off_config() -> AppConfig:
+    """AppConfig with all suppression flags OFF."""
+    return AppConfig(
+        background_calls=BackgroundCallsConfig(
+            disable_auto_memory=False,
+            disable_claudeai_mcp_servers=False,
+            disable_background_tasks=False,
+            disable_nonessential_traffic=False,
+            disable_cron=False,
+            disable_feedback_survey=False,
+            disable_telemetry=False,
+            subprocess_env_scrub=False,
+            skip_version_check=False,
+            dont_inherit_env=False,
+        )
+    )
+
+
+class TestResolveEnvVars:
+    def test_enable_tasks_always_set(self):
+        sdk = _make_sdk()
+        with patch("src.config_manager.load_config", return_value=_suppression_off_config()):
+            env = sdk._resolve_env_vars()
+        assert env["CLAUDE_CODE_ENABLE_TASKS"] == "true"
+
+    def test_global_defaults_applied_to_env_dict(self):
+        # Use session config that does not opt back in to anything
+        config = SessionConfig(auto_memory_mode="disabled", enable_claudeai_mcp_servers=False)
+        sdk = _make_sdk(config=config)
+        with patch("src.config_manager.load_config", return_value=_all_suppressed_config()):
+            env = sdk._resolve_env_vars()
+        assert env["CLAUDE_CODE_DISABLE_AUTO_MEMORY"] == "1"
+        assert env["ENABLE_CLAUDEAI_MCP_SERVERS"] == "false"
+        assert env["CLAUDE_CODE_DISABLE_BACKGROUND_TASKS"] == "1"
+        assert env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] == "1"
+        assert env["CLAUDE_CODE_DISABLE_CRON"] == "1"
+        assert env["CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY"] == "1"
+        assert env["CLAUDE_CODE_ENABLE_TELEMETRY"] == "0"
+        assert env["CLAUDE_CODE_SUBPROCESS_ENV_SCRUB"] == "1"
+        assert env["CLAUDE_AGENT_SDK_SKIP_VERSION_CHECK"] == "1"
+
+    def test_auto_memory_claude_mode_removes_disable_var(self):
+        config = SessionConfig(auto_memory_mode="claude")
+        sdk = _make_sdk(config=config)
+        with patch("src.config_manager.load_config", return_value=_all_suppressed_config()):
+            env = sdk._resolve_env_vars()
+        assert "CLAUDE_CODE_DISABLE_AUTO_MEMORY" not in env
+
+    def test_auto_memory_session_mode_keeps_disable_var(self):
+        config = SessionConfig(auto_memory_mode="session")
+        sdk = _make_sdk(config=config)
+        with patch("src.config_manager.load_config", return_value=_suppression_off_config()):
+            env = sdk._resolve_env_vars()
+        assert env["CLAUDE_CODE_DISABLE_AUTO_MEMORY"] == "1"
+
+    def test_enable_claudeai_mcp_true_removes_global_disable(self):
+        config = SessionConfig(enable_claudeai_mcp_servers=True)
+        sdk = _make_sdk(config=config)
+        with patch("src.config_manager.load_config", return_value=_all_suppressed_config()):
+            env = sdk._resolve_env_vars()
+        assert "ENABLE_CLAUDEAI_MCP_SERVERS" not in env
+
+    def test_enable_claudeai_mcp_false_sets_disable(self):
+        config = SessionConfig(enable_claudeai_mcp_servers=False)
+        sdk = _make_sdk(config=config)
+        with patch("src.config_manager.load_config", return_value=_suppression_off_config()):
+            env = sdk._resolve_env_vars()
+        assert env["ENABLE_CLAUDEAI_MCP_SERVERS"] == "false"
+
+    def test_extra_env_overrides_all_layers(self):
+        sdk = _make_sdk(
+            extra_env={"CLAUDE_CODE_DISABLE_AUTO_MEMORY": "0", "MY_CUSTOM": "yes"}
+        )
+        with patch("src.config_manager.load_config", return_value=_all_suppressed_config()):
+            env = sdk._resolve_env_vars()
+        assert env["CLAUDE_CODE_DISABLE_AUTO_MEMORY"] == "0"
+        assert env["MY_CUSTOM"] == "yes"
+
+    def test_experimental_flag_adds_agent_teams_var(self):
+        sdk = _make_sdk(experimental=True)
+        with patch("src.config_manager.load_config", return_value=_suppression_off_config()):
+            env = sdk._resolve_env_vars()
+        assert env["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"] == "1"

--- a/src/tests/test_config_manager.py
+++ b/src/tests/test_config_manager.py
@@ -6,6 +6,7 @@ import pytest
 
 from src.config_manager import (
     AppConfig,
+    BackgroundCallsConfig,
     NetworkingConfig,
     check_network_binding,
     ensure_config_file,
@@ -145,3 +146,55 @@ class TestAppConfig:
         assert NetworkingConfig(True, False).network_binding_allowed is False
         assert NetworkingConfig(False, True).network_binding_allowed is False
         assert NetworkingConfig(False, False).network_binding_allowed is False
+
+
+class TestBackgroundCallsConfig:
+    def test_defaults_all_suppression_on_except_dont_inherit_env(self):
+        cfg = BackgroundCallsConfig()
+        assert cfg.disable_auto_memory is True
+        assert cfg.disable_claudeai_mcp_servers is True
+        assert cfg.disable_background_tasks is True
+        assert cfg.disable_nonessential_traffic is True
+        assert cfg.disable_cron is True
+        assert cfg.disable_feedback_survey is True
+        assert cfg.disable_telemetry is True
+        assert cfg.subprocess_env_scrub is True
+        assert cfg.skip_version_check is True
+        assert cfg.dont_inherit_env is False
+
+    def test_background_calls_defaults_present_in_new_config_file(self, tmp_path):
+        config_file = tmp_path / "config.json"
+        ensure_config_file(config_file)
+        data = json.loads(config_file.read_text())
+        bg = data["background_calls"]
+        assert bg["disable_auto_memory"] is True
+        assert bg["disable_claudeai_mcp_servers"] is True
+        assert bg["subprocess_env_scrub"] is True
+        assert bg["dont_inherit_env"] is False
+
+    def test_background_calls_round_trip_serialization(self):
+        original = AppConfig(
+            background_calls=BackgroundCallsConfig(
+                disable_auto_memory=False,
+                dont_inherit_env=True,
+            )
+        )
+        restored = AppConfig.from_dict(original.to_dict())
+        assert restored.background_calls.disable_auto_memory is False
+        assert restored.background_calls.dont_inherit_env is True
+        assert restored.background_calls.disable_telemetry is True
+
+    def test_background_calls_missing_section_uses_defaults(self, tmp_path):
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({"networking": {}}))
+        config = load_config(config_file)
+        assert config.background_calls.disable_auto_memory is True
+        assert config.background_calls.dont_inherit_env is False
+
+    def test_background_calls_partial_section_fills_missing_fields(self, tmp_path):
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({"background_calls": {"disable_auto_memory": False}}))
+        config = load_config(config_file)
+        assert config.background_calls.disable_auto_memory is False
+        assert config.background_calls.disable_telemetry is True
+        assert config.background_calls.dont_inherit_env is False


### PR DESCRIPTION
## Summary
Resolves #1126

Add a `BackgroundCallsConfig` dataclass to `AppConfig` that suppresses all ambient/background SDK API calls by default (auto-memory, Claude AI MCP polling, telemetry, cron, feedback survey, version check, subprocess env scrub). Per-session config can opt back in via existing fields; `extra_env` has highest priority.

## Changes Made
- `src/config_manager.py`: `BackgroundCallsConfig` dataclass with 9 suppression flags (all default ON except `dont_inherit_env`); wired into `AppConfig.from_dict()`/`to_dict()`; existing configs without the section fall back to defaults
- `src/claude_sdk.py`: `_BACKGROUND_CALL_ENV_MAP` constant maps config fields → SDK env var names; `_resolve_env_vars()` method applies global suppression floor then per-session opt-back-in; `_build_options()` delegates to this method
- `CLAUDE.md`: New "Environment Configuration" section documenting all 10 env vars, defaults, per-session override mechanisms, and SDK audit guidance
- `src/tests/test_claude_sdk_env.py`: 8 new unit tests covering global defaults, each opt-back-in flag, `extra_env` priority, and experimental flag
- `src/tests/test_config_manager.py`: 5 new tests covering `BackgroundCallsConfig` defaults, round-trip serialization, missing section fallback, and partial section fill

## Merge order
```
global BackgroundCallsConfig defaults
  → per-session opt-back-in (auto_memory_mode, enable_claudeai_mcp_servers, env_scrub_enabled)
  → SessionConfig.extra_env (highest priority)
```

`env_scrub_enabled=False` (default) is treated as "no preference" — the global `subprocess_env_scrub` setting stays in effect. Only an explicit `True` forces scrubbing on. There is no session-level opt-out path; `extra_env` is the escape hatch.

## Testing
- 8 new env resolution unit tests (all pass)
- 5 new `BackgroundCallsConfig` config tests (all pass)
- Full test suite: 1076 pass, 5 pre-existing failures unrelated to this change
- Ruff: zero violations

## Follow-up consideration (not a blocker)
The existing `enable_claudeai_mcp_servers=True` default in `SessionConfig` means most sessions will opt back in to Claude AI MCP servers even when the global `disable_claudeai_mcp_servers=True`. Operators wanting hard suppression should set `enable_claudeai_mcp_servers=False` on session templates/profiles. This is the documented "session overrides global" behavior — addressed in a future issue if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)