### PR TITLE
chore: use BuildKit apt cache mounts in all Dockerfiles

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -31,7 +31,10 @@
 FROM debian:bookworm-slim
 
 # ---------- Layer 1: System packages (rarely changes) ----------
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
+    apt-get update && apt-get install -y --no-install-recommends \
     curl \
     ca-certificates \
     git \
@@ -39,29 +42,34 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     jq \
     gnupg \
     build-essential \
-    bubblewrap \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+    bubblewrap
 
 # ---------- Layer 2: Node.js 22 LTS via nodesource (rarely changes) ----------
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
-    && apt-get install -y --no-install-recommends nodejs \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs
 
 # ---------- Layer 3: Chromium for headless browser testing (rarely changes) ----------
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
+    apt-get update && apt-get install -y --no-install-recommends \
     chromium \
     chromium-driver \
-    fonts-noto-color-emoji \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+    fonts-noto-color-emoji
 
 # ---------- Layer 4: gh CLI (GitHub CLI) ----------
-RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
     && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
     | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-    && apt-get update && apt-get install -y --no-install-recommends gh \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+    && apt-get update && apt-get install -y --no-install-recommends gh
 
 # ---------- Layer 5: Non-root user ----------
 RUN useradd -m -s /bin/bash claude

--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -2,15 +2,17 @@ FROM debian:bookworm-slim
 
 # Install only what's needed: curl for downloading, git for claude operations,
 # ca-certificates for HTTPS, and basic tools claude might want to use
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
+    apt-get update && apt-get install -y --no-install-recommends \
     curl \
     ca-certificates \
     git \
     jq \
     bubblewrap \
     openssh-client \
-    ncat \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+    ncat
 
 # Create non-root user
 RUN useradd -m -s /bin/bash claude

--- a/src/docker/proxy/Dockerfile
+++ b/src/docker/proxy/Dockerfile
@@ -1,6 +1,9 @@
 FROM debian:bookworm-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
+    apt-get update && apt-get install -y --no-install-recommends \
     python3 \
     python3-pip \
     pipx \
@@ -13,8 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     jq \
     ca-certificates \
     ulogd2 \
-    openssh-client \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+    openssh-client
 
 # Install mitmproxy + httpx system-wide so uid 9999 can execute mitmdump
 # httpx is required by addon.py for REST-fetch secret resolution (issue #1134)


### PR DESCRIPTION
## Summary
Resolves #1152

Converts all apt-get `RUN` blocks across three Dockerfiles to use BuildKit cache mounts, so repeated `docker build --no-cache` runs reuse cached `.deb` packages from the host rather than re-downloading from Debian/upstream mirrors.

## Changes Made
- `docker/Dockerfile.dev`: 4 blocks updated (system packages, Node.js 22, Chromium, GitHub CLI)
- `src/docker/Dockerfile`: 1 block updated (base claude image)
- `src/docker/proxy/Dockerfile`: 1 block updated (proxy image)

Each block:
1. Adds `--mount=type=cache,target=/var/cache/apt,sharing=locked` and `--mount=type=cache,target=/var/lib/apt,sharing=locked`
2. Prepends `rm -f /etc/apt/apt.conf.d/docker-clean` to prevent the Debian base image from auto-purging downloaded `.deb` files after install
3. Removes the now-redundant `apt-get clean && rm -rf /var/lib/apt/lists/*` trailing cleanup (both paths are mount points, not image layers)

## Testing
- Cold build populates the host cache; subsequent `--no-cache` builds complete the apt step in seconds
- Image contents and sizes are unchanged — cache mounts are not committed to image layers
- Requires Docker with BuildKit enabled (default since Docker 20.10+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)