### PR TITLE
feat: per-session token and cost tracking with model pricing config

### DIFF
--- a/frontend/src/components/legion/MinionViewModal.vue
+++ b/frontend/src/components/legion/MinionViewModal.vue
@@ -11,7 +11,10 @@
       <div class="modal-content">
         <div class="modal-header">
           <h5 class="modal-title" id="minionViewModalLabel">Minion Details</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          <div class="d-flex align-items-center gap-2">
+            <SessionCostBadge v-if="session" :session-id="session.session_id" />
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
         </div>
         <div class="modal-body">
           <div v-if="!session" class="text-center text-muted py-4">
@@ -140,6 +143,7 @@
 <script setup>
 import { ref, onMounted, onUnmounted, watch } from 'vue'
 import { useUIStore } from '@/stores/ui'
+import SessionCostBadge from '@/components/session/SessionCostBadge.vue'
 
 const uiStore = useUIStore()
 

--- a/frontend/src/components/session/SessionCostBadge.vue
+++ b/frontend/src/components/session/SessionCostBadge.vue
@@ -1,0 +1,208 @@
+<template>
+  <span v-if="usage" class="position-relative d-inline-block" ref="badgeRef">
+    <button
+      type="button"
+      class="btn btn-sm badge bg-light text-dark border border-secondary-subtle px-2 py-1"
+      style="font-size: 0.75rem; font-weight: 500; cursor: pointer;"
+      :title="popoverOpen ? '' : 'Click for cost breakdown'"
+      @click.stop="togglePopover"
+    >
+      {{ badgeLabel }}
+    </button>
+
+    <div
+      v-if="popoverOpen"
+      class="cost-popover card shadow"
+      role="dialog"
+      aria-label="Token usage breakdown"
+    >
+      <div class="card-header d-flex justify-content-between align-items-center py-2 px-3">
+        <span class="fw-semibold small">Token Usage</span>
+        <button
+          type="button"
+          class="btn-close btn-close-sm"
+          aria-label="Close"
+          @click.stop="popoverOpen = false"
+        ></button>
+      </div>
+      <div class="card-body py-2 px-3">
+        <!-- Model info -->
+        <div class="d-flex justify-content-between small text-muted mb-2">
+          <span>Model</span>
+          <span class="font-monospace">{{ usage.model || 'unknown' }}</span>
+        </div>
+        <div class="d-flex justify-content-between small text-muted mb-2">
+          <span>Turns</span>
+          <span>{{ usage.turn_count }}</span>
+        </div>
+
+        <hr class="my-2" />
+
+        <!-- Token breakdown table -->
+        <table class="table table-borderless table-sm small mb-0">
+          <thead>
+            <tr class="text-muted">
+              <th class="ps-0">Category</th>
+              <th class="text-end">Tokens</th>
+              <th class="text-end pe-0">Cost</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="ps-0">Input</td>
+              <td class="text-end">{{ formatTokens(usage.input_tokens) }}</td>
+              <td class="text-end pe-0">{{ formatCost(rowCost('input')) }}</td>
+            </tr>
+            <tr>
+              <td class="ps-0">Output</td>
+              <td class="text-end">{{ formatTokens(usage.output_tokens) }}</td>
+              <td class="text-end pe-0">{{ formatCost(rowCost('output')) }}</td>
+            </tr>
+            <tr>
+              <td class="ps-0">Cache write</td>
+              <td class="text-end">{{ formatTokens(usage.cache_write_tokens) }}</td>
+              <td class="text-end pe-0">{{ formatCost(rowCost('cache_write')) }}</td>
+            </tr>
+            <tr>
+              <td class="ps-0">Cache read</td>
+              <td class="text-end">{{ formatTokens(usage.cache_read_tokens) }}</td>
+              <td class="text-end pe-0">{{ formatCost(rowCost('cache_read')) }}</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <hr class="my-2" />
+
+        <!-- Totals -->
+        <div class="d-flex justify-content-between small fw-semibold mb-1">
+          <span>Total tokens</span>
+          <span>{{ formatTokens(totalTokens) }}</span>
+        </div>
+        <div class="d-flex justify-content-between small fw-semibold mb-1">
+          <span>Estimated cost</span>
+          <span>{{ estimatedCostLabel }}</span>
+        </div>
+        <div
+          v-if="usage.sdk_reported_cost_usd != null"
+          class="d-flex justify-content-between small text-muted"
+        >
+          <span>SDK reported cost</span>
+          <span>${{ usage.sdk_reported_cost_usd.toFixed(4) }}</span>
+        </div>
+
+        <!-- Unknown model note -->
+        <div
+          v-if="!usage.rates_known"
+          class="alert alert-warning py-1 px-2 mt-2 mb-0 small"
+          role="alert"
+        >
+          Unknown model — pricing rates not available. Update
+          <code>~/.config/cc_webui/config.json</code> to add rates.
+        </div>
+
+        <!-- Rates used -->
+        <div v-if="usage.rates_used" class="mt-2">
+          <div class="text-muted small mb-1">Rates (USD / 1M tokens)</div>
+          <div class="d-flex flex-wrap gap-2 small font-monospace text-muted">
+            <span>in:${{ usage.rates_used.input }}</span>
+            <span>out:${{ usage.rates_used.output }}</span>
+            <span>cw:${{ usage.rates_used.cache_write }}</span>
+            <span>cr:${{ usage.rates_used.cache_read }}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </span>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { useUsageStore } from '@/stores/usage'
+
+const props = defineProps({
+  sessionId: {
+    type: String,
+    required: true,
+  },
+})
+
+const usageStore = useUsageStore()
+const badgeRef = ref(null)
+const popoverOpen = ref(false)
+
+const usage = computed(() => usageStore.usageBySession.get(props.sessionId) || null)
+
+const totalTokens = computed(() => {
+  if (!usage.value) return 0
+  return (
+    (usage.value.input_tokens || 0) +
+    (usage.value.output_tokens || 0) +
+    (usage.value.cache_write_tokens || 0) +
+    (usage.value.cache_read_tokens || 0)
+  )
+})
+
+const badgeLabel = computed(() => {
+  if (!usage.value) return ''
+  const cost = usage.value.estimated_cost_usd
+  const costStr = cost != null
+    ? (usage.value.rates_known ? `~$${cost.toFixed(3)}` : '~$?')
+    : '~$?'
+  return `${costStr} · ${formatTokens(totalTokens.value)}`
+})
+
+const estimatedCostLabel = computed(() => {
+  if (!usage.value) return '—'
+  const cost = usage.value.estimated_cost_usd
+  if (cost == null || !usage.value.rates_known) return '~$? (unknown model)'
+  return `~$${cost.toFixed(4)}`
+})
+
+function rowCost(category) {
+  if (!usage.value?.rates_used) return null
+  const tokens = usage.value[`${category}_tokens`] || 0
+  const rate = usage.value.rates_used[category] || 0
+  return (tokens / 1_000_000) * rate
+}
+
+function formatTokens(n) {
+  if (n == null) return '0'
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
+  return String(n)
+}
+
+function formatCost(cost) {
+  if (cost == null) return '—'
+  return `$${cost.toFixed(4)}`
+}
+
+function togglePopover() {
+  popoverOpen.value = !popoverOpen.value
+}
+
+function handleClickOutside(event) {
+  if (popoverOpen.value && badgeRef.value && !badgeRef.value.contains(event.target)) {
+    popoverOpen.value = false
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('click', handleClickOutside)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('click', handleClickOutside)
+})
+</script>
+
+<style scoped>
+.cost-popover {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 1060;
+  min-width: 280px;
+  max-width: 340px;
+}
+</style>

--- a/frontend/src/components/session/SessionInfoBar.vue
+++ b/frontend/src/components/session/SessionInfoBar.vue
@@ -7,11 +7,13 @@
         {{ session.error_message }}
       </div>
     </div>
+    <SessionCostBadge :session-id="session.session_id" />
   </div>
 </template>
 
 <script setup>
 import { computed } from 'vue'
+import SessionCostBadge from './SessionCostBadge.vue'
 
 const props = defineProps({
   session: {

--- a/frontend/src/stores/polling.js
+++ b/frontend/src/stores/polling.js
@@ -512,6 +512,13 @@ export const usePollingStore = defineStore('polling', () => {
         break
       }
 
+      case 'usage_updated': {
+        import('./usage').then(({ useUsageStore }) => {
+          useUsageStore().handleUsageUpdated(payload)
+        })
+        break
+      }
+
       case 'context_update': {
         const { input_tokens, context_window, context_pct } = payload
         sessionStore.patchSession(sessionId, {

--- a/frontend/src/stores/session.js
+++ b/frontend/src/stores/session.js
@@ -456,6 +456,10 @@ export const useSessionStore = defineStore('session', () => {
         return
       }
 
+      // Issue #1125: Load existing usage data for cost badge
+      const usageStore = await import('./usage')
+      usageStore.useUsageStore().loadUsage(sessionId)
+
       // CRITICAL: Await polling connection to prevent race conditions
       const wsStore = await import('./polling')
       await wsStore.usePollingStore().connectSession(sessionId)

--- a/frontend/src/stores/usage.js
+++ b/frontend/src/stores/usage.js
@@ -1,0 +1,57 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { useSessionStore } from './session'
+import { api } from '@/utils/api'
+
+export const useUsageStore = defineStore('usage', () => {
+  // ========== STATE ==========
+
+  // Usage aggregate per session (sessionId -> usageDict)
+  const usageBySession = ref(new Map())
+
+  // ========== COMPUTED ==========
+
+  const currentUsage = computed(() => {
+    const sessionStore = useSessionStore()
+    return usageBySession.value.get(sessionStore.currentSessionId) || null
+  })
+
+  // ========== ACTIONS ==========
+
+  async function loadUsage(sessionId) {
+    if (!sessionId) return
+    try {
+      const data = await api.get(`/api/sessions/${sessionId}/usage`)
+      usageBySession.value.set(sessionId, data)
+      usageBySession.value = new Map(usageBySession.value)
+    } catch (err) {
+      // 404 = no usage yet — silently ignore
+      if (err?.status !== 404) {
+        console.warn(`Failed to load usage for session ${sessionId}:`, err)
+      }
+    }
+  }
+
+  function handleUsageUpdated(event) {
+    const sessionId = event.session_id
+    const usage = event.usage
+    if (!sessionId || !usage) return
+    usageBySession.value.set(sessionId, usage)
+    usageBySession.value = new Map(usageBySession.value)
+  }
+
+  function clearUsage(sessionId) {
+    if (!sessionId) return
+    usageBySession.value.delete(sessionId)
+    usageBySession.value = new Map(usageBySession.value)
+  }
+
+  // ========== RETURN ==========
+  return {
+    usageBySession,
+    currentUsage,
+    loadUsage,
+    handleUsageUpdated,
+    clearUsage,
+  }
+})

--- a/src/analytics/database.py
+++ b/src/analytics/database.py
@@ -48,6 +48,33 @@ CREATE INDEX IF NOT EXISTS idx_audit_project_ts
     ON audit_events(project_id, timestamp DESC);
 CREATE INDEX IF NOT EXISTS idx_audit_session_turn
     ON audit_events(session_id, turn_id);
+
+CREATE TABLE IF NOT EXISTS turn_usage (
+  id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_id          TEXT    NOT NULL,
+  turn_seq            INTEGER NOT NULL,
+  model               TEXT,
+  input_tokens        INTEGER NOT NULL DEFAULT 0,
+  output_tokens       INTEGER NOT NULL DEFAULT 0,
+  cache_write_tokens  INTEGER NOT NULL DEFAULT 0,
+  cache_read_tokens   INTEGER NOT NULL DEFAULT 0,
+  sdk_total_cost_usd  REAL,
+  ts                  REAL    NOT NULL,
+  UNIQUE(session_id, turn_seq)
+);
+CREATE INDEX IF NOT EXISTS idx_turn_session ON turn_usage(session_id);
+
+CREATE TABLE IF NOT EXISTS session_usage (
+  session_id          TEXT PRIMARY KEY,
+  model               TEXT,
+  turn_count          INTEGER NOT NULL DEFAULT 0,
+  input_tokens        INTEGER NOT NULL DEFAULT 0,
+  output_tokens       INTEGER NOT NULL DEFAULT 0,
+  cache_write_tokens  INTEGER NOT NULL DEFAULT 0,
+  cache_read_tokens   INTEGER NOT NULL DEFAULT 0,
+  sdk_total_cost_usd  REAL,
+  last_updated        REAL    NOT NULL
+);
 """
 
 

--- a/src/analytics_store.py
+++ b/src/analytics_store.py
@@ -1,0 +1,143 @@
+"""
+Analytics store for per-session token usage and cost tracking (issue #1125).
+
+Delegates all SQLite I/O to AnalyticsDB (issue #1127), which owns the shared
+connection, WAL mode configuration, and asyncio write lock.
+"""
+
+from __future__ import annotations
+
+import logging
+from time import time
+
+from src.analytics.database import AnalyticsDB
+
+logger = logging.getLogger(__name__)
+
+_SESSION_COLS = [
+    "session_id", "model", "turn_count",
+    "input_tokens", "output_tokens",
+    "cache_write_tokens", "cache_read_tokens",
+    "sdk_total_cost_usd", "last_updated",
+]
+
+
+class AnalyticsStore:
+    """Per-session token usage store backed by AnalyticsDB.
+
+    AnalyticsDB owns the connection and write lock; this class contains only
+    business logic (INSERT OR IGNORE replay safety, aggregate upsert math).
+    """
+
+    def __init__(self, db: AnalyticsDB) -> None:
+        self._db = db
+
+    async def record_turn(
+        self,
+        session_id: str,
+        turn_seq: int,
+        model: str | None,
+        usage: dict,
+        sdk_total_cost_usd: float | None,
+    ) -> None:
+        """Insert a turn_usage row (idempotent) and upsert session aggregate."""
+        input_tokens = int(usage.get("input_tokens") or 0)
+        output_tokens = int(usage.get("output_tokens") or 0)
+        # SDK uses cache_creation_input_tokens; normalize to cache_write_tokens
+        cache_write_tokens = int(
+            usage.get("cache_creation_input_tokens")
+            or usage.get("cache_write_tokens")
+            or 0
+        )
+        cache_read_tokens = int(
+            usage.get("cache_read_input_tokens")
+            or usage.get("cache_read_tokens")
+            or 0
+        )
+        now = time()
+
+        try:
+            await self._db.execute_write(
+                """
+                INSERT OR IGNORE INTO turn_usage
+                  (session_id, turn_seq, model,
+                   input_tokens, output_tokens,
+                   cache_write_tokens, cache_read_tokens,
+                   sdk_total_cost_usd, ts)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    session_id, turn_seq, model,
+                    input_tokens, output_tokens,
+                    cache_write_tokens, cache_read_tokens,
+                    sdk_total_cost_usd, now,
+                ),
+            )
+            # Upsert session aggregate by re-summing from turn_usage so the
+            # result is consistent even after idempotent replays.
+            await self._db.execute_write(
+                """
+                INSERT INTO session_usage
+                  (session_id, model, turn_count,
+                   input_tokens, output_tokens,
+                   cache_write_tokens, cache_read_tokens,
+                   sdk_total_cost_usd, last_updated)
+                SELECT
+                  ?,
+                  ?,
+                  COUNT(*),
+                  COALESCE(SUM(input_tokens), 0),
+                  COALESCE(SUM(output_tokens), 0),
+                  COALESCE(SUM(cache_write_tokens), 0),
+                  COALESCE(SUM(cache_read_tokens), 0),
+                  COALESCE(SUM(COALESCE(sdk_total_cost_usd, 0)), 0),
+                  ?
+                FROM turn_usage WHERE session_id = ?
+                ON CONFLICT(session_id) DO UPDATE SET
+                  model              = excluded.model,
+                  turn_count         = excluded.turn_count,
+                  input_tokens       = excluded.input_tokens,
+                  output_tokens      = excluded.output_tokens,
+                  cache_write_tokens = excluded.cache_write_tokens,
+                  cache_read_tokens  = excluded.cache_read_tokens,
+                  sdk_total_cost_usd = excluded.sdk_total_cost_usd,
+                  last_updated       = excluded.last_updated
+                """,
+                (session_id, model, now, session_id),
+            )
+        except Exception:
+            logger.exception("Failed to record turn usage for session %s", session_id)
+
+    async def get_session_usage(self, session_id: str) -> dict | None:
+        """Return session aggregate as dict, or None if no data exists yet."""
+        rows = await self._db.execute_read(
+            """
+            SELECT session_id, model, turn_count,
+                   input_tokens, output_tokens,
+                   cache_write_tokens, cache_read_tokens,
+                   sdk_total_cost_usd, last_updated
+            FROM session_usage WHERE session_id = ?
+            """,
+            (session_id,),
+        )
+        return rows[0] if rows else None
+
+    async def get_turn_count(self, session_id: str) -> int:
+        """Return current turn count (used to seed turn_seq on restart)."""
+        val = await self._db.execute_scalar(
+            "SELECT turn_count FROM session_usage WHERE session_id = ?",
+            (session_id,),
+        )
+        return int(val) if val is not None else 0
+
+    async def delete_session(self, session_id: str) -> None:
+        """Remove all analytics rows for a session."""
+        try:
+            await self._db.execute_write(
+                "DELETE FROM turn_usage WHERE session_id = ?", (session_id,)
+            )
+            await self._db.execute_write(
+                "DELETE FROM session_usage WHERE session_id = ?", (session_id,)
+            )
+        except Exception:
+            logger.exception("Failed to delete analytics for session %s", session_id)

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -8,11 +8,139 @@ Config file location: ~/.config/cc_webui/config.json
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 CONFIG_DIR = Path.home() / ".config" / "cc_webui"
 CONFIG_FILE = CONFIG_DIR / "config.json"
 
 LOCALHOST_ADDRESSES = {"127.0.0.1", "localhost", "::1"}
+
+# ---------------------------------------------------------------------------
+# Pricing configuration
+# ---------------------------------------------------------------------------
+
+# Canonical model IDs for built-in defaults
+_SONNET_4_6 = "claude-sonnet-4-6"
+_OPUS_4_7 = "claude-opus-4-7"
+_HAIKU_4_5 = "claude-haiku-4-5"
+
+# Short-name aliases → canonical model ID
+_MODEL_ALIASES: dict[str, str] = {
+    "sonnet": _SONNET_4_6,
+    "sonnet-4-6": _SONNET_4_6,
+    "opus": _OPUS_4_7,
+    "opus-4-7": _OPUS_4_7,
+    "opusplan": _OPUS_4_7,
+    "haiku": _HAIKU_4_5,
+    "haiku-4-5": _HAIKU_4_5,
+}
+
+
+def normalize_model_id(model: str | None) -> str | None:
+    """Resolve a model alias or partial name to its canonical form."""
+    if model is None:
+        return None
+    key = model.lower().strip()
+    return _MODEL_ALIASES.get(key, model)
+
+
+def _default_rates() -> "dict[str, ModelRates]":
+    """Return built-in pricing defaults (USD per 1 M tokens, as of 2026-04)."""
+    return {
+        _SONNET_4_6: ModelRates(input=3.0, output=15.0, cache_write=3.75, cache_read=0.30),
+        _OPUS_4_7: ModelRates(input=15.0, output=75.0, cache_write=18.75, cache_read=1.50),
+        _HAIKU_4_5: ModelRates(input=0.80, output=4.0, cache_write=1.0, cache_read=0.08),
+    }
+
+
+@dataclass
+class ModelRates:
+    """USD per 1 M tokens for a single model."""
+
+    input: float = 0.0
+    output: float = 0.0
+    cache_write: float = 0.0
+    cache_read: float = 0.0
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "ModelRates":
+        return cls(
+            input=float(data.get("input", 0.0)),
+            output=float(data.get("output", 0.0)),
+            cache_write=float(data.get("cache_write", 0.0)),
+            cache_read=float(data.get("cache_read", 0.0)),
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "input": self.input,
+            "output": self.output,
+            "cache_write": self.cache_write,
+            "cache_read": self.cache_read,
+        }
+
+
+@dataclass
+class PricingConfig:
+    """Per-model pricing table and default model fallback."""
+
+    rates: dict[str, ModelRates] = field(default_factory=_default_rates)
+    default_model: str = _SONNET_4_6
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "PricingConfig":
+        raw_rates = data.get("rates", {})
+        rates = {
+            model_id: ModelRates.from_dict(r)
+            for model_id, r in raw_rates.items()
+            if isinstance(r, dict)
+        }
+        # Merge with defaults so unknown models in config don't lose built-in entries
+        merged = _default_rates()
+        merged.update(rates)
+        return cls(
+            rates=merged,
+            default_model=data.get("default_model", _SONNET_4_6),
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "_comment": (
+                "Pricing rates in USD per 1 M tokens. "
+                "Edit to override without restarting the server. "
+                "Cost is recomputed at query time from the current file."
+            ),
+            "default_model": self.default_model,
+            "rates": {model_id: r.to_dict() for model_id, r in self.rates.items()},
+        }
+
+    def get_rates(self, model: str | None) -> tuple[ModelRates | None, bool]:
+        """Return (ModelRates, rates_known).
+
+        Tries the given model, then its normalized form, then the default_model.
+        Returns (None, False) when no match exists at all.
+        """
+        if model:
+            if model in self.rates:
+                return self.rates[model], True
+            canonical = normalize_model_id(model)
+            if canonical and canonical in self.rates:
+                return self.rates[canonical], True
+        # Try default
+        if self.default_model in self.rates:
+            return self.rates[self.default_model], False
+        return None, False
+
+
+def compute_cost(rates: ModelRates, counts: dict[str, Any]) -> float:
+    """Compute estimated cost in USD given ModelRates and token counts dict."""
+    m = 1_000_000.0
+    return (
+        rates.input * int(counts.get("input_tokens") or 0) / m
+        + rates.output * int(counts.get("output_tokens") or 0) / m
+        + rates.cache_write * int(counts.get("cache_write_tokens") or 0) / m
+        + rates.cache_read * int(counts.get("cache_read_tokens") or 0) / m
+    )
 
 
 @dataclass
@@ -98,6 +226,7 @@ class AppConfig:
     background_calls: BackgroundCallsConfig = field(default_factory=BackgroundCallsConfig)
     watchdog: WatchdogConfig = field(default_factory=WatchdogConfig)
     secrets: SecretsConfig = field(default_factory=SecretsConfig)
+    pricing: PricingConfig = field(default_factory=PricingConfig)
 
     @classmethod
     def from_dict(cls, data: dict) -> "AppConfig":
@@ -154,6 +283,8 @@ class AppConfig:
             backend_override=secrets_data.get("backend_override", None),
             keyring_service_name=secrets_data.get("keyring_service_name", "cc_webui"),
         )
+        pricing_data = data.get("pricing", {})
+        pricing = PricingConfig.from_dict(pricing_data) if pricing_data else PricingConfig()
         return cls(
             networking=networking,
             features=features,
@@ -162,6 +293,7 @@ class AppConfig:
             background_calls=background_calls,
             watchdog=watchdog,
             secrets=secrets,
+            pricing=pricing,
         )
 
     def to_dict(self) -> dict:
@@ -219,6 +351,7 @@ class AppConfig:
                 "backend_override": self.secrets.backend_override,
                 "keyring_service_name": self.secrets.keyring_service_name,
             },
+            "pricing": self.pricing.to_dict(),
         }
 
 

--- a/src/routers/config.py
+++ b/src/routers/config.py
@@ -54,6 +54,27 @@ def build_router(webui) -> APIRouter:
                     raise ValueError("max_concurrent_minions must be a positive integer")
                 config.legion.max_concurrent_minions = val
 
+        # Merge pricing section (issue #1125)
+        if "pricing" in body:
+            from ..config_manager import ModelRates
+            pricing_body = body["pricing"]
+            if "default_model" in pricing_body:
+                config.pricing.default_model = str(pricing_body["default_model"])
+            if "rates" in pricing_body:
+                raw_rates = pricing_body["rates"]
+                if not isinstance(raw_rates, dict):
+                    raise ValueError("pricing.rates must be an object")
+                for model_id, rate_data in raw_rates.items():
+                    if not isinstance(rate_data, dict):
+                        raise ValueError(f"pricing.rates.{model_id} must be an object")
+                    for key in ("input", "output", "cache_write", "cache_read"):
+                        val = rate_data.get(key)
+                        if val is not None and (not isinstance(val, (int, float)) or float(val) < 0):
+                            raise ValueError(
+                                f"pricing.rates.{model_id}.{key} must be a non-negative number"
+                            )
+                    config.pricing.rates[model_id] = ModelRates.from_dict(rate_data)
+
         if webui.config_file:
             save_config(config, webui.config_file)
         else:

--- a/src/routers/sessions.py
+++ b/src/routers/sessions.py
@@ -93,6 +93,42 @@ def build_router(webui) -> APIRouter:
 
         return info
 
+    @router.get("/api/sessions/{session_id}/usage")
+    @handle_exceptions("get session usage")
+    async def get_session_usage(session_id: str):
+        """Return aggregated token usage and estimated cost for a session (issue #1125)."""
+        from ..config_manager import PricingConfig, compute_cost, load_config
+        aggregate = await webui.coordinator.analytics_store.get_session_usage(session_id)
+        if aggregate is None:
+            raise HTTPException(status_code=404, detail="No usage data for this session")
+
+        config = load_config(webui.config_file) if webui.config_file else load_config()
+        pricing = config.pricing if config.pricing else PricingConfig()
+
+        model = aggregate.get("model")
+        rates, rates_known = pricing.get_rates(model)
+
+        result: dict = {
+            "session_id": session_id,
+            "model": model,
+            "turn_count": aggregate.get("turn_count", 0),
+            "input_tokens": aggregate.get("input_tokens", 0),
+            "output_tokens": aggregate.get("output_tokens", 0),
+            "cache_write_tokens": aggregate.get("cache_write_tokens", 0),
+            "cache_read_tokens": aggregate.get("cache_read_tokens", 0),
+            "sdk_reported_cost_usd": aggregate.get("sdk_total_cost_usd"),
+            "rates_known": rates_known,
+        }
+
+        if rates is not None:
+            result["estimated_cost_usd"] = compute_cost(rates, aggregate)
+            result["rates_used"] = rates.to_dict()
+        else:
+            result["estimated_cost_usd"] = None
+            result["rates_used"] = None
+
+        return result
+
     @router.get("/api/sessions/{session_id}/descendants")
     @handle_exceptions("get session descendants")
     async def get_session_descendants(session_id: str, limit: int = 50, offset: int = 0):

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -279,6 +279,13 @@ class SessionCoordinator:
         self.queue_manager = QueueManager()
         self.queue_processor = QueueProcessor(self)
 
+        # Issue #1125: Per-session token usage analytics (injected by web_server via set_analytics_store)
+        self.analytics_store = None
+        # Per-session turn sequence counters (rehydrated lazily from DB on first use)
+        self._turn_seq_by_session: dict[str, int] = {}
+        # Callback for broadcasting usage_updated events (injected by web_server)
+        self._usage_broadcast_callback: "Callable[[str, dict], None] | None" = None
+
         # Issue #404: Resource MCP tools for displaying resources in task panel
         # Callback for broadcasting resource_registered events will be set by web_server
         from src.mcp.resource_mcp_tools import ResourceMCPTools
@@ -301,6 +308,10 @@ class SessionCoordinator:
     def set_sdk_factory(self, factory):
         """Set custom SDK factory for testing (e.g., MockClaudeSDK)."""
         self._sdk_factory = factory
+
+    def set_analytics_store(self, store) -> None:
+        """Inject the AnalyticsStore instance (issue #1125)."""
+        self.analytics_store = store
 
     def set_audit_writer(self, writer) -> None:
         """Wire an AuditWriter into all existing and future storage managers."""
@@ -1892,6 +1903,13 @@ class SessionCoordinator:
 
             if success:
                 coord_logger.info(f"Session {session_id} deleted")
+                # Issue #1125: Remove analytics rows for deleted session
+                if self.analytics_store:
+                    try:
+                        await self.analytics_store.delete_session(session_id)
+                        self._turn_seq_by_session.pop(session_id, None)
+                    except Exception:
+                        logger.exception("Failed to delete analytics for session %s", session_id)
                 # Notify about session deletion (using a special state change)
                 await self._notify_state_change(session_id, "deleted")
                 # Add this session to the deleted list
@@ -3904,6 +3922,33 @@ class SessionCoordinator:
                         await self.session_manager.update_processing_state(session_id, False)
                     except Exception:
                         logger.exception(f"Failed to reset processing state for session {session_id}")
+
+                    # Issue #1125: Record turn usage in analytics DB and broadcast update
+                    if self.analytics_store:
+                        try:
+                            meta = parsed_message.metadata or {}
+                            usage = meta.get("usage") or {}
+                            sdk_cost = meta.get("total_cost_usd")
+                            # Resolve model from session info
+                            _sinfo = await self.session_manager.get_session_info(session_id)
+                            _model = _sinfo.model if _sinfo else None
+                            # Lazily initialise turn_seq from DB on first use after restart
+                            if session_id not in self._turn_seq_by_session:
+                                db_count = await self.analytics_store.get_turn_count(session_id)
+                                self._turn_seq_by_session[session_id] = db_count
+                            self._turn_seq_by_session[session_id] += 1
+                            turn_seq = self._turn_seq_by_session[session_id]
+                            await self.analytics_store.record_turn(
+                                session_id, turn_seq, _model, usage, sdk_cost
+                            )
+                            aggregate = await self.analytics_store.get_session_usage(session_id)
+                            if aggregate and self._usage_broadcast_callback:
+                                try:
+                                    await self._usage_broadcast_callback(session_id, aggregate)
+                                except Exception:
+                                    logger.exception("Failed to broadcast usage_updated for %s", session_id)
+                        except Exception:
+                            logger.exception("Failed to record analytics for session %s", session_id)
 
                     # Issue #904: Poll for SDK-generated session title after each turn
                     task = asyncio.create_task(self._check_sdk_generated_name(session_id))

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -284,7 +284,7 @@ class SessionCoordinator:
         # Per-session turn sequence counters (rehydrated lazily from DB on first use)
         self._turn_seq_by_session: dict[str, int] = {}
         # Callback for broadcasting usage_updated events (injected by web_server)
-        self._usage_broadcast_callback: "Callable[[str, dict], None] | None" = None
+        self._usage_broadcast_callback: Callable[[str, dict], None] | None = None
 
         # Issue #404: Resource MCP tools for displaying resources in task panel
         # Callback for broadcasting resource_registered events will be set by web_server

--- a/src/tests/test_analytics_store.py
+++ b/src/tests/test_analytics_store.py
@@ -1,0 +1,138 @@
+"""Unit tests for AnalyticsStore (issue #1125)."""
+
+import pytest
+
+from src.analytics.database import AnalyticsDB
+from src.analytics_store import AnalyticsStore
+
+
+@pytest.fixture
+async def store(tmp_path):
+    db = AnalyticsDB(tmp_path / "analytics.db")
+    await db.initialize()
+    s = AnalyticsStore(db)
+    yield s
+    await db.close()
+
+
+# ---------------------------------------------------------------------------
+# Basic insert and retrieval
+# ---------------------------------------------------------------------------
+
+async def test_get_session_usage_returns_none_when_empty(store):
+    result = await store.get_session_usage("sid-missing")
+    assert result is None
+
+
+async def test_record_turn_creates_session_aggregate(store):
+    usage = {
+        "input_tokens": 100,
+        "output_tokens": 50,
+        "cache_creation_input_tokens": 10,
+        "cache_read_input_tokens": 5,
+    }
+    await store.record_turn("sid-1", 1, "claude-sonnet-4-6", usage, 0.001)
+
+    agg = await store.get_session_usage("sid-1")
+    assert agg is not None
+    assert agg["session_id"] == "sid-1"
+    assert agg["turn_count"] == 1
+    assert agg["input_tokens"] == 100
+    assert agg["output_tokens"] == 50
+    assert agg["cache_write_tokens"] == 10
+    assert agg["cache_read_tokens"] == 5
+    assert agg["model"] == "claude-sonnet-4-6"
+
+
+async def test_multiple_turns_accumulate(store):
+    usage = {"input_tokens": 100, "output_tokens": 50}
+    await store.record_turn("sid-2", 1, "claude-sonnet-4-6", usage, 0.001)
+    await store.record_turn("sid-2", 2, "claude-sonnet-4-6", usage, 0.001)
+
+    agg = await store.get_session_usage("sid-2")
+    assert agg["turn_count"] == 2
+    assert agg["input_tokens"] == 200
+    assert agg["output_tokens"] == 100
+
+
+# ---------------------------------------------------------------------------
+# Idempotent replay via UNIQUE(session_id, turn_seq)
+# ---------------------------------------------------------------------------
+
+async def test_duplicate_turn_seq_is_ignored(store):
+    usage = {"input_tokens": 100, "output_tokens": 50}
+    await store.record_turn("sid-3", 1, "claude-sonnet-4-6", usage, None)
+    # Insert same turn_seq again — should be ignored (INSERT OR IGNORE)
+    await store.record_turn("sid-3", 1, "claude-sonnet-4-6", usage, None)
+
+    agg = await store.get_session_usage("sid-3")
+    assert agg["turn_count"] == 1
+    assert agg["input_tokens"] == 100
+
+
+# ---------------------------------------------------------------------------
+# get_turn_count initialisation helper
+# ---------------------------------------------------------------------------
+
+async def test_get_turn_count_returns_zero_for_unknown_session(store):
+    count = await store.get_turn_count("nonexistent")
+    assert count == 0
+
+
+async def test_get_turn_count_returns_correct_value(store):
+    usage = {"input_tokens": 10}
+    await store.record_turn("sid-4", 1, None, usage, None)
+    await store.record_turn("sid-4", 2, None, usage, None)
+
+    count = await store.get_turn_count("sid-4")
+    assert count == 2
+
+
+# ---------------------------------------------------------------------------
+# Cascade delete
+# ---------------------------------------------------------------------------
+
+async def test_delete_session_removes_rows(store):
+    usage = {"input_tokens": 100}
+    await store.record_turn("sid-5", 1, None, usage, None)
+    await store.delete_session("sid-5")
+
+    agg = await store.get_session_usage("sid-5")
+    assert agg is None
+    count = await store.get_turn_count("sid-5")
+    assert count == 0
+
+
+async def test_delete_nonexistent_session_is_safe(store):
+    # Should not raise
+    await store.delete_session("no-such-session")
+
+
+# ---------------------------------------------------------------------------
+# sdk_total_cost_usd aggregation
+# ---------------------------------------------------------------------------
+
+async def test_sdk_cost_is_summed(store):
+    await store.record_turn("sid-6", 1, None, {}, 0.001)
+    await store.record_turn("sid-6", 2, None, {}, 0.002)
+
+    agg = await store.get_session_usage("sid-6")
+    assert abs(agg["sdk_total_cost_usd"] - 0.003) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Alternative SDK field name (cache_read_input_tokens)
+# ---------------------------------------------------------------------------
+
+async def test_cache_field_aliases_are_mapped(store):
+    usage = {
+        "input_tokens": 50,
+        "output_tokens": 20,
+        "cache_creation_input_tokens": 8,
+        "cache_read_input_tokens": 4,
+    }
+    await store.record_turn("sid-7", 1, None, usage, None)
+
+    agg = await store.get_session_usage("sid-7")
+    assert agg["cache_write_tokens"] == 8
+    assert agg["cache_read_tokens"] == 4

--- a/src/tests/test_pricing_config.py
+++ b/src/tests/test_pricing_config.py
@@ -1,0 +1,182 @@
+"""Unit tests for PricingConfig, ModelRates, and compute_cost (issue #1125)."""
+
+
+from src.config_manager import (
+    ModelRates,
+    PricingConfig,
+    compute_cost,
+    normalize_model_id,
+)
+
+_SONNET = "claude-sonnet-4-6"
+_OPUS = "claude-opus-4-7"
+_HAIKU = "claude-haiku-4-5"
+
+
+# ---------------------------------------------------------------------------
+# ModelRates
+# ---------------------------------------------------------------------------
+
+def test_model_rates_defaults():
+    r = ModelRates()
+    assert r.input == 0.0
+    assert r.output == 0.0
+    assert r.cache_write == 0.0
+    assert r.cache_read == 0.0
+
+
+def test_model_rates_round_trip():
+    r = ModelRates(input=3.0, output=15.0, cache_write=3.75, cache_read=0.30)
+    d = r.to_dict()
+    r2 = ModelRates.from_dict(d)
+    assert r2.input == r.input
+    assert r2.output == r.output
+    assert r2.cache_write == r.cache_write
+    assert r2.cache_read == r.cache_read
+
+
+# ---------------------------------------------------------------------------
+# PricingConfig defaults
+# ---------------------------------------------------------------------------
+
+def test_pricing_config_default_rates_exist():
+    p = PricingConfig()
+    assert _SONNET in p.rates
+    assert _OPUS in p.rates
+    assert _HAIKU in p.rates
+
+
+def test_pricing_config_default_model():
+    p = PricingConfig()
+    assert p.default_model == _SONNET
+
+
+def test_pricing_config_sonnet_rates_positive():
+    p = PricingConfig()
+    r = p.rates[_SONNET]
+    assert r.input > 0
+    assert r.output > 0
+    assert r.cache_write > 0
+    assert r.cache_read > 0
+
+
+# ---------------------------------------------------------------------------
+# PricingConfig round-trip serialisation
+# ---------------------------------------------------------------------------
+
+def test_pricing_config_round_trip():
+    p = PricingConfig()
+    d = p.to_dict()
+    p2 = PricingConfig.from_dict(d)
+
+    assert p2.default_model == p.default_model
+    for model_id, rates in p.rates.items():
+        assert model_id in p2.rates
+        r2 = p2.rates[model_id]
+        assert r2.input == rates.input
+        assert r2.output == rates.output
+
+
+def test_pricing_config_from_dict_merges_with_defaults():
+    """Custom rates in config must not erase built-in defaults for other models."""
+    data = {
+        "default_model": _SONNET,
+        "rates": {
+            "my-model": {"input": 1.0, "output": 5.0, "cache_write": 1.25, "cache_read": 0.10},
+        },
+    }
+    p = PricingConfig.from_dict(data)
+    assert "my-model" in p.rates
+    assert _SONNET in p.rates  # built-in default retained
+
+
+# ---------------------------------------------------------------------------
+# get_rates
+# ---------------------------------------------------------------------------
+
+def test_get_rates_known_model():
+    p = PricingConfig()
+    rates, known = p.get_rates(_SONNET)
+    assert rates is not None
+    assert known is True
+
+
+def test_get_rates_alias():
+    p = PricingConfig()
+    rates, known = p.get_rates("sonnet")
+    assert rates is not None
+    assert known is True
+
+
+def test_get_rates_unknown_model_falls_back():
+    p = PricingConfig()
+    rates, known = p.get_rates("some-future-model-xyz")
+    assert known is False
+    # Falls back to default_model (sonnet)
+    assert rates is not None
+
+
+def test_get_rates_none_model_falls_back():
+    p = PricingConfig()
+    rates, known = p.get_rates(None)
+    assert known is False
+    assert rates is not None
+
+
+# ---------------------------------------------------------------------------
+# compute_cost
+# ---------------------------------------------------------------------------
+
+def test_compute_cost_simple():
+    rates = ModelRates(input=3.0, output=15.0, cache_write=0.0, cache_read=0.0)
+    counts = {"input_tokens": 1_000_000, "output_tokens": 1_000_000}
+    cost = compute_cost(rates, counts)
+    assert abs(cost - 18.0) < 1e-9
+
+
+def test_compute_cost_cache_tokens():
+    rates = ModelRates(input=0.0, output=0.0, cache_write=3.75, cache_read=0.30)
+    counts = {"cache_write_tokens": 1_000_000, "cache_read_tokens": 1_000_000}
+    cost = compute_cost(rates, counts)
+    assert abs(cost - 4.05) < 1e-9
+
+
+def test_compute_cost_zero_tokens():
+    rates = ModelRates(input=3.0, output=15.0, cache_write=3.75, cache_read=0.30)
+    cost = compute_cost(rates, {})
+    assert cost == 0.0
+
+
+def test_compute_cost_partial_tokens():
+    rates = ModelRates(input=3.0, output=15.0, cache_write=0.0, cache_read=0.0)
+    counts = {"input_tokens": 500_000}
+    cost = compute_cost(rates, counts)
+    assert abs(cost - 1.5) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# normalize_model_id
+# ---------------------------------------------------------------------------
+
+def test_normalize_alias_sonnet():
+    assert normalize_model_id("sonnet") == _SONNET
+
+
+def test_normalize_alias_opus():
+    assert normalize_model_id("opus") == _OPUS
+
+
+def test_normalize_alias_haiku():
+    assert normalize_model_id("haiku") == _HAIKU
+
+
+def test_normalize_opusplan_alias():
+    assert normalize_model_id("opusplan") == _OPUS
+
+
+def test_normalize_unknown_returns_as_is():
+    assert normalize_model_id("some-custom-model") == "some-custom-model"
+
+
+def test_normalize_none_returns_none():
+    assert normalize_model_id(None) is None

--- a/src/tests/test_route_inventory.py
+++ b/src/tests/test_route_inventory.py
@@ -5,7 +5,7 @@ def test_route_count_unchanged():
     from src.web_server import create_app
     app = create_app()
     api_routes = [r for r in app.routes if hasattr(r, "methods")]
-    assert len(api_routes) == 131, (
-        f"Expected 131 routes (+1 edit-history from #1128, +3 audit from #1127), got {len(api_routes)}. "
+    assert len(api_routes) == 132, (
+        f"Expected 132 routes (+1 usage from #1125, +1 edit-history from #1128, +3 audit from #1127), got {len(api_routes)}. "
         "A route was added or removed."
     )

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -19,6 +19,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 
 from .analytics.audit_writer import AuditWriter
 from .analytics.database import AnalyticsDB
+from .analytics_store import AnalyticsStore
 from .application_service import ApplicationService
 from .event_queue import EventQueue
 from .message_parser import MessageParser, MessageProcessor
@@ -174,6 +175,8 @@ class ClaudeWebUI:
         _analytics_db_path = (data_dir or Path("data")) / "analytics.db"
         self._analytics_db = AnalyticsDB(_analytics_db_path)
         self._audit_writer = AuditWriter(self._analytics_db)
+        # Issue #1125: Per-session token usage store (shares AnalyticsDB connection)
+        self.analytics_store = AnalyticsStore(self._analytics_db)
         # Expose for router access
         self.analytics_db = self._analytics_db
         self.audit_writer = self._audit_writer
@@ -433,6 +436,19 @@ class ClaudeWebUI:
         except Exception:
             logger.exception("Error appending queue_update")
 
+    async def _broadcast_usage_update(self, session_id: str, usage: dict):
+        """Append usage_updated event to session poll queue (issue #1125)."""
+        try:
+            if session_id in self.session_queues:
+                self.session_queues[session_id].append({
+                    "type": "usage_updated",
+                    "session_id": session_id,
+                    "usage": usage,
+                    "timestamp": datetime.now(UTC).isoformat(),
+                })
+        except Exception:
+            logger.exception("Error appending usage_updated")
+
     def _cleanup_pending_permissions_for_session(self, session_id: str):
         """Clean up pending permissions for a specific session by auto-denying them"""
         self.permission_service.cleanup_pending_for_session(session_id)
@@ -468,6 +484,9 @@ class ClaudeWebUI:
         # callers of enqueue_message) emit real-time queue_update events to the WebUI.
         self.coordinator.set_enqueue_broadcast_callback(self._broadcast_queue_update)
 
+        # Issue #1125: Wire analytics usage broadcast callback
+        self.coordinator._usage_broadcast_callback = self._broadcast_usage_update
+
         # Issue #1050: Best-effort proxy image check on startup (informational only)
         from .config_manager import load_config
         from .logging_config import get_logger as _get_logger
@@ -491,6 +510,7 @@ class ClaudeWebUI:
         try:
             await self._analytics_db.initialize()
             self.coordinator.set_audit_writer(self._audit_writer)
+            self.coordinator.set_analytics_store(self.analytics_store)
             self.coordinator.session_manager.add_state_change_callback(
                 self._audit_writer.on_session_state_change
             )


### PR DESCRIPTION
## Summary
Resolves #1125

Implements per-session token and cost tracking with UI display.

## Changes Made

**Backend:**
- `src/analytics/database.py`: Added `turn_usage` and `session_usage` DDL tables to `AnalyticsDB` (shared connection from #1127)
- `src/analytics_store.py`: Rewritten to accept `AnalyticsDB` via dependency injection — delegates all SQLite I/O to shared connection/lock
- `src/session_coordinator.py`: Wires `AnalyticsStore` via `set_analytics_store()` setter (mirrors `set_audit_writer()`); records turn usage after each `ResultMessage`; lazy `turn_seq` rehydration from DB on restart
- `src/web_server.py`: Creates `AnalyticsStore(self._analytics_db)` and injects via `set_analytics_store()`; adds `_broadcast_usage_update()` for live frontend updates
- `src/routers/sessions.py`: `GET /api/sessions/{id}/usage` endpoint — computes cost from `PricingConfig` at query time; `rates_known=false` for unknown models
- `src/routers/config.py`: PUT /api/config accepts `pricing` section with per-model rate overrides
- `src/config_manager.py`: `ModelRates`, `PricingConfig` dataclasses; `compute_cost()`, `normalize_model_id()`, default rates for sonnet/opus/haiku

**Frontend:**
- `frontend/src/stores/usage.js`: Pinia store for usage data (`usageBySession` Map, live `usage_updated` event handling)
- `frontend/src/stores/polling.js`: Dispatches `usage_updated` events to usage store
- `frontend/src/stores/session.js`: Loads usage data on `selectSession()`
- `frontend/src/components/session/SessionCostBadge.vue`: Compact badge (`~$0.04 · 12k tokens`) with click-to-open breakdown popover (4 token categories, model, rates, SDK cost)
- `frontend/src/components/session/SessionInfoBar.vue`: Mounts `SessionCostBadge`
- `frontend/src/components/legion/MinionViewModal.vue`: Mounts `SessionCostBadge` in minion modal header

**Tests:**
- `src/tests/test_analytics_store.py`: 10 async unit tests (insert, idempotent replay, accumulation, cascade delete, SDK cost sum, cache field aliases)
- `src/tests/test_pricing_config.py`: 21 tests for `ModelRates`, `PricingConfig`, `compute_cost`, `normalize_model_id`
- `src/tests/test_route_inventory.py`: Updated route count to 132

## Testing
- All 32 unit tests pass
- Ruff clean (`uv run ruff check src/`)
- Frontend built successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)