### PR TITLE
fix: resolve 6 pre-existing test failures (stale mocks and assertions)

### DIFF
--- a/src/tests/test_application_service.py
+++ b/src/tests/test_application_service.py
@@ -288,7 +288,10 @@ async def test_update_session_delegates_to_session_manager(service, mock_coordin
     result = await service.update_session("s1", name="new name", model="sonnet")
 
     mock_coordinator.session_manager.update_session.assert_called_once_with(
-        "s1", name="new name", model="sonnet"
+        "s1",
+        template_manager=mock_coordinator.template_manager,
+        name="new name",
+        model="sonnet",
     )
     assert result is True
 

--- a/src/tests/test_claude_sdk_env.py
+++ b/src/tests/test_claude_sdk_env.py
@@ -63,7 +63,7 @@ class TestResolveEnvVars:
         assert env["CLAUDE_CODE_DISABLE_CRON"] == "1"
         assert env["CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY"] == "1"
         assert env["CLAUDE_CODE_ENABLE_TELEMETRY"] == "0"
-        assert env["CLAUDE_CODE_SUBPROCESS_ENV_SCRUB"] == "1"
+        assert "CLAUDE_CODE_SUBPROCESS_ENV_SCRUB" not in env
         assert env["CLAUDE_AGENT_SDK_SKIP_VERSION_CHECK"] == "1"
 
     def test_auto_memory_claude_mode_removes_disable_var(self):

--- a/src/tests/test_legion_mcp_tools.py
+++ b/src/tests/test_legion_mcp_tools.py
@@ -324,6 +324,7 @@ def _make_send_comm_system(session_id: str, docker_enabled: bool, data_dir):
     session_coordinator = MagicMock()
     session_coordinator.session_manager = session_manager
     session_coordinator.data_dir = Path(data_dir)
+    session_coordinator.register_uploaded_resource = AsyncMock(return_value=None)
 
     mock_system = MagicMock()
     mock_system.session_coordinator = session_coordinator

--- a/src/tests/test_minion_template.py
+++ b/src/tests/test_minion_template.py
@@ -4,20 +4,20 @@
 from ..models.minion_template import MinionTemplate
 
 
-class TestMinionTemplateProfileId:
-    """Tests for profile_id field added in issue #1059."""
+class TestMinionTemplateProfileIds:
+    """Tests for profile_ids field added in issue #1062."""
 
-    def test_minion_template_profile_id_default(self):
-        """profile_id defaults to None when not provided."""
+    def test_minion_template_profile_ids_default(self):
+        """profile_ids defaults to empty dict when not provided."""
         template = MinionTemplate(
             template_id="tmpl-001",
             name="Test Template",
             permission_mode="acceptEdits",
         )
-        assert template.profile_id is None
+        assert template.profile_ids == {}
 
     def test_minion_template_from_dict_backward_compat(self):
-        """from_dict with missing profile_id defaults to None."""
+        """from_dict with missing profile_ids defaults to empty dict."""
         data = {
             "template_id": "tmpl-002",
             "name": "Legacy Template",
@@ -26,15 +26,15 @@ class TestMinionTemplateProfileId:
             "updated_at": "2025-01-01T00:00:00+00:00",
         }
         template = MinionTemplate.from_dict(data)
-        assert template.profile_id is None
+        assert template.profile_ids == {}
 
-    def test_minion_template_round_trip_profile_id(self):
-        """to_dict() → from_dict() preserves profile_id."""
+    def test_minion_template_round_trip_profile_ids(self):
+        """to_dict() → from_dict() preserves profile_ids."""
         template = MinionTemplate(
             template_id="tmpl-003",
             name="Profile Template",
             permission_mode="acceptEdits",
-            profile_id="profile-xyz",
+            profile_ids={"model": "profile-xyz"},
         )
         restored = MinionTemplate.from_dict(template.to_dict())
-        assert restored.profile_id == "profile-xyz"
+        assert restored.profile_ids == {"model": "profile-xyz"}


### PR DESCRIPTION
## Summary
Resolves #1140

Fix 6 stale test failures left by prior PRs that changed production signatures without updating corresponding tests.

## Changes Made
- `test_application_service.py`: add `template_manager` kwarg to `update_session` assertion
- `test_claude_sdk_env.py`: assert `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB` absent (default is now `False`)
- `test_legion_mcp_tools.py`: mock `register_uploaded_resource` as `AsyncMock` (method became async)
- `test_minion_template.py`: rename `profile_id` → `profile_ids`, update type `str` → `dict`, default `None` → `{}`

## Testing
- All 6 previously-failing tests now pass
- Full suite: 1090 passed (1084 → 1090), zero regressions
- Zero ruff violations on all modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)