### PR TITLE
feat: add Edit History panel — chronological file-modifying tool calls

### DIFF
--- a/frontend/src/components/layout/RightSidebar.vue
+++ b/frontend/src/components/layout/RightSidebar.vue
@@ -33,6 +33,9 @@
       <!-- Diff Tab -->
       <DiffPanel v-show="activeTab === 'diff'" role="tabpanel" aria-label="Diff panel" />
 
+      <!-- Edits Tab -->
+      <EditHistoryPanel v-show="activeTab === 'edits'" role="tabpanel" aria-label="Edit history panel" />
+
       <!-- Tasks Tab -->
       <TaskListPanel v-show="activeTab === 'tasks'" role="tabpanel" aria-label="Tasks panel" />
 
@@ -62,12 +65,14 @@ import { useTaskStore } from '@/stores/task'
 import { useResourceStore } from '@/stores/resource'
 import { useDiffStore } from '@/stores/diff'
 import { useSessionStore } from '@/stores/session'
+import { useEditHistoryStore } from '@/stores/editHistory'
 import AgentOverview from './AgentOverview.vue'
 import TaskListPanel from '../tasks/TaskListPanel.vue'
 import ResourceGallery from '../tasks/ResourceGallery.vue'
 import ResourceFullView from '../common/ResourceFullView.vue'
 import DiffPanel from '../tasks/DiffPanel.vue'
 import DiffFullView from '../common/DiffFullView.vue'
+import EditHistoryPanel from '../tasks/EditHistoryPanel.vue'
 import SchedulePanel from '../schedules/SchedulePanel.vue'
 import ProxyPanel from '../tasks/ProxyPanel.vue'
 import { useScheduleStore } from '@/stores/schedule'
@@ -78,6 +83,7 @@ const taskStore = useTaskStore()
 const resourceStore = useResourceStore()
 const diffStore = useDiffStore()
 const sessionStore = useSessionStore()
+const editHistoryStore = useEditHistoryStore()
 const scheduleStore = useScheduleStore()
 const proxyStore = useProxyStore()
 
@@ -105,11 +111,15 @@ const schedulesHasError = computed(() => {
 
 const proxyEnabled = computed(() => sessionStore.currentSession?.docker_proxy_enabled === true)
 const proxyBadge = computed(() => proxyStore.currentTotalCount)
+const editHistoryCount = computed(() =>
+  editHistoryStore.entryCount(sessionStore.currentSessionId)
+)
 
 // Tab definitions
 const tabs = computed(() => {
   const list = [
     { id: 'diff', label: 'Diff', badge: diffFileCount.value },
+    { id: 'edits', label: 'Edits', badge: editHistoryCount.value },
     { id: 'tasks', label: 'Tasks', badge: taskStats.value.total > 0 ? taskStats.value.total : 0 },
     { id: 'resources', label: 'Resources', badge: resourceCount.value },
     { id: 'schedules', label: 'Sched', badge: schedulesCount.value, badgeError: schedulesHasError.value }

--- a/frontend/src/components/tasks/EditHistoryPanel.vue
+++ b/frontend/src/components/tasks/EditHistoryPanel.vue
@@ -1,0 +1,515 @@
+<template>
+  <div class="edit-history-panel">
+    <!-- Header -->
+    <div class="panel-header">
+      <span class="panel-title">Edit History</span>
+      <div class="header-actions">
+        <label class="bash-toggle" :title="showNonModifyingBash ? 'Hiding non-modifying Bash' : 'Showing only likely-modifying Bash'">
+          <input type="checkbox" v-model="editHistoryStore.showNonModifyingBash" />
+          All Bash
+        </label>
+        <button class="refresh-btn" @click="refresh" :disabled="isLoading" title="Refresh">
+          <span :class="{ spinning: isLoading }">↺</span>
+        </button>
+      </div>
+    </div>
+
+    <!-- Gap warning banner -->
+    <div class="gap-warning">
+      Bash file changes listed by command only — no inline diff.
+      See the <strong>Diff</strong> tab for aggregate git changes.
+    </div>
+
+    <!-- Loading state -->
+    <div v-if="isLoading && !entries.length" class="state-placeholder">
+      <span class="spinner">⟳</span> Loading…
+    </div>
+
+    <!-- Error state -->
+    <div v-else-if="errorMsg" class="state-error">
+      <span>{{ errorMsg }}</span>
+      <button class="retry-btn" @click="refresh">Retry</button>
+    </div>
+
+    <!-- Empty state -->
+    <div v-else-if="!entries.length" class="state-placeholder">
+      No file modifications yet.
+    </div>
+
+    <!-- Entry list -->
+    <div v-else class="entry-list">
+      <div
+        v-for="entry in entries"
+        :key="entry.tool_use_id"
+        class="entry-item"
+        :class="{ expanded: isExpanded(entry.tool_use_id) }"
+      >
+        <!-- Entry header row -->
+        <div class="entry-row" @click="toggle(entry)">
+          <span class="entry-icon">{{ toolIcon(entry.tool_name) }}</span>
+
+          <span class="entry-label text-truncate" :title="entryLabel(entry)">
+            {{ entryLabel(entry) }}
+          </span>
+
+          <span v-if="entry.tool_name === 'Edit'" class="entry-stats">
+            <span class="stat-diff" v-if="isExpanded(entry.tool_use_id)">
+              <span class="stat-removed">-{{ diffFor(entry).removed }}</span>
+              <span class="stat-added">+{{ diffFor(entry).added }}</span>
+            </span>
+          </span>
+          <span v-else-if="entry.tool_name === 'Write'" class="entry-stats write-lines">
+            {{ entry.line_count }} lines
+          </span>
+
+          <span class="entry-ts" :title="fullTs(entry.timestamp)">
+            {{ relativeTs(entry.timestamp) }}
+          </span>
+
+          <span class="entry-status" :title="statusTitle(entry.succeeded)">
+            {{ statusIcon(entry.succeeded) }}
+          </span>
+
+          <span class="expand-arrow">{{ isExpanded(entry.tool_use_id) ? '▲' : '▼' }}</span>
+        </div>
+
+        <!-- Expanded detail -->
+        <div v-if="isExpanded(entry.tool_use_id)" class="entry-detail">
+
+          <!-- Edit: inline diff -->
+          <template v-if="entry.tool_name === 'Edit'">
+            <div class="diff-container">
+              <div
+                v-for="(line, i) in diffFor(entry).lines"
+                :key="i"
+                class="diff-line"
+                :class="{
+                  'diff-line-removed': line.type === 'removed',
+                  'diff-line-added': line.type === 'added',
+                  'diff-line-context': line.type === 'context',
+                  'diff-line-hunk': line.type === 'hunk'
+                }"
+              >
+                <span class="diff-marker">{{
+                  line.type === 'removed' ? '-' :
+                  line.type === 'added' ? '+' :
+                  line.type === 'hunk' ? '@' : ' '
+                }}</span>
+                <span class="diff-content">{{ line.content }}</span>
+              </div>
+            </div>
+          </template>
+
+          <!-- Write: content preview -->
+          <template v-else-if="entry.tool_name === 'Write'">
+            <div class="write-preview">
+              <div class="write-meta">
+                Wrote {{ entry.line_count }} lines to
+                <code>{{ entry.file_path }}</code>
+                <button class="view-full-btn" @click.stop="viewFullWrite(entry)">View Full</button>
+              </div>
+              <pre class="write-content">{{ writePreview(entry) }}</pre>
+            </div>
+          </template>
+
+          <!-- Bash: command block -->
+          <template v-else-if="entry.tool_name === 'Bash'">
+            <div class="bash-detail">
+              <pre class="bash-command">{{ entry.command }}</pre>
+              <div class="bash-note">No inline diff — changed via Bash.</div>
+            </div>
+          </template>
+
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed, watch } from 'vue'
+import { useEditHistoryStore } from '@/stores/editHistory'
+import { useSessionStore } from '@/stores/session'
+import { useResourceStore } from '@/stores/resource'
+import { buildEditDiff } from '@/utils/diffRender'
+import { getRelativeTime, formatFullTimestamp, parseTimestamp } from '@/utils/time'
+
+const editHistoryStore = useEditHistoryStore()
+const sessionStore = useSessionStore()
+const resourceStore = useResourceStore()
+
+const sessionId = computed(() => sessionStore.currentSessionId)
+
+const sessionData = computed(() => editHistoryStore.entriesBySession.get(sessionId.value) || {})
+const isLoading = computed(() => sessionData.value.loading || false)
+const errorMsg = computed(() => sessionData.value.error || null)
+const entries = computed(() => editHistoryStore.visibleEntries(sessionId.value))
+
+function refresh() {
+  if (sessionId.value) editHistoryStore.refreshHistory(sessionId.value)
+}
+
+function isExpanded(toolUseId) {
+  return editHistoryStore.isExpanded(sessionId.value, toolUseId)
+}
+
+function toggle(entry) {
+  if (sessionId.value) editHistoryStore.toggleExpand(sessionId.value, entry.tool_use_id)
+}
+
+// Lazy diff computation per entry (only when expanded)
+const diffCache = new Map()
+function diffFor(entry) {
+  const key = entry.tool_use_id
+  if (!diffCache.has(key)) {
+    const inp = entry.input || {}
+    diffCache.set(key, buildEditDiff(entry.file_path, inp.old_string, inp.new_string))
+  }
+  return diffCache.get(key)
+}
+
+function toolIcon(toolName) {
+  switch (toolName) {
+    case 'Edit': return '✏️'
+    case 'Write': return '📝'
+    case 'Bash': return '⚡'
+    default: return '🔧'
+  }
+}
+
+function entryLabel(entry) {
+  if (entry.tool_name === 'Bash') {
+    const cmd = entry.command || ''
+    return cmd.length > 60 ? cmd.slice(0, 60) + '…' : cmd
+  }
+  const fp = entry.file_path || ''
+  return fp.split('/').pop() || fp
+}
+
+function relativeTs(ts) {
+  if (!ts) return ''
+  return getRelativeTime(parseTimestamp(ts))
+}
+
+function fullTs(ts) {
+  if (!ts) return ''
+  return formatFullTimestamp(parseTimestamp(ts))
+}
+
+function statusIcon(succeeded) {
+  if (succeeded === true) return '✓'
+  if (succeeded === false) return '✗'
+  return '…'
+}
+
+function statusTitle(succeeded) {
+  if (succeeded === true) return 'Succeeded'
+  if (succeeded === false) return 'Failed'
+  return 'Pending'
+}
+
+function writePreview(entry) {
+  const content = (entry.input || {}).content || ''
+  const lines = content.split('\n')
+  const preview = lines.slice(0, 100).join('\n')
+  return lines.length > 100 ? preview + '\n…' : preview
+}
+
+function viewFullWrite(entry) {
+  const fileName = (entry.file_path || 'file').split('/').pop()
+  const content = (entry.input || {}).content || ''
+  resourceStore.openWithDirectContent(`Write: ${fileName}`, content)
+}
+
+// Auto-load when session changes
+watch(
+  sessionId,
+  (newId) => {
+    if (newId && !editHistoryStore.entriesBySession.get(newId)) {
+      editHistoryStore.loadHistory(newId)
+    }
+  },
+  { immediate: true }
+)
+</script>
+
+<style scoped>
+.edit-history-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  font-size: 12px;
+  overflow: hidden;
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 10px;
+  border-bottom: 1px solid #e2e8f0;
+  flex-shrink: 0;
+}
+
+.panel-title {
+  font-weight: 600;
+  color: #334155;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.bash-toggle {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+  color: #64748b;
+  font-size: 11px;
+  user-select: none;
+}
+
+.refresh-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #64748b;
+  font-size: 16px;
+  padding: 0 2px;
+  line-height: 1;
+}
+
+.refresh-btn:hover { color: #334155; }
+.refresh-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+.spinning {
+  display: inline-block;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.gap-warning {
+  background: #fef9c3;
+  border-bottom: 1px solid #fde68a;
+  padding: 5px 10px;
+  font-size: 11px;
+  color: #92400e;
+  flex-shrink: 0;
+}
+
+.state-placeholder,
+.state-error {
+  padding: 24px 16px;
+  text-align: center;
+  color: #94a3b8;
+  font-size: 12px;
+}
+
+.state-error { color: #dc3545; }
+
+.retry-btn {
+  display: block;
+  margin: 8px auto 0;
+  padding: 4px 12px;
+  background: #f1f5f9;
+  border: 1px solid #e2e8f0;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 11px;
+}
+
+.entry-list {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.entry-item {
+  border-bottom: 1px solid #f1f5f9;
+}
+
+.entry-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.entry-row:hover {
+  background: #f8fafc;
+}
+
+.entry-icon {
+  font-size: 13px;
+  flex-shrink: 0;
+}
+
+.entry-label {
+  flex: 1;
+  min-width: 0;
+  font-family: 'Courier New', monospace;
+  font-size: 11px;
+  color: #334155;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.entry-stats {
+  flex-shrink: 0;
+  font-size: 10px;
+  font-family: 'Courier New', monospace;
+}
+
+.stat-removed { color: #dc3545; }
+.stat-added { color: #198754; }
+.stat-diff { display: flex; gap: 4px; }
+
+.write-lines {
+  color: #64748b;
+}
+
+.entry-ts {
+  flex-shrink: 0;
+  color: #94a3b8;
+  font-size: 10px;
+  white-space: nowrap;
+}
+
+.entry-status {
+  flex-shrink: 0;
+  font-size: 11px;
+  width: 14px;
+  text-align: center;
+}
+
+.expand-arrow {
+  flex-shrink: 0;
+  color: #94a3b8;
+  font-size: 9px;
+}
+
+/* Entry detail sections */
+.entry-detail {
+  padding: 0 8px 8px;
+}
+
+/* Diff (Edit) */
+.diff-container {
+  font-family: 'Courier New', monospace;
+  font-size: 11px;
+  border: 1px solid #e2e8f0;
+  border-radius: 4px;
+  overflow: auto;
+  max-height: 240px;
+}
+
+.diff-line {
+  display: flex;
+  white-space: nowrap;
+  line-height: 1.4;
+}
+
+.diff-line-removed { background: #ffebe9; color: #24292f; }
+.diff-line-removed .diff-marker { background: #ffcecb; color: #dc3545; }
+.diff-line-added { background: #dafbe1; color: #24292f; }
+.diff-line-added .diff-marker { background: #abf2bc; color: #198754; }
+.diff-line-context { background: #fff; color: #57606a; }
+.diff-line-context .diff-marker { background: #f6f8fa; color: #57606a; }
+.diff-line-hunk { background: #f6f8fa; color: #0969da; font-weight: 600; }
+.diff-line-hunk .diff-marker { background: #e1e4e8; color: #0969da; }
+
+.diff-marker {
+  width: 1.6rem;
+  flex-shrink: 0;
+  text-align: center;
+  font-weight: 700;
+  user-select: none;
+}
+
+.diff-content {
+  padding: 0 6px;
+  white-space: pre;
+}
+
+/* Write preview */
+.write-preview {
+  border: 1px solid #e2e8f0;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.write-meta {
+  background: #f1f5f9;
+  padding: 4px 8px;
+  font-size: 11px;
+  color: #64748b;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.write-meta code {
+  font-family: 'Courier New', monospace;
+  color: #0d6efd;
+  font-size: 10px;
+}
+
+.view-full-btn {
+  margin-left: auto;
+  padding: 2px 8px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 10px;
+  color: #3b82f6;
+}
+
+.view-full-btn:hover { background: #f0f9ff; }
+
+.write-content {
+  margin: 0;
+  padding: 6px 8px;
+  font-family: 'Courier New', monospace;
+  font-size: 10px;
+  color: #334155;
+  background: #fff;
+  max-height: 200px;
+  overflow: auto;
+  white-space: pre;
+}
+
+/* Bash detail */
+.bash-detail {
+  background: #1e1e2e;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.bash-command {
+  margin: 0;
+  padding: 8px 10px;
+  font-family: 'Courier New', monospace;
+  font-size: 11px;
+  color: #cdd6f4;
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 160px;
+  overflow: auto;
+}
+
+.bash-note {
+  padding: 4px 10px;
+  font-size: 10px;
+  color: #6c7086;
+  border-top: 1px solid #313244;
+}
+</style>

--- a/frontend/src/components/tools/EditToolHandler.vue
+++ b/frontend/src/components/tools/EditToolHandler.vue
@@ -60,7 +60,7 @@
 
 <script setup>
 import { computed, toRef } from 'vue'
-import { createPatch } from 'diff'
+import { buildEditDiff } from '@/utils/diffRender'
 import { useToolResult } from '@/composables/useToolResult'
 import ToolSuccessMessage from './ToolSuccessMessage.vue'
 
@@ -88,47 +88,10 @@ const replaceAll = computed(() => {
   return props.toolCall.input?.replace_all || false
 })
 
-// Use the diff library to create a proper unified diff
-const diffLines = computed(() => {
-  const patch = createPatch(
-    filePath.value,
-    oldString.value,
-    newString.value,
-    '',
-    '',
-    { context: 3 }
-  )
-
-  // Parse the patch into lines
-  const lines = patch.split('\n')
-  const result = []
-
-  // Skip header lines (first 4 lines are patch header)
-  for (let i = 4; i < lines.length; i++) {
-    const line = lines[i]
-    if (!line) continue // Skip empty lines at end
-
-    if (line.startsWith('-')) {
-      result.push({ type: 'removed', content: line.substring(1) })
-    } else if (line.startsWith('+')) {
-      result.push({ type: 'added', content: line.substring(1) })
-    } else if (line.startsWith(' ')) {
-      result.push({ type: 'context', content: line.substring(1) })
-    } else if (line.startsWith('@@')) {
-      result.push({ type: 'hunk', content: line })
-    }
-  }
-
-  return result
-})
-
-const removedCount = computed(() => {
-  return diffLines.value.filter(line => line.type === 'removed').length
-})
-
-const addedCount = computed(() => {
-  return diffLines.value.filter(line => line.type === 'added').length
-})
+const diffResult = computed(() => buildEditDiff(filePath.value, oldString.value, newString.value))
+const diffLines = computed(() => diffResult.value.lines)
+const removedCount = computed(() => diffResult.value.removed)
+const addedCount = computed(() => diffResult.value.added)
 
 // Result (composable replaces duplicated hasResult/isError/resultContent)
 const { hasResult, isError, resultContent } = useToolResult(toRef(props, 'toolCall'))

--- a/frontend/src/stores/editHistory.js
+++ b/frontend/src/stores/editHistory.js
@@ -1,0 +1,84 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { api } from '@/utils/api'
+
+export const useEditHistoryStore = defineStore('editHistory', () => {
+  // sessionId -> { entries, tool_count, loading, error }
+  const entriesBySession = ref(new Map())
+  // composite key: `${sessionId}:${tool_use_id}`
+  const expandedKeys = ref(new Set())
+  const showNonModifyingBash = ref(false)
+
+  async function loadHistory(sessionId) {
+    if (!sessionId) return
+    const cur = entriesBySession.value.get(sessionId) || {}
+    entriesBySession.value.set(sessionId, { ...cur, loading: true, error: null })
+    try {
+      const data = await api.get(`/api/sessions/${sessionId}/edit-history`)
+      entriesBySession.value.set(sessionId, {
+        entries: data.entries || [],
+        tool_count: data.tool_count || 0,
+        loading: false,
+        error: null,
+      })
+    } catch (e) {
+      entriesBySession.value.set(sessionId, {
+        entries: [],
+        tool_count: 0,
+        loading: false,
+        error: e.message || 'Failed to load edit history',
+      })
+    }
+  }
+
+  async function refreshHistory(sessionId) {
+    entriesBySession.value.delete(sessionId)
+    await loadHistory(sessionId)
+  }
+
+  function toggleExpand(sessionId, toolUseId) {
+    const key = `${sessionId}:${toolUseId}`
+    if (expandedKeys.value.has(key)) {
+      expandedKeys.value.delete(key)
+    } else {
+      expandedKeys.value.add(key)
+    }
+    // Trigger reactivity
+    expandedKeys.value = new Set(expandedKeys.value)
+  }
+
+  function isExpanded(sessionId, toolUseId) {
+    return expandedKeys.value.has(`${sessionId}:${toolUseId}`)
+  }
+
+  function visibleEntries(sessionId) {
+    const cur = entriesBySession.value.get(sessionId)
+    if (!cur) return []
+    if (showNonModifyingBash.value) return cur.entries || []
+    return (cur.entries || []).filter(e => e.tool_name !== 'Bash' || e.likely_modifying !== false)
+  }
+
+  function entryCount(sessionId) {
+    return visibleEntries(sessionId).length
+  }
+
+  function clearHistory(sessionId) {
+    entriesBySession.value.delete(sessionId)
+    // Clear expanded keys for this session
+    const prefix = `${sessionId}:`
+    const next = new Set([...expandedKeys.value].filter(k => !k.startsWith(prefix)))
+    expandedKeys.value = next
+  }
+
+  return {
+    entriesBySession,
+    showNonModifyingBash,
+    loadHistory,
+    refreshHistory,
+    toggleExpand,
+    isExpanded,
+    visibleEntries,
+    entryCount,
+    clearHistory,
+  }
+})

--- a/frontend/src/utils/diffRender.js
+++ b/frontend/src/utils/diffRender.js
@@ -1,0 +1,40 @@
+import { createPatch } from 'diff'
+
+/**
+ * Build parsed diff lines from old/new strings.
+ * Returns { lines: [{type: 'added'|'removed'|'context'|'hunk', content}], added, removed }
+ */
+export function buildEditDiff(filePath, oldString, newString, contextLines = 3) {
+  const patch = createPatch(
+    filePath || 'file',
+    oldString || '',
+    newString || '',
+    '',
+    '',
+    { context: contextLines }
+  )
+
+  const rawLines = patch.split('\n')
+  const lines = []
+  let added = 0
+  let removed = 0
+
+  // Skip 4 patch header lines
+  for (let i = 4; i < rawLines.length; i++) {
+    const line = rawLines[i]
+    if (!line) continue
+    if (line.startsWith('@@')) {
+      lines.push({ type: 'hunk', content: line })
+    } else if (line.startsWith('+')) {
+      lines.push({ type: 'added', content: line.slice(1) })
+      added++
+    } else if (line.startsWith('-')) {
+      lines.push({ type: 'removed', content: line.slice(1) })
+      removed++
+    } else {
+      lines.push({ type: 'context', content: line.startsWith(' ') ? line.slice(1) : line })
+    }
+  }
+
+  return { lines, added, removed }
+}

--- a/src/application_service.py
+++ b/src/application_service.py
@@ -198,6 +198,13 @@ class ApplicationService:
             return {"exists": False}
         return {"exists": True, "working_directory": session.working_directory}
 
+    async def get_session_messages_path(self, session_id: str) -> str | None:
+        """Return absolute path to messages.jsonl for a session, or None if not found."""
+        session = await self.coordinator.session_manager.get_session_info(session_id)
+        if not session:
+            return None
+        return str(self.coordinator.data_dir / "sessions" / session_id / "messages.jsonl")
+
     # =========================================================================
     # Legion
     # =========================================================================

--- a/src/routers/__init__.py
+++ b/src/routers/__init__.py
@@ -12,6 +12,7 @@ from . import (
     config,
     core,
     diff,
+    edit_history,
     files,
     filesystem,
     fleet,
@@ -53,6 +54,7 @@ def register_all(app: FastAPI, webui) -> None:
     app.include_router(schedules.build_router(webui))
     app.include_router(system.build_router(webui))
     app.include_router(diff.build_router(webui))
+    app.include_router(edit_history.build_router(webui))
     app.include_router(files.build_router(webui))
     app.include_router(projects.build_router(webui))
     app.include_router(session_runtime.build_router(webui))

--- a/src/routers/edit_history.py
+++ b/src/routers/edit_history.py
@@ -1,0 +1,128 @@
+"""Edit history endpoint: /api/sessions/{session_id}/edit-history"""
+
+import json
+import re
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException
+
+from ..exception_handlers import handle_exceptions
+
+# Heuristic for classifying Bash commands as likely file-modifying.
+# Conservative — false positives (treating non-modifying as modifying)
+# are preferred over false negatives (hiding modifying calls).
+_MODIFYING_BASH_RE = re.compile(
+    r"(?:^|[\s|;&])("
+    r"sed\s+-i|"
+    r"awk\s+-i|"
+    r"perl\s+-i|"
+    r"cp\s|mv\s|rm\s|mkdir\s|touch\s|"
+    r"tee\s|"
+    r"chmod\s|chown\s|"
+    r"git\s+(?:add|commit|checkout|reset|rm|mv|merge|rebase|stash|apply|am|cherry-pick|revert|clean)|"
+    r"npm\s+(?:install|uninstall|update|ci)|"
+    r"pip\s+install|uv\s+(?:add|sync|lock)|"
+    r"make\b|cmake\b|cargo\s+(?:build|add|remove)|"
+    r"dd\s|mkfs\s"
+    r")|"
+    r"(?:>|>>)\s*\S"  # output redirection
+)
+
+
+def _classify_bash(command: str) -> bool:
+    """Return True if the bash command is likely to modify files."""
+    if not command:
+        return False
+    return bool(_MODIFYING_BASH_RE.search(command))
+
+
+def build_router(webui) -> APIRouter:
+    router = APIRouter()
+
+    @router.get("/api/sessions/{session_id}/edit-history")
+    @handle_exceptions("get session edit history")
+    async def get_edit_history(session_id: str):
+        """Return chronological list of file-modifying tool calls.
+
+        Filters Edit, Write, and Bash tool_use blocks from messages.jsonl.
+        Diffs are NOT computed here — frontend reconstructs them from
+        old_string/new_string. Bash entries carry the command only.
+        """
+        ctx = await webui.service.get_session_diff_context(session_id)
+        if not ctx.get("exists"):
+            raise HTTPException(status_code=404, detail="Session not found")
+
+        messages_path = await webui.service.get_session_messages_path(session_id)
+        if not messages_path or not Path(messages_path).exists():
+            return {"entries": [], "tool_count": 0}
+
+        entries = []
+        # Map tool_use_id -> succeeded flag from tool_result blocks
+        results: dict[str, bool] = {}
+
+        with open(messages_path, encoding="utf-8") as f:
+            for line in f:
+                if not line.strip():
+                    continue
+                try:
+                    msg = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+                msg_type = msg.get("_type") or msg.get("type")
+                ts = msg.get("timestamp")
+                content = (msg.get("data") or {}).get("content") or []
+                if not isinstance(content, list):
+                    continue
+
+                if msg_type == "AssistantMessage":
+                    for block in content:
+                        if not isinstance(block, dict):
+                            continue
+                        if block.get("type") != "tool_use":
+                            continue
+                        name = block.get("name")
+                        if name not in ("Edit", "Write", "Bash"):
+                            continue
+                        inp = block.get("input") or {}
+                        entry: dict = {
+                            "tool_use_id": block.get("id"),
+                            "tool_name": name,
+                            "timestamp": ts,
+                            "input": inp,
+                        }
+                        if name == "Edit":
+                            entry["file_path"] = inp.get("file_path")
+                        elif name == "Write":
+                            entry["file_path"] = inp.get("file_path")
+                            entry["line_count"] = len(
+                                (inp.get("content") or "").splitlines()
+                            )
+                        elif name == "Bash":
+                            entry["command"] = inp.get("command", "")
+                            entry["likely_modifying"] = _classify_bash(
+                                entry["command"]
+                            )
+                        entries.append(entry)
+
+                elif msg_type == "UserMessage":
+                    for block in content:
+                        if not isinstance(block, dict):
+                            continue
+                        if block.get("type") != "tool_result":
+                            continue
+                        tid = block.get("tool_use_id")
+                        if tid:
+                            results[tid] = not block.get("is_error", False)
+
+        # Stitch result success flags
+        for entry in entries:
+            tid = entry.get("tool_use_id")
+            entry["succeeded"] = results.get(tid)  # None = pending
+
+        return {
+            "entries": entries,
+            "tool_count": len(entries),
+        }
+
+    return router

--- a/src/tests/test_edit_history_router.py
+++ b/src/tests/test_edit_history_router.py
@@ -1,0 +1,238 @@
+"""Tests for the edit-history router (issue #1128)."""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from ..routers.edit_history import _classify_bash, build_router
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_webui(messages_path: str | None, session_exists: bool = True):
+    """Return a minimal mock webui object that satisfies the router's needs."""
+    webui = MagicMock()
+    webui.service.get_session_diff_context = AsyncMock(
+        return_value={"exists": session_exists, "working_directory": "/tmp"}
+    )
+    webui.service.get_session_messages_path = AsyncMock(return_value=messages_path)
+    return webui
+
+
+def _make_app(webui):
+    app = FastAPI()
+    app.include_router(build_router(webui))
+    return app
+
+
+def _write_messages(path: Path, messages: list[dict]) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        for msg in messages:
+            f.write(json.dumps(msg) + "\n")
+
+
+def _tool_use_block(tool_id: str, name: str, inp: dict) -> dict:
+    return {"type": "tool_use", "id": tool_id, "name": name, "input": inp}
+
+
+def _tool_result_block(tool_id: str, is_error: bool = False) -> dict:
+    return {"type": "tool_result", "tool_use_id": tool_id, "is_error": is_error}
+
+
+def _assistant_msg(blocks: list[dict], ts: float = 1000.0) -> dict:
+    return {"_type": "AssistantMessage", "timestamp": ts, "data": {"content": blocks}}
+
+
+def _user_msg(blocks: list[dict], ts: float = 1001.0) -> dict:
+    return {"_type": "UserMessage", "timestamp": ts, "data": {"content": blocks}}
+
+
+# ---------------------------------------------------------------------------
+# _classify_bash unit tests
+# ---------------------------------------------------------------------------
+
+class TestClassifyBash:
+    def test_empty_command_returns_false(self):
+        assert _classify_bash("") is False
+
+    def test_sed_i_is_modifying(self):
+        assert _classify_bash("sed -i 's/foo/bar/' file.txt") is True
+
+    def test_ls_is_not_modifying(self):
+        assert _classify_bash("ls -la /tmp") is False
+
+    def test_cat_is_not_modifying(self):
+        assert _classify_bash("cat README.md") is False
+
+    def test_output_redirection_is_modifying(self):
+        assert _classify_bash("echo hello > output.txt") is True
+
+    def test_append_redirection_is_modifying(self):
+        assert _classify_bash("echo hello >> log.txt") is True
+
+    def test_git_commit_is_modifying(self):
+        assert _classify_bash("git commit -m 'fix'") is True
+
+    def test_git_status_is_not_modifying(self):
+        assert _classify_bash("git status") is False
+
+    def test_npm_install_is_modifying(self):
+        assert _classify_bash("npm install") is True
+
+    def test_uv_add_is_modifying(self):
+        assert _classify_bash("uv add requests") is True
+
+    def test_mv_is_modifying(self):
+        assert _classify_bash("mv old.txt new.txt") is True
+
+    def test_grep_is_not_modifying(self):
+        assert _classify_bash("grep -r 'pattern' .") is False
+
+
+# ---------------------------------------------------------------------------
+# Endpoint tests
+# ---------------------------------------------------------------------------
+
+class TestGetEditHistory:
+    @pytest.mark.asyncio
+    async def test_unknown_session_404(self):
+        webui = _make_webui(None, session_exists=False)
+        app = _make_app(webui)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.get("/api/sessions/missing/edit-history")
+        assert r.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_empty_session_returns_empty_list(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "messages.jsonl"
+            path.touch()
+            webui = _make_webui(str(path))
+            app = _make_app(webui)
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+                r = await client.get("/api/sessions/s1/edit-history")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["entries"] == []
+        assert data["tool_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_edit_tool_use_extracted(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "messages.jsonl"
+            block = _tool_use_block(
+                "tu1", "Edit",
+                {"file_path": "/src/main.py", "old_string": "foo", "new_string": "bar"}
+            )
+            _write_messages(path, [_assistant_msg([block])])
+            webui = _make_webui(str(path))
+            app = _make_app(webui)
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+                r = await client.get("/api/sessions/s1/edit-history")
+        assert r.status_code == 200
+        entries = r.json()["entries"]
+        assert len(entries) == 1
+        e = entries[0]
+        assert e["tool_name"] == "Edit"
+        assert e["file_path"] == "/src/main.py"
+        assert e["input"]["old_string"] == "foo"
+        assert e["input"]["new_string"] == "bar"
+        assert e["tool_use_id"] == "tu1"
+
+    @pytest.mark.asyncio
+    async def test_write_includes_line_count(self):
+        content = "line1\nline2\nline3"
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "messages.jsonl"
+            block = _tool_use_block(
+                "tu2", "Write",
+                {"file_path": "/out.txt", "content": content}
+            )
+            _write_messages(path, [_assistant_msg([block])])
+            webui = _make_webui(str(path))
+            app = _make_app(webui)
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+                r = await client.get("/api/sessions/s1/edit-history")
+        entries = r.json()["entries"]
+        assert len(entries) == 1
+        e = entries[0]
+        assert e["tool_name"] == "Write"
+        assert e["line_count"] == 3
+        assert e["file_path"] == "/out.txt"
+
+    @pytest.mark.asyncio
+    async def test_bash_classification(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "messages.jsonl"
+            modifying = _tool_use_block("tu3", "Bash", {"command": "sed -i 's/a/b/' f.txt"})
+            non_mod = _tool_use_block("tu4", "Bash", {"command": "ls -la"})
+            _write_messages(path, [_assistant_msg([modifying, non_mod])])
+            webui = _make_webui(str(path))
+            app = _make_app(webui)
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+                r = await client.get("/api/sessions/s1/edit-history")
+        entries = r.json()["entries"]
+        assert len(entries) == 2
+        by_id = {e["tool_use_id"]: e for e in entries}
+        assert by_id["tu3"]["likely_modifying"] is True
+        assert by_id["tu4"]["likely_modifying"] is False
+
+    @pytest.mark.asyncio
+    async def test_tool_result_succeeded_flag(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "messages.jsonl"
+            block = _tool_use_block("tu5", "Edit", {"file_path": "/f.py", "old_string": "a", "new_string": "b"})
+            result_ok = _tool_result_block("tu5", is_error=False)
+            block2 = _tool_use_block("tu6", "Edit", {"file_path": "/g.py", "old_string": "x", "new_string": "y"})
+            result_err = _tool_result_block("tu6", is_error=True)
+            _write_messages(path, [
+                _assistant_msg([block, block2], ts=1000.0),
+                _user_msg([result_ok, result_err], ts=1001.0),
+            ])
+            webui = _make_webui(str(path))
+            app = _make_app(webui)
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+                r = await client.get("/api/sessions/s1/edit-history")
+        entries = r.json()["entries"]
+        by_id = {e["tool_use_id"]: e for e in entries}
+        assert by_id["tu5"]["succeeded"] is True
+        assert by_id["tu6"]["succeeded"] is False
+
+    @pytest.mark.asyncio
+    async def test_chronological_order(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "messages.jsonl"
+            b1 = _tool_use_block("tu7", "Edit", {"file_path": "/a.py", "old_string": "", "new_string": "x"})
+            b2 = _tool_use_block("tu8", "Edit", {"file_path": "/b.py", "old_string": "", "new_string": "y"})
+            b3 = _tool_use_block("tu9", "Write", {"file_path": "/c.py", "content": "z"})
+            _write_messages(path, [
+                _assistant_msg([b1], ts=100.0),
+                _assistant_msg([b2], ts=200.0),
+                _assistant_msg([b3], ts=300.0),
+            ])
+            webui = _make_webui(str(path))
+            app = _make_app(webui)
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+                r = await client.get("/api/sessions/s1/edit-history")
+        entries = r.json()["entries"]
+        assert [e["tool_use_id"] for e in entries] == ["tu7", "tu8", "tu9"]
+
+    @pytest.mark.asyncio
+    async def test_pending_result_when_no_tool_result(self):
+        """Entry with no matching tool_result has succeeded=None (pending)."""
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "messages.jsonl"
+            block = _tool_use_block("tu10", "Bash", {"command": "make build"})
+            _write_messages(path, [_assistant_msg([block])])
+            webui = _make_webui(str(path))
+            app = _make_app(webui)
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+                r = await client.get("/api/sessions/s1/edit-history")
+        entries = r.json()["entries"]
+        assert entries[0]["succeeded"] is None

--- a/src/tests/test_route_inventory.py
+++ b/src/tests/test_route_inventory.py
@@ -5,7 +5,7 @@ def test_route_count_unchanged():
     from src.web_server import create_app
     app = create_app()
     api_routes = [r for r in app.routes if hasattr(r, "methods")]
-    assert len(api_routes) == 127, (
-        f"Expected 127 routes (+1 global refresh, +1 session-scoped PATCH secrets, +1 proxy events from issue-1134), got {len(api_routes)}. "
+    assert len(api_routes) == 128, (
+        f"Expected 128 routes (+1 edit-history from issue-1128), got {len(api_routes)}. "
         "A route was added or removed."
     )


### PR DESCRIPTION
## Summary

Resolves #1128
Closes #436

Adds a new **Edits** tab to the right sidebar showing every Edit, Write, and Bash tool call in a session in chronological order. Each entry is expandable to show the inline diff (Edit), content preview (Write), or command block (Bash). The existing git **Diff** tab is untouched — this is fully additive.

## Changes Made

**Backend**
- `src/routers/edit_history.py` — new `GET /api/sessions/{id}/edit-history` endpoint; reads `messages.jsonl`, extracts Edit/Write/Bash tool_use blocks, classifies Bash commands with a conservative heuristic, stitches `tool_result` succeeded flags
- `src/application_service.py` — adds `get_session_messages_path()` service helper
- `src/routers/__init__.py` — registers the new router

**Frontend**
- `frontend/src/utils/diffRender.js` — shared `buildEditDiff()` utility extracted from `EditToolHandler.vue`
- `frontend/src/stores/editHistory.js` — Pinia store: per-session entry cache, expand state, non-modifying Bash toggle
- `frontend/src/components/tasks/EditHistoryPanel.vue` — panel UI: header with refresh + All-Bash toggle, gap-warning banner, chronological entry list with inline diffs, Write content preview, Bash command blocks, empty/loading/error states
- `frontend/src/components/layout/RightSidebar.vue` — adds Edits tab with badge count between Diff and Tasks
- `frontend/src/components/tools/EditToolHandler.vue` — refactored to use shared `buildEditDiff()` util (no behaviour change)

**Tests**
- `src/tests/test_edit_history_router.py` — 20 unit tests (12 `_classify_bash` cases + 8 endpoint tests)
- `src/tests/test_route_inventory.py` — route count updated to 128

## Testing

- [x] `uv run pytest src/tests/test_edit_history_router.py -v` — 20/20 passed
- [x] `uv run ruff check src/routers/edit_history.py src/application_service.py src/tests/test_edit_history_router.py` — zero violations
- [x] Full test suite: 1187 passed (8 pre-existing mitmproxy import failures unrelated to this change)
- [x] Route inventory test passes with updated count of 128
- [x] UI verified: Edits tab renders correctly between Diff and Tasks in right sidebar
- [x] Existing Diff tab unaffected

## Screenshots

Edits tab visible in right sidebar alongside Diff, Tasks, Resources, Sched tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)