### PR TITLE
feat: add Vitest frontend testing infrastructure with 40+ store and component tests

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -17,6 +17,9 @@ dist-ssr/
 *.sln
 *.sw?
 
+# Test coverage
+coverage/
+
 # Environment variables (keep .env.example)
 .env
 .env.local

--- a/frontend/TESTING.md
+++ b/frontend/TESTING.md
@@ -1,0 +1,177 @@
+# Frontend Testing Guide
+
+## Overview
+
+The frontend uses [Vitest](https://vitest.dev/) with [Vue Test Utils](https://test-utils.vuejs.org/) and
+[@testing-library/vue](https://testing-library.com/docs/vue-testing-library/intro/) for unit and component testing.
+
+## Running Tests
+
+```bash
+cd frontend
+npm test            # single run (CI)
+npm run test:watch  # watch mode (development)
+npm run test:coverage  # with coverage report
+```
+
+All 40+ tests should pass in under 10 seconds.
+
+## Test Structure
+
+```
+frontend/src/
+├── stores/__tests__/          # 24 Pinia store tests (6 files)
+│   ├── session.test.js        # Session CRUD, currentInput getter/setter
+│   ├── project.test.js        # Project fetch, reorder, status segments
+│   ├── message.test.js        # Messages, tool lifecycle, permissions
+│   ├── polling.test.js        # HTTP polling actions (send, interrupt)
+│   ├── legion.test.js         # Multi-agent: sendComm, createMinion, haltAll
+│   └── ui.test.js             # Sidebar toggle, modals, responsive state
+│
+└── components/*/__tests__/    # 16 component tests (11 files)
+    ├── common/
+    │   ├── AttachmentChip.test.js
+    │   └── AuthPrompt.test.js
+    ├── layout/
+    │   ├── AgentChip.test.js
+    │   ├── ConnectionIndicator.test.js
+    │   └── ProjectPill.test.js
+    ├── messages/
+    │   ├── InputArea.test.js
+    │   ├── MessageItem.test.js
+    │   └── MessageList.test.js
+    ├── messages/tools/
+    │   ├── ActivityTimeline.test.js
+    │   └── PermissionPrompt.test.js
+    └── tools/
+        └── BashToolHandler.test.js
+```
+
+## Test Utilities
+
+### `src/test-utils/factories.js`
+
+Factory functions that produce plain objects matching store shapes:
+
+```js
+import { makeSession, makeProject, makeMessage, makeToolCall, makeMinion, makeComm } from '@/test-utils/factories'
+
+const session = makeSession({ session_id: 'sess-1', name: 'My Session' })
+const message = makeMessage({ content: 'Hello' })
+```
+
+### `src/test-utils/render.js`
+
+`renderWithStores(component, options)` — mounts a Vue component with a fresh Pinia and
+in-memory router. Returns the pinia instance for store access.
+
+```js
+import { renderWithStores } from '@/test-utils/render'
+
+const { pinia } = renderWithStores(MyComponent, {
+  props: { foo: 'bar' },
+  stubs: { ChildComponent: true }
+})
+
+// Access stores bound to the component's pinia
+const { useMyStore } = await import('@/stores/myStore')
+const store = useMyStore(pinia)
+store.someValue = 'test'
+```
+
+## Writing Store Tests
+
+Store tests use dynamic imports to bind the store to the active Pinia:
+
+```js
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const apiMock = vi.hoisted(() => ({
+  get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn(), patch: vi.fn()
+}))
+vi.mock('@/utils/api', () => ({ api: apiMock, getAuthToken: vi.fn() }))
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  Object.values(apiMock).forEach(fn => fn.mockReset())
+})
+
+it('does something', async () => {
+  const { useMyStore } = await import('@/stores/myStore')
+  const store = useMyStore()
+  // ...
+})
+```
+
+## Writing Component Tests
+
+Component tests use `renderWithStores` which handles Pinia + router setup and DOM cleanup:
+
+```js
+import { describe, it, expect, vi } from 'vitest'
+import { nextTick } from 'vue'
+import { screen, fireEvent } from '@testing-library/vue'
+import { renderWithStores } from '@/test-utils/render'
+import MyComponent from '@/components/MyComponent.vue'
+
+vi.mock('@/utils/api', () => ({
+  api: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn(), patch: vi.fn() },
+  getAuthToken: vi.fn()
+}))
+
+it('renders expected content', async () => {
+  const { pinia } = renderWithStores(MyComponent, {
+    props: { title: 'Hello' },
+    stubs: { ComplexChild: true }
+  })
+
+  // Set store state and wait for re-render
+  const { useSessionStore } = await import('@/stores/session')
+  const store = useSessionStore(pinia)
+  store.currentSessionId = 'sess-1'
+  await nextTick()
+
+  expect(screen.getByText('Hello')).toBeTruthy()
+})
+```
+
+## Mocking Patterns
+
+### API mock (required in almost every test file)
+
+```js
+const apiMock = vi.hoisted(() => ({
+  get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn(), patch: vi.fn()
+}))
+vi.mock('@/utils/api', () => ({ api: apiMock, getAuthToken: vi.fn() }))
+```
+
+### Composable mock
+
+```js
+vi.mock('@/composables/useTTSReadAloud', () => ({
+  useTTSReadAloud: () => ({
+    isEnabled: { value: false },
+    isPlaying: { value: false },
+    speak: vi.fn(),
+    stop: vi.fn()
+  })
+}))
+```
+
+### Component stub (inline template)
+
+```js
+stubs: {
+  TimelineNode: { template: '<div data-testid="node" />', props: ['tool'] }
+}
+```
+
+## Configuration
+
+- **`vitest.config.js`**: Standalone Vitest config (uses `vitest/config`, not `vite/config`)
+- **`vitest.setup.js`**: Global beforeEach/afterEach (clear storage, suppress console noise)
+- **Environment**: jsdom
+- **Globals**: enabled (no need to import `describe`/`it`/`expect`)
+- **Alias**: `@` → `src/`

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@mermaid-js/mermaid-zenuml": "^0.2.2",
@@ -24,7 +27,14 @@
     "vue-router": "^4.3.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/user-event": "^14.6.1",
+    "@testing-library/vue": "^8.1.0",
     "@vitejs/plugin-vue": "^6.0.3",
-    "vite": "^7.1.12"
+    "@vitest/coverage-v8": "^2.1.9",
+    "@vue/test-utils": "^2.4.8",
+    "jsdom": "^25.0.1",
+    "vite": "^7.1.12",
+    "vitest": "^2.1.9"
   }
 }

--- a/frontend/src/components/common/__tests__/AttachmentChip.test.js
+++ b/frontend/src/components/common/__tests__/AttachmentChip.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest'
+import { screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { renderWithStores } from '@/test-utils/render'
+import AttachmentChip from '@/components/common/AttachmentChip.vue'
+
+vi.mock('@/utils/fileTypes', () => ({
+  getFileIcon: () => '📄',
+  getFileIconByMimeType: () => '📄'
+}))
+
+describe('AttachmentChip', () => {
+  it('renders filename and emits preview when clicked with resourceId', async () => {
+    const user = userEvent.setup()
+    const { emitted } = renderWithStores(AttachmentChip, {
+      props: {
+        filename: 'report.pdf',
+        resourceId: 'res-1',
+        sessionId: 'sess-1'
+      }
+    })
+
+    expect(screen.getByText('report.pdf')).toBeTruthy()
+
+    const chip = screen.getByTitle('Click to preview')
+    await user.click(chip)
+
+    expect(emitted().preview).toBeTruthy()
+  })
+})

--- a/frontend/src/components/common/__tests__/AuthPrompt.test.js
+++ b/frontend/src/components/common/__tests__/AuthPrompt.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest'
+import { screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { renderWithStores } from '@/test-utils/render'
+import AuthPrompt from '@/components/common/AuthPrompt.vue'
+
+const apiGetMock = vi.hoisted(() => vi.fn())
+const setAuthTokenMock = vi.hoisted(() => vi.fn())
+vi.mock('@/utils/api', () => ({
+  api: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn(), patch: vi.fn() },
+  apiGet: apiGetMock,
+  setAuthToken: setAuthTokenMock,
+  getAuthToken: vi.fn().mockReturnValue(null),
+  clearAuthToken: vi.fn()
+}))
+
+describe('AuthPrompt', () => {
+  it('submitting token calls setAuthToken and verifies via apiGet', async () => {
+    const user = userEvent.setup()
+    apiGetMock.mockResolvedValue({ authenticated: true })
+
+    const { emitted } = renderWithStores(AuthPrompt)
+
+    const input = screen.getByPlaceholderText(/paste token/i)
+    await user.type(input, 'my-secret-token')
+
+    const btn = screen.getByRole('button', { name: /authenticate/i })
+    await user.click(btn)
+
+    expect(setAuthTokenMock).toHaveBeenCalledWith('my-secret-token')
+    expect(apiGetMock).toHaveBeenCalledWith('/api/auth/check')
+    expect(emitted().authenticated).toBeTruthy()
+  })
+})

--- a/frontend/src/components/layout/__tests__/AgentChip.test.js
+++ b/frontend/src/components/layout/__tests__/AgentChip.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { screen } from '@testing-library/vue'
+import { renderWithStores } from '@/test-utils/render'
+import AgentChip from '@/components/layout/AgentChip.vue'
+import { makeSession } from '@/test-utils/factories'
+
+const apiMock = vi.hoisted(() => ({
+  get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn(), patch: vi.fn()
+}))
+vi.mock('@/utils/api', () => ({ api: apiMock, getAuthToken: vi.fn() }))
+vi.mock('@/stores/schedule', () => ({
+  useScheduleStore: () => ({ getScheduleCount: vi.fn().mockReturnValue(0) })
+}))
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+})
+
+describe('AgentChip', () => {
+  it('renders session name and reflects active state', () => {
+    const session = makeSession({ session_id: 'sess-1', name: 'My Agent', state: 'active' })
+
+    renderWithStores(AgentChip, {
+      props: {
+        session,
+        isActive: true,
+        isParentOfActive: false,
+        variant: 'default',
+        isGhost: false
+      }
+    })
+
+    expect(screen.getByText('My Agent')).toBeTruthy()
+    // Role button with aria-label that includes the agent name
+    const btn = screen.getByRole('button', { name: /my agent/i })
+    expect(btn.classList.contains('active')).toBe(true)
+  })
+})

--- a/frontend/src/components/layout/__tests__/ConnectionIndicator.test.js
+++ b/frontend/src/components/layout/__tests__/ConnectionIndicator.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { screen } from '@testing-library/vue'
+import { renderWithStores } from '@/test-utils/render'
+import ConnectionIndicator from '@/components/layout/ConnectionIndicator.vue'
+
+const apiMock = vi.hoisted(() => ({
+  get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn(), patch: vi.fn()
+}))
+vi.mock('@/utils/api', () => ({ api: apiMock, getAuthToken: vi.fn() }))
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+})
+
+describe('ConnectionIndicator', () => {
+  it('reflects polling store connected/disconnected state via aria-label', async () => {
+    const { pinia } = renderWithStores(ConnectionIndicator)
+
+    const { usePollingStore } = await import('@/stores/polling')
+    const pollingStore = usePollingStore(pinia)
+
+    pollingStore.uiConnected = true
+    await new Promise(r => setTimeout(r, 0))
+
+    const uiIndicator = screen.getByRole('status', { name: /ui poll/i })
+    expect(uiIndicator.getAttribute('aria-label')).toContain('Connected')
+
+    pollingStore.uiConnected = false
+    pollingStore.uiRetryCount = 0
+    await new Promise(r => setTimeout(r, 0))
+
+    expect(uiIndicator.getAttribute('aria-label')).toContain('Disconnected')
+  })
+})

--- a/frontend/src/components/layout/__tests__/ProjectPill.test.js
+++ b/frontend/src/components/layout/__tests__/ProjectPill.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { screen } from '@testing-library/vue'
+import { renderWithStores } from '@/test-utils/render'
+import ProjectPill from '@/components/layout/ProjectPill.vue'
+import { makeProject, makeSession } from '@/test-utils/factories'
+
+const apiMock = vi.hoisted(() => ({
+  get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn(), patch: vi.fn()
+}))
+vi.mock('@/utils/api', () => ({ api: apiMock, getAuthToken: vi.fn() }))
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+})
+
+describe('ProjectPill', () => {
+  it('renders project name and session count', async () => {
+    const project = makeProject({ project_id: 'p1', name: 'My Project', session_ids: ['sess-1'] })
+    const session = makeSession({ session_id: 'sess-1', state: 'active' })
+
+    const { pinia } = renderWithStores(ProjectPill, {
+      props: { project, isActive: false, isBrowsing: false }
+    })
+
+    const { useSessionStore } = await import('@/stores/session')
+    const { useProjectStore } = await import('@/stores/project')
+    const sessionStore = useSessionStore(pinia)
+    const projectStore = useProjectStore(pinia)
+    sessionStore.sessions.set('sess-1', session)
+    projectStore.projects.set('p1', project)
+
+    expect(screen.getByText('My Project')).toBeTruthy()
+    // Session count displayed
+    expect(screen.getByText('1')).toBeTruthy()
+  })
+})

--- a/frontend/src/components/messages/UserMessage.vue
+++ b/frontend/src/components/messages/UserMessage.vue
@@ -230,16 +230,6 @@ const toolResults = computed(() => {
   return props.message.metadata?.tool_results || []
 })
 
-const copyFeedback = ref(false)
-let copyTimer = null
-
-async function copyMarkdown() {
-  await navigator.clipboard.writeText(cleanContent.value)
-  copyFeedback.value = true
-  clearTimeout(copyTimer)
-  copyTimer = setTimeout(() => { copyFeedback.value = false }, 2000)
-}
-
 function truncate(text, maxLength) {
   if (!text) return ''
   if (text.length <= maxLength) return text

--- a/frontend/src/components/messages/__tests__/InputArea.test.js
+++ b/frontend/src/components/messages/__tests__/InputArea.test.js
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { nextTick } from 'vue'
+import { setActivePinia, createPinia } from 'pinia'
+import { screen, fireEvent } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { renderWithStores } from '@/test-utils/render'
+import InputArea from '@/components/messages/InputArea.vue'
+
+const apiMock = vi.hoisted(() => ({
+  get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn(), patch: vi.fn()
+}))
+vi.mock('@/utils/api', () => ({
+  api: apiMock,
+  getAuthToken: vi.fn().mockReturnValue(null),
+  setAuthToken: vi.fn()
+}))
+vi.mock('@/composables/useNotifications', () => ({ notify: vi.fn() }))
+vi.mock('@/composables/useSessionState', () => ({
+  useSessionState: () => ({
+    isStarting: { value: false },
+    isPaused: { value: false },
+    isActive: { value: true },
+    isError: { value: false }
+  })
+}))
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  Object.values(apiMock).forEach(fn => fn.mockReset())
+})
+
+describe('InputArea', () => {
+  it('typing updates currentInput in session store', async () => {
+    const { pinia } = renderWithStores(InputArea, {
+      stubs: {
+        AttachmentList: true,
+        SlashCommandDropdown: true
+      }
+    })
+
+    const { useSessionStore } = await import('@/stores/session')
+    const { usePollingStore } = await import('@/stores/polling')
+    const sessionStore = useSessionStore(pinia)
+    const pollingStore = usePollingStore(pinia)
+    sessionStore.currentSessionId = 'sess-1'
+    pollingStore.sessionConnected = true
+    await nextTick()
+
+    const textarea = screen.getByRole('textbox')
+    fireEvent.input(textarea, { target: { value: 'hello' } })
+    await nextTick()
+
+    expect(sessionStore.currentInput).toBe('hello')
+  })
+
+  it('Send button is disabled when input is empty', async () => {
+    const { pinia } = renderWithStores(InputArea, {
+      stubs: {
+        AttachmentList: true,
+        SlashCommandDropdown: true
+      }
+    })
+
+    const { useSessionStore } = await import('@/stores/session')
+    const { usePollingStore } = await import('@/stores/polling')
+    const sessionStore = useSessionStore(pinia)
+    const pollingStore = usePollingStore(pinia)
+    sessionStore.currentSessionId = 'sess-1'
+    sessionStore.currentInput = ''
+    pollingStore.sessionConnected = true
+
+    const btn = screen.getByRole('button', { name: /send/i })
+    expect(btn).toBeDisabled()
+  })
+
+  it('slash command dropdown opens when typing /', async () => {
+    const { pinia } = renderWithStores(InputArea, {
+      stubs: {
+        AttachmentList: true,
+        SlashCommandDropdown: { template: '<div role="listbox" aria-label="slash commands" />', props: ['commands', 'filter', 'selectedIndex'] }
+      }
+    })
+
+    const { useSessionStore } = await import('@/stores/session')
+    const { usePollingStore } = await import('@/stores/polling')
+    const sessionStore = useSessionStore(pinia)
+    const pollingStore = usePollingStore(pinia)
+    sessionStore.currentSessionId = 'sess-1'
+    pollingStore.sessionConnected = true
+    sessionStore.initData.set('sess-1', { slash_commands: ['memory', 'clear'] })
+    // Directly set input to trigger watcher in InputArea
+    sessionStore.currentInput = '/me'
+    await nextTick()
+
+    expect(screen.getByRole('listbox')).toBeTruthy()
+  })
+})

--- a/frontend/src/components/messages/__tests__/MessageItem.test.js
+++ b/frontend/src/components/messages/__tests__/MessageItem.test.js
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { screen } from '@testing-library/vue'
+import { renderWithStores } from '@/test-utils/render'
+import { makeMessage } from '@/test-utils/factories'
+import MessageItem from '@/components/messages/MessageItem.vue'
+
+const apiMock = vi.hoisted(() => ({
+  get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn(), patch: vi.fn()
+}))
+vi.mock('@/utils/api', () => ({ api: apiMock, getAuthToken: vi.fn() }))
+vi.mock('@/composables/useNotifications', () => ({ notify: vi.fn() }))
+vi.mock('@/composables/useMarkdown', () => ({
+  useMarkdown: () => ({ renderMarkdown: (t) => t })
+}))
+vi.mock('@/composables/useMermaid', () => ({
+  useMermaid: () => ({ renderMermaid: vi.fn() })
+}))
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+})
+
+describe('MessageItem', () => {
+  it('renders user message content', async () => {
+    renderWithStores(MessageItem, {
+      props: {
+        message: makeMessage({ type: 'user', content: 'Hello from user' }),
+        attachedTools: []
+      },
+      stubs: {
+        UserMessage: { template: '<div>{{ message.content }}</div>', props: ['message'] },
+        AssistantMessage: true,
+        SystemMessage: true,
+        ActivityTimeline: true
+      }
+    })
+
+    expect(screen.getByText('Hello from user')).toBeTruthy()
+  })
+
+  it('renders assistant message content', async () => {
+    renderWithStores(MessageItem, {
+      props: {
+        message: makeMessage({ type: 'assistant', content: 'Hello from assistant' }),
+        attachedTools: []
+      },
+      stubs: {
+        UserMessage: true,
+        AssistantMessage: { template: '<div>{{ message.content }}</div>', props: ['message', 'attachedTools'] },
+        SystemMessage: true,
+        ActivityTimeline: true
+      }
+    })
+
+    expect(screen.getByText('Hello from assistant')).toBeTruthy()
+  })
+})

--- a/frontend/src/components/messages/__tests__/MessageList.test.js
+++ b/frontend/src/components/messages/__tests__/MessageList.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { render, screen } from '@testing-library/vue'
+import { createPinia as _createPinia } from 'pinia'
+import { renderWithStores } from '@/test-utils/render'
+import { makeMessage } from '@/test-utils/factories'
+import MessageList from '@/components/messages/MessageList.vue'
+
+const apiMock = vi.hoisted(() => ({
+  get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn(), patch: vi.fn()
+}))
+vi.mock('@/utils/api', () => ({ api: apiMock, getAuthToken: vi.fn() }))
+vi.mock('@/composables/useNotifications', () => ({ notify: vi.fn() }))
+vi.mock('@/composables/useTTSReadAloud', () => ({
+  useTTSReadAloud: () => ({
+    isEnabled: { value: false },
+    isPlaying: { value: false },
+    speak: vi.fn(),
+    stop: vi.fn()
+  })
+}))
+vi.mock('@/composables/useMermaid', () => ({
+  useMermaid: () => ({ renderMermaid: vi.fn() })
+}))
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  apiMock.get.mockResolvedValue({ messages: [], total_count: 0, has_more: false })
+})
+
+describe('MessageList', () => {
+  it('renders messages from the message store', async () => {
+    const { pinia } = renderWithStores(MessageList, {
+      stubs: {
+        MessageItem: { template: '<div role="article" data-testid="msg-item">{{ message.content }}</div>', props: ['message', 'attachedTools'] },
+        TruncationBanner: true,
+        SubagentTimeline: true
+      }
+    })
+
+    const { useSessionStore } = await import('@/stores/session')
+    const { useMessageStore } = await import('@/stores/message')
+    const sessionStore = useSessionStore(pinia)
+    const messageStore = useMessageStore(pinia)
+
+    sessionStore.currentSessionId = 'sess-1'
+    messageStore.messagesBySession.set('sess-1', [
+      makeMessage({ content: 'First message' }),
+      makeMessage({ content: 'Second message' })
+    ])
+    messageStore.messagesBySession = new Map(messageStore.messagesBySession)
+
+    await new Promise(r => setTimeout(r, 50))
+
+    const items = screen.getAllByRole('article')
+    expect(items.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('shows empty state when no session is selected', async () => {
+    const { pinia } = renderWithStores(MessageList, {
+      stubs: {
+        MessageItem: true,
+        TruncationBanner: true,
+        SubagentTimeline: true
+      }
+    })
+
+    const { useSessionStore } = await import('@/stores/session')
+    const sessionStore = useSessionStore(pinia)
+    sessionStore.currentSessionId = null
+
+    await new Promise(r => setTimeout(r, 10))
+
+    // No article elements when no session
+    expect(screen.queryAllByRole('article').length).toBe(0)
+  })
+})

--- a/frontend/src/components/messages/tools/__tests__/ActivityTimeline.test.js
+++ b/frontend/src/components/messages/tools/__tests__/ActivityTimeline.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { screen } from '@testing-library/vue'
+import { renderWithStores } from '@/test-utils/render'
+import ActivityTimeline from '@/components/messages/tools/ActivityTimeline.vue'
+
+const apiMock = vi.hoisted(() => ({
+  get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn(), patch: vi.fn()
+}))
+vi.mock('@/utils/api', () => ({ api: apiMock, getAuthToken: vi.fn() }))
+vi.mock('@/composables/useNotifications', () => ({ notify: vi.fn() }))
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+})
+
+describe('ActivityTimeline', () => {
+  it('renders one TimelineNode per tool call', async () => {
+    const tools = [
+      { id: 'use-1', name: 'Bash', input: { command: 'ls' }, status: 'completed', isExpanded: false },
+      { id: 'use-2', name: 'Read', input: { file_path: '/tmp/f' }, status: 'completed', isExpanded: false }
+    ]
+
+    renderWithStores(ActivityTimeline, {
+      props: { tools },
+      stubs: {
+        TimelineNode: { template: '<div data-testid="timeline-node" />', props: ['tool', 'isExpanded', 'compact'] },
+        TimelineDetail: true,
+        TimelineSegment: true,
+        TimelineOverflow: true,
+        PermissionPrompt: true
+      }
+    })
+
+    await new Promise(r => setTimeout(r, 0))
+
+    const nodes = screen.getAllByTestId('timeline-node')
+    expect(nodes.length).toBe(2)
+  })
+})

--- a/frontend/src/components/messages/tools/__tests__/PermissionPrompt.test.js
+++ b/frontend/src/components/messages/tools/__tests__/PermissionPrompt.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { renderWithStores } from '@/test-utils/render'
+import PermissionPrompt from '@/components/messages/tools/PermissionPrompt.vue'
+
+const apiMock = vi.hoisted(() => ({
+  get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn(), patch: vi.fn()
+}))
+vi.mock('@/utils/api', () => ({ api: apiMock, getAuthToken: vi.fn() }))
+vi.mock('@/composables/useNotifications', () => ({ notify: vi.fn() }))
+vi.mock('@/components/tools/AskUserQuestionToolHandler.vue', () => ({
+  default: { template: '<div />', props: ['toolCall', 'disabled'] }
+}))
+
+const makePendingTool = (overrides = {}) => ({
+  id: 'use-1',
+  name: 'Edit',
+  input: { path: '/tmp/f' },
+  status: 'permission_required',
+  backendStatus: 'awaiting_permission',
+  permissionRequestId: 'req-1',
+  suggestions: [],
+  isExpanded: true,
+  ...overrides
+})
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  Object.values(apiMock).forEach(fn => fn.mockReset())
+  apiMock.post.mockResolvedValue({})
+})
+
+describe('PermissionPrompt', () => {
+  it('renders Approve and Deny buttons for a permission_required tool', async () => {
+    const { pinia } = renderWithStores(PermissionPrompt, {
+      props: { toolCall: makePendingTool() }
+    })
+
+    const { useSessionStore } = await import('@/stores/session')
+    const sessionStore = useSessionStore(pinia)
+    sessionStore.currentSessionId = 'sess-1'
+
+    await new Promise(r => setTimeout(r, 0))
+
+    expect(screen.getByRole('button', { name: /approve/i })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /deny/i })).toBeTruthy()
+  })
+
+  it('clicking Approve calls sendPermissionResponse with allow decision', async () => {
+    const user = userEvent.setup()
+    const { pinia } = renderWithStores(PermissionPrompt, {
+      props: { toolCall: makePendingTool() }
+    })
+
+    const { useSessionStore } = await import('@/stores/session')
+    const sessionStore = useSessionStore(pinia)
+    sessionStore.currentSessionId = 'sess-1'
+
+    await new Promise(r => setTimeout(r, 0))
+
+    const approveBtn = screen.getByRole('button', { name: /^approve$/i })
+    await user.click(approveBtn)
+
+    expect(apiMock.post).toHaveBeenCalledWith(
+      expect.stringContaining('/permission/req-1'),
+      expect.objectContaining({ decision: 'allow' })
+    )
+  })
+})

--- a/frontend/src/components/tools/__tests__/BashToolHandler.test.js
+++ b/frontend/src/components/tools/__tests__/BashToolHandler.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { screen } from '@testing-library/vue'
+import { renderWithStores } from '@/test-utils/render'
+import BashToolHandler from '@/components/tools/BashToolHandler.vue'
+
+const apiMock = vi.hoisted(() => ({
+  get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn(), patch: vi.fn()
+}))
+vi.mock('@/utils/api', () => ({ api: apiMock, getAuthToken: vi.fn() }))
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+})
+
+describe('BashToolHandler', () => {
+  it('renders command text and output content', () => {
+    const toolCall = {
+      id: 'use-1',
+      name: 'Bash',
+      input: { command: 'ls -la' },
+      status: 'completed',
+      result: { error: false, content: 'file.txt\ndir/' },
+      isExpanded: true
+    }
+
+    renderWithStores(BashToolHandler, { props: { toolCall } })
+
+    expect(screen.getByText('ls -la')).toBeTruthy()
+    expect(screen.getByText(/file\.txt/)).toBeTruthy()
+  })
+})

--- a/frontend/src/stores/__tests__/legion.test.js
+++ b/frontend/src/stores/__tests__/legion.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { makeComm, makeMinion } from '@/test-utils/factories'
+
+const apiMock = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  delete: vi.fn(),
+  patch: vi.fn()
+}))
+vi.mock('@/utils/api', () => ({ api: apiMock, getAuthToken: vi.fn() }))
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  Object.values(apiMock).forEach(fn => fn.mockReset())
+})
+
+describe('legion store', () => {
+  it('sendComm posts to backend and returns comm', async () => {
+    const { useLegionStore } = await import('@/stores/legion')
+    const store = useLegionStore()
+
+    const comm = makeComm({ comm_id: 'c-1' })
+    apiMock.post.mockResolvedValue({ comm })
+
+    const result = await store.sendComm('leg-1', { summary: 'test', content: 'hello' })
+
+    expect(apiMock.post).toHaveBeenCalledWith('/api/legions/leg-1/comms', expect.any(Object))
+    expect(result.comm_id).toBe('c-1')
+  })
+
+  it('createMinion posts to backend and returns minion', async () => {
+    const { useLegionStore } = await import('@/stores/legion')
+    const store = useLegionStore()
+
+    const minion = makeMinion({ minion_id: 'm-1' })
+    apiMock.post.mockResolvedValue({ minion })
+
+    const result = await store.createMinion('leg-1', { name: 'Worker', role: 'worker' })
+
+    expect(apiMock.post).toHaveBeenCalledWith('/api/legions/leg-1/minions', expect.any(Object))
+    expect(result.minion_id).toBe('m-1')
+  })
+
+  it('haltAll posts to halt-all endpoint', async () => {
+    const { useLegionStore } = await import('@/stores/legion')
+    const store = useLegionStore()
+
+    apiMock.post.mockResolvedValue({ halted_count: 2, total_minions: 2, failed_minions: [] })
+
+    const result = await store.haltAll('leg-1')
+
+    expect(apiMock.post).toHaveBeenCalledWith('/api/legions/leg-1/halt-all')
+    expect(result.halted_count).toBe(2)
+  })
+})

--- a/frontend/src/stores/__tests__/message.test.js
+++ b/frontend/src/stores/__tests__/message.test.js
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { makeMessage, makeToolCall } from '@/test-utils/factories'
+
+const apiMock = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  delete: vi.fn(),
+  patch: vi.fn()
+}))
+vi.mock('@/utils/api', () => ({ api: apiMock, getAuthToken: vi.fn() }))
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  Object.values(apiMock).forEach(fn => fn.mockReset())
+})
+
+describe('message store', () => {
+  it('addMessage appends to session bucket', async () => {
+    const { useMessageStore } = await import('@/stores/message')
+    const store = useMessageStore()
+
+    store.addMessage('sess-1', makeMessage({ content: 'hi' }))
+
+    expect(store.messagesBySession.get('sess-1').length).toBe(1)
+    expect(store.messagesBySession.get('sess-1')[0].content).toBe('hi')
+  })
+
+  it('loadMessages stores messages from paged API response', async () => {
+    const { useMessageStore } = await import('@/stores/message')
+    const store = useMessageStore()
+
+    const messages = [makeMessage({ content: 'msg1' }), makeMessage({ content: 'msg2' })]
+    apiMock.get.mockResolvedValue({
+      messages,
+      total_count: 2,
+      has_more: false,
+      event_cursor: 10
+    })
+
+    const result = await store.loadMessages('sess-1')
+
+    expect(apiMock.get).toHaveBeenCalledWith(expect.stringContaining('/api/sessions/sess-1/messages'))
+    expect(store.messagesBySession.get('sess-1').length).toBe(2)
+    expect(result.totalCount).toBe(2)
+  })
+
+  it('handleToolCall creates new entry then updates on second call', async () => {
+    const { useMessageStore } = await import('@/stores/message')
+    const store = useMessageStore()
+
+    store.handleToolCall('sess-1', {
+      tool_use_id: 'use-1',
+      name: 'Bash',
+      input: { command: 'ls' },
+      status: 'running'
+    })
+
+    let calls = store.toolCallsBySession.get('sess-1')
+    expect(calls.length).toBe(1)
+    expect(calls[0].status).toBe('executing')
+
+    store.handleToolCall('sess-1', {
+      tool_use_id: 'use-1',
+      name: 'Bash',
+      input: { command: 'ls' },
+      status: 'completed',
+      result: 'file.txt'
+    })
+
+    calls = store.toolCallsBySession.get('sess-1')
+    expect(calls.length).toBe(1)
+    expect(calls[0].status).toBe('completed')
+    expect(calls[0].result.content).toBe('file.txt')
+  })
+
+  it('handlePermissionRequest maps request to tool then handlePermissionResponse updates status', async () => {
+    const { useMessageStore } = await import('@/stores/message')
+    const { useSessionStore } = await import('@/stores/session')
+    const store = useMessageStore()
+    const sessionStore = useSessionStore()
+    sessionStore.currentSessionId = 'sess-1'
+
+    store.handleToolCall('sess-1', {
+      tool_use_id: 'use-1',
+      name: 'Edit',
+      input: { path: '/tmp/f' },
+      status: 'awaiting_permission',
+      request_id: 'req-1'
+    })
+
+    expect(store.toolCallsBySession.get('sess-1')[0].status).toBe('permission_required')
+
+    store.handlePermissionResponse('sess-1', {
+      request_id: 'req-1',
+      decision: 'allow'
+    })
+
+    const tc = store.toolCallsBySession.get('sess-1')[0]
+    expect(tc.permissionDecision).toBe('allow')
+    expect(tc.status).toBe('executing')
+  })
+
+  it('markToolUseOrphaned marks tool as orphaned', async () => {
+    const { useMessageStore } = await import('@/stores/message')
+    const store = useMessageStore()
+
+    store.handleToolCall('sess-1', {
+      tool_use_id: 'use-1',
+      name: 'Bash',
+      input: { command: 'ls' },
+      status: 'running'
+    })
+
+    store.markToolUseOrphaned('sess-1', 'use-1', 'Session was restarted')
+
+    const tc = store.toolCallsBySession.get('sess-1')[0]
+    expect(tc._isOrphaned).toBe(true)
+    expect(store.isToolUseOrphaned('sess-1', 'use-1')).toBe(true)
+  })
+})

--- a/frontend/src/stores/__tests__/polling.test.js
+++ b/frontend/src/stores/__tests__/polling.test.js
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const apiMock = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  delete: vi.fn(),
+  patch: vi.fn()
+}))
+vi.mock('@/utils/api', () => ({
+  api: apiMock,
+  getAuthToken: vi.fn().mockReturnValue(null)
+}))
+vi.mock('@/composables/useNotifications', () => ({ notify: vi.fn() }))
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  Object.values(apiMock).forEach(fn => fn.mockReset())
+})
+
+describe('polling store', () => {
+  it('sendMessage POSTs to correct sessions endpoint', async () => {
+    const { usePollingStore } = await import('@/stores/polling')
+    const { useSessionStore } = await import('@/stores/session')
+    const pollingStore = usePollingStore()
+    const sessionStore = useSessionStore()
+
+    sessionStore.currentSessionId = 'sess-1'
+    apiMock.post.mockResolvedValue({})
+
+    await pollingStore.sendMessage('hello world')
+
+    expect(apiMock.post).toHaveBeenCalledWith(
+      '/api/sessions/sess-1/messages',
+      expect.objectContaining({ message: 'hello world' })
+    )
+  })
+
+  it('interruptSession POSTs to interrupt endpoint', async () => {
+    const { usePollingStore } = await import('@/stores/polling')
+    const { useSessionStore } = await import('@/stores/session')
+    const pollingStore = usePollingStore()
+    const sessionStore = useSessionStore()
+
+    sessionStore.currentSessionId = 'sess-1'
+    apiMock.post.mockResolvedValue({})
+
+    await pollingStore.interruptSession()
+
+    expect(apiMock.post).toHaveBeenCalledWith('/api/sessions/sess-1/interrupt', {})
+  })
+
+  it('sendPermissionResponse POSTs with correct payload', async () => {
+    const { usePollingStore } = await import('@/stores/polling')
+    const { useSessionStore } = await import('@/stores/session')
+    const pollingStore = usePollingStore()
+    const sessionStore = useSessionStore()
+
+    sessionStore.currentSessionId = 'sess-1'
+    apiMock.post.mockResolvedValue({})
+
+    await pollingStore.sendPermissionResponse('req-1', 'allow', false)
+
+    expect(apiMock.post).toHaveBeenCalledWith(
+      '/api/sessions/sess-1/permission/req-1',
+      expect.objectContaining({ decision: 'allow' })
+    )
+  })
+
+  it('stopUIPolling sets uiConnected to false', async () => {
+    const { usePollingStore } = await import('@/stores/polling')
+    const pollingStore = usePollingStore()
+
+    pollingStore.uiConnected = true
+    pollingStore.stopUIPolling()
+
+    expect(pollingStore.uiConnected).toBe(false)
+  })
+})

--- a/frontend/src/stores/__tests__/project.test.js
+++ b/frontend/src/stores/__tests__/project.test.js
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { makeProject, makeSession } from '@/test-utils/factories'
+
+const apiMock = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  delete: vi.fn(),
+  patch: vi.fn()
+}))
+vi.mock('@/utils/api', () => ({ api: apiMock, getAuthToken: vi.fn() }))
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  Object.values(apiMock).forEach(fn => fn.mockReset())
+})
+
+describe('project store', () => {
+  it('fetchProjects populates map and orderedProjects sorts by order', async () => {
+    const { useProjectStore } = await import('@/stores/project')
+    const store = useProjectStore()
+
+    const p1 = makeProject({ project_id: 'p1', order: 1 })
+    const p2 = makeProject({ project_id: 'p2', order: 0 })
+    apiMock.get.mockResolvedValue({ projects: [p1, p2] })
+
+    await store.fetchProjects()
+
+    expect(store.projects.size).toBe(2)
+    expect(store.orderedProjects[0].project_id).toBe('p2')
+    expect(store.orderedProjects[1].project_id).toBe('p1')
+  })
+
+  it('createProject adds new project to map', async () => {
+    const { useProjectStore } = await import('@/stores/project')
+    const store = useProjectStore()
+
+    const project = makeProject({ project_id: 'p-new' })
+    apiMock.post.mockResolvedValue({ project })
+
+    const result = await store.createProject('My Project', '/tmp')
+
+    expect(apiMock.post).toHaveBeenCalledWith('/api/projects', expect.objectContaining({ name: 'My Project' }))
+    expect(store.projects.has('p-new')).toBe(true)
+    expect(result.project_id).toBe('p-new')
+  })
+
+  it('reorderProjects updates order fields', async () => {
+    const { useProjectStore } = await import('@/stores/project')
+    const store = useProjectStore()
+
+    store.projects.set('p1', makeProject({ project_id: 'p1', order: 0 }))
+    store.projects.set('p2', makeProject({ project_id: 'p2', order: 1 }))
+    apiMock.put.mockResolvedValue({})
+
+    await store.reorderProjects(['p2', 'p1'])
+
+    expect(store.projects.get('p2').order).toBe(0)
+    expect(store.projects.get('p1').order).toBe(1)
+  })
+
+  it('getStatusBarSegments returns segment per session', async () => {
+    const { useProjectStore } = await import('@/stores/project')
+    const { useSessionStore } = await import('@/stores/session')
+    const store = useProjectStore()
+    const sessionStore = useSessionStore()
+
+    const session = makeSession({ session_id: 'sess-1', state: 'active', is_processing: false })
+    sessionStore.sessions.set('sess-1', session)
+
+    const project = makeProject({ project_id: 'p1', session_ids: ['sess-1'] })
+    store.projects.set('p1', project)
+
+    const segments = store.getStatusBarSegments('p1', sessionStore)
+
+    expect(segments.length).toBe(1)
+    expect(segments[0].status).toBe('idle')
+  })
+})

--- a/frontend/src/stores/__tests__/session.test.js
+++ b/frontend/src/stores/__tests__/session.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { makeSession } from '@/test-utils/factories'
+
+const apiMock = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  delete: vi.fn(),
+  patch: vi.fn()
+}))
+vi.mock('@/utils/api', () => ({ api: apiMock, getAuthToken: vi.fn() }))
+vi.mock('@/composables/useNotifications', () => ({ notify: vi.fn() }))
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  Object.values(apiMock).forEach(fn => fn.mockReset())
+})
+
+describe('session store', () => {
+  it('fetchSessions merges into existing Map without losing references', async () => {
+    const { useSessionStore } = await import('@/stores/session')
+    const store = useSessionStore()
+
+    const existing = makeSession({ session_id: 'sess-1', name: 'Old Name' })
+    store.sessions.set('sess-1', existing)
+
+    const updated = makeSession({ session_id: 'sess-1', name: 'New Name' })
+    const fresh = makeSession({ session_id: 'sess-2', name: 'Fresh' })
+    apiMock.get.mockResolvedValue({ sessions: [updated, fresh] })
+
+    await store.fetchSessions()
+
+    expect(store.sessions.size).toBe(2)
+    // Object.assign semantics: name merged from updated session
+    expect(store.sessions.get('sess-1').name).toBe('New Name')
+    // Session that was not in the return set is removed
+    expect(store.sessions.has('sess-2')).toBe(true)
+  })
+
+  it('createSession posts and adds session to map', async () => {
+    const { useSessionStore } = await import('@/stores/session')
+    const store = useSessionStore()
+
+    apiMock.post.mockResolvedValue({ session_id: 'sess-2' })
+    apiMock.get.mockResolvedValue({ session: makeSession({ session_id: 'sess-2' }) })
+
+    const session = await store.createSession('proj-1', { name: 'New' })
+
+    expect(apiMock.post).toHaveBeenCalledWith('/api/sessions', expect.objectContaining({ project_id: 'proj-1' }))
+    expect(store.sessions.has('sess-2')).toBe(true)
+    expect(session.session_id).toBe('sess-2')
+  })
+
+  it('selectSession early-returns when already current and not selecting', async () => {
+    const { useSessionStore } = await import('@/stores/session')
+    const store = useSessionStore()
+    store.currentSessionId = 'sess-1'
+
+    await store.selectSession('sess-1')
+
+    expect(apiMock.get).not.toHaveBeenCalled()
+  })
+
+  it('deleteSession removes all cascaded IDs and clears currentSessionId', async () => {
+    const { useSessionStore } = await import('@/stores/session')
+    const store = useSessionStore()
+
+    store.sessions.set('sess-1', makeSession({ session_id: 'sess-1' }))
+    store.sessions.set('sess-2', makeSession({ session_id: 'sess-2' }))
+    store.currentSessionId = 'sess-1'
+
+    apiMock.delete.mockResolvedValue({ deleted_session_ids: ['sess-1', 'sess-2'] })
+
+    await store.deleteSession('sess-1')
+
+    expect(store.sessions.has('sess-1')).toBe(false)
+    expect(store.sessions.has('sess-2')).toBe(false)
+    expect(store.currentSessionId).toBeNull()
+  })
+
+  it('currentInput getter/setter caches per session', async () => {
+    const { useSessionStore } = await import('@/stores/session')
+    const store = useSessionStore()
+
+    store.currentSessionId = 'sess-1'
+    store.currentInput = 'hello'
+
+    store.currentSessionId = 'sess-2'
+    expect(store.currentInput).toBe('')
+
+    store.currentSessionId = 'sess-1'
+    expect(store.currentInput).toBe('hello')
+  })
+})

--- a/frontend/src/stores/__tests__/ui.test.js
+++ b/frontend/src/stores/__tests__/ui.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+})
+
+describe('ui store', () => {
+  it('toggleRightSidebar flips rightSidebarCollapsed and persists to localStorage', async () => {
+    const { useUIStore } = await import('@/stores/ui')
+    const store = useUIStore()
+
+    const initial = store.rightSidebarCollapsed
+    store.toggleRightSidebar()
+
+    expect(store.rightSidebarCollapsed).toBe(!initial)
+    expect(localStorage.getItem('webui-sidebar-rightCollapsed')).toBe(JSON.stringify(!initial))
+  })
+
+  it('showModal sets activeModal after setTimeout; hideModal clears it', async () => {
+    vi.useFakeTimers()
+    const { useUIStore } = await import('@/stores/ui')
+    const store = useUIStore()
+
+    store.showModal('create-project', { foo: 1 })
+
+    // Before timeout fires, modal is cleared
+    expect(store.activeModal).toBeNull()
+
+    vi.advanceTimersByTime(0)
+
+    expect(store.activeModal).toBe('create-project')
+    expect(store.modalData).toEqual({ foo: 1 })
+
+    store.hideModal()
+
+    expect(store.activeModal).toBeNull()
+    expect(store.modalData).toBeNull()
+  })
+
+  it('handleResize updates windowWidth and isMobile computed', async () => {
+    const { useUIStore } = await import('@/stores/ui')
+    const store = useUIStore()
+
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 500 })
+    store.handleResize()
+    expect(store.isMobile).toBe(true)
+
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1200 })
+    store.handleResize()
+    expect(store.isMobile).toBe(false)
+  })
+})

--- a/frontend/src/test-utils/factories.js
+++ b/frontend/src/test-utils/factories.js
@@ -1,0 +1,75 @@
+export function makeSession(overrides = {}) {
+  return {
+    session_id: 'sess-1',
+    project_id: 'proj-1',
+    name: 'Test Session',
+    state: 'active',
+    is_processing: false,
+    current_permission_mode: 'default',
+    working_directory: '/tmp',
+    order: 0,
+    child_minion_ids: [],
+    is_minion: false,
+    ...overrides
+  }
+}
+
+export function makeProject(overrides = {}) {
+  return {
+    project_id: 'proj-1',
+    name: 'Test Project',
+    working_directory: '/tmp',
+    session_ids: [],
+    is_expanded: true,
+    is_multi_agent: false,
+    order: 0,
+    ...overrides
+  }
+}
+
+export function makeMessage(overrides = {}) {
+  return {
+    type: 'assistant',
+    content: 'hello',
+    timestamp: 1700000000,
+    session_id: 'sess-1',
+    ...overrides
+  }
+}
+
+export function makeToolCall(overrides = {}) {
+  return {
+    id: 'tool-1',
+    tool_use_id: 'use-1',
+    name: 'Bash',
+    input: { command: 'ls' },
+    status: 'pending',
+    session_id: 'sess-1',
+    ...overrides
+  }
+}
+
+export function makeMinion(overrides = {}) {
+  return {
+    minion_id: 'min-1',
+    name: 'Minion-1',
+    legion_id: 'leg-1',
+    role: 'worker',
+    capabilities: [],
+    ...overrides
+  }
+}
+
+export function makeComm(overrides = {}) {
+  return {
+    comm_id: 'comm-1',
+    legion_id: 'leg-1',
+    from_minion_id: 'min-1',
+    to_minion_id: 'min-2',
+    summary: 'test',
+    content: 'test content',
+    comm_type: 'info',
+    timestamp: 1700000000,
+    ...overrides
+  }
+}

--- a/frontend/src/test-utils/render.js
+++ b/frontend/src/test-utils/render.js
@@ -1,0 +1,55 @@
+import { mount } from '@vue/test-utils'
+import { getQueriesForElement } from '@testing-library/dom'
+import { createPinia } from 'pinia'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import { afterEach } from 'vitest'
+
+const noopComponent = { template: '<div />' }
+const _mounted = []
+
+// Cleanup after each test without calling @testing-library/vue's cleanup
+// (which has a bug with VTU's attachTo onUnmount callback)
+afterEach(() => {
+  while (_mounted.length) {
+    const { wrapper, container } = _mounted.pop()
+    try { wrapper.unmount() } catch (_) { /* ignore */ }
+    if (container.parentNode) container.parentNode.removeChild(container)
+  }
+})
+
+export function renderWithStores(component, { props, slots, routes, initialRoute = '/', stubs } = {}) {
+  const pinia = createPinia()
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: routes ?? [
+      { path: '/', component: noopComponent },
+      { path: '/session/:sessionId', component: noopComponent },
+      { path: '/project/:projectId', component: noopComponent }
+    ]
+  })
+  router.push(initialRoute)
+
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+
+  const wrapper = mount(component, {
+    attachTo: container,
+    global: {
+      plugins: [pinia, router],
+      stubs: stubs ?? {}
+    },
+    props,
+    slots
+  })
+
+  _mounted.push({ wrapper, container })
+
+  return {
+    pinia,
+    router,
+    container,
+    wrapper,
+    emitted: name => wrapper.emitted(name),
+    ...getQueriesForElement(document.body)
+  }
+}

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -1,0 +1,26 @@
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.js'],
+    include: ['src/**/__tests__/**/*.test.js'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      include: ['src/stores/**', 'src/components/**', 'src/utils/**'],
+      exclude: ['src/**/__tests__/**', 'src/test-utils/**']
+    },
+    testTimeout: 5000,
+    hookTimeout: 5000
+  },
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url))
+    }
+  }
+})

--- a/frontend/vitest.setup.js
+++ b/frontend/vitest.setup.js
@@ -1,0 +1,15 @@
+import '@testing-library/jest-dom/vitest'
+import { afterEach, beforeEach, vi } from 'vitest'
+
+beforeEach(() => {
+  localStorage.clear()
+  sessionStorage.clear()
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+})


### PR DESCRIPTION
## Summary
Resolves #232

Adds a complete Vitest testing infrastructure to the Vue 3 frontend. `npm test` exits 0 with 40 tests passing in under 3 seconds.

## Changes Made

### Infrastructure
- `frontend/vitest.config.js` — standalone Vitest config (jsdom environment, globals, `@/` alias, v8 coverage)
- `frontend/vitest.setup.js` — global setup: clear storage, suppress console noise
- `frontend/src/test-utils/factories.js` — `makeSession`, `makeProject`, `makeMessage`, `makeToolCall`, `makeMinion`, `makeComm` factory helpers
- `frontend/src/test-utils/render.js` — `renderWithStores()` helper: mounts with fresh Pinia + in-memory router via `@vue/test-utils` `mount` directly (bypasses `@testing-library/vue`'s `unwrapNode`/`onUnmount` DOM bug)
- `frontend/TESTING.md` — developer guide for writing and running tests

### Store Tests (24 tests, 6 files)
Covers all 6 Pinia stores: `session`, `project`, `message`, `polling`, `legion`, `ui`

### Component Tests (16 tests, 11 files)
- `common/`: AttachmentChip, AuthPrompt
- `layout/`: AgentChip, ConnectionIndicator, ProjectPill
- `messages/`: InputArea (3 tests), MessageItem (2), MessageList (2)
- `messages/tools/`: ActivityTimeline, PermissionPrompt (2)
- `tools/`: BashToolHandler

### Bug Fix
- `frontend/src/components/messages/UserMessage.vue` — remove duplicate `copyFeedback`/`copyTimer`/`copyMarkdown` declarations that caused `SyntaxError` at import time in the test environment (production bug)

## Testing
- `cd frontend && npm test` — 40 tests, 17 files, all pass, ~2s wall-clock
- No backend changes; no `frontend/dist` rebuild needed (test-only additions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)