### PR TITLE
fix: deduplicate audit lifecycle events and add tool call tracking

### DIFF
--- a/src/analytics/audit_writer.py
+++ b/src/analytics/audit_writer.py
@@ -61,6 +61,8 @@ class AuditWriter:
         self._batch: list[tuple] = []
         self._flush_task: asyncio.Task | None = None
         self._running = False
+        # (state_name, is_processing) per session — skip identical consecutive events
+        self._session_state_cache: dict[str, tuple[str, bool]] = {}
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -90,15 +92,20 @@ class AuditWriter:
     # Hook: session state changes (from SessionManager)
     # ------------------------------------------------------------------
 
-    async def on_session_state_change(self, session_id: str, new_state: Any) -> None:
+    async def on_session_state_change(self, session_id: str, new_state: Any, is_processing: bool = False) -> None:
         """Called by SessionManager when a session changes state."""
         if self._db is None:
             return
         try:
             state_name = new_state.value if hasattr(new_state, "value") else str(new_state)
+            current = (state_name, is_processing)
+            if self._session_state_cache.get(session_id) == current:
+                return  # Nothing changed — skip duplicate
+            self._session_state_cache[session_id] = current
             # Close any open turn when session terminates
             if state_name in ("terminated", "error"):
                 self._tracker.on_result(session_id)
+                self._session_state_cache.pop(session_id, None)
             self._enqueue(
                 session_id=session_id,
                 project_id=None,
@@ -109,7 +116,7 @@ class AuditWriter:
                 status=state_name,
                 summary=_truncate(f"Session state → {state_name}"),
                 message_id=None,
-                extra={"state": state_name},
+                extra={"state": state_name, "is_processing": is_processing},
             )
         except Exception:
             logger.exception("AuditWriter.on_session_state_change error (non-fatal)")
@@ -139,6 +146,7 @@ class AuditWriter:
         msg: dict[str, Any],
     ) -> None:
         msg_type = msg.get("type", "")
+        stored_type = msg.get("_type", "")
         timestamp = msg.get("timestamp") or time.time()
         source_ts = msg.get("source_ts")
         message_id = msg.get("message_id")
@@ -151,8 +159,50 @@ class AuditWriter:
 
         turn_id = self._tracker.current_turn_id(session_id)
 
+        # ToolCallUpdate: authoritative source for tool lifecycle events (#1160)
+        if stored_type == "ToolCallUpdate":
+            data = msg.get("data", {})
+            tool_name = data.get("name")
+            tool_use_id = data.get("tool_use_id")
+            tc_status = data.get("status", "pending")
+            tool_input = data.get("input") or {}
+
+            if tc_status == "pending":
+                summary = _make_tool_summary(tool_name, tool_input)
+                extra = {"tool_name": tool_name, "tool_use_id": tool_use_id}
+                self._enqueue_with_ts(
+                    timestamp, source_ts, session_id, project_id, None, turn_id,
+                    "tool_call", tool_name, "started", summary, message_id, extra,
+                )
+            elif tc_status == "awaiting_permission":
+                summary = _truncate(f"Permission requested: {tool_name}")
+                extra = {"tool_name": tool_name, "tool_use_id": tool_use_id}
+                self._enqueue_with_ts(
+                    timestamp, source_ts, session_id, project_id, None, turn_id,
+                    "permission", tool_name, "requested", summary, message_id, extra,
+                )
+            elif tc_status == "denied":
+                summary = _truncate(f"Permission denied: {tool_name}")
+                extra = {"tool_name": tool_name, "tool_use_id": tool_use_id}
+                self._enqueue_with_ts(
+                    timestamp, source_ts, session_id, project_id, None, turn_id,
+                    "permission", tool_name, "denied", summary, message_id, extra,
+                )
+            elif tc_status in ("completed", "failed", "interrupted"):
+                is_error = tc_status != "completed"
+                audit_status = {"completed": "ok", "failed": "error", "interrupted": "interrupted"}[tc_status]
+                summary = _make_tool_result_summary(tool_name, {}, is_error)
+                extra = {"tool_name": tool_name, "tool_use_id": tool_use_id}
+                self._enqueue_with_ts(
+                    timestamp, source_ts, session_id, project_id, None, turn_id,
+                    "tool_call", tool_name, audit_status, summary, message_id, extra,
+                )
+            # running state: skip — covered by started/permission events
+            return
+
         # Map message type to event_type + summary
         if msg_type in ("tool_use",):
+            # Legacy type kept for backward compatibility with old JSONL files
             metadata = msg.get("metadata", {})
             tool_name = metadata.get("tool_name") or msg.get("tool_name")
             tool_input = metadata.get("tool_input") or {}
@@ -165,6 +215,7 @@ class AuditWriter:
             )
 
         elif msg_type in ("tool_result", "tool_error"):
+            # Legacy type kept for backward compatibility with old JSONL files
             metadata = msg.get("metadata", {})
             tool_name = metadata.get("tool_name") or msg.get("tool_name")
             is_error = msg_type == "tool_error" or metadata.get("is_error", False)

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -4306,7 +4306,7 @@ class SessionCoordinator:
         except Exception:
             logger.exception(f"Error notifying state change for {session_id}")
 
-    async def _on_session_manager_state_change(self, session_id: str, new_state: SessionState):
+    async def _on_session_manager_state_change(self, session_id: str, new_state: SessionState, is_processing: bool = False):
         """Handle state changes from session manager"""
         # logger.info(f"Received state change from session manager: {session_id} -> {new_state.value}")
         await self._notify_state_change(session_id, new_state)

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -1175,8 +1175,10 @@ class SessionManager:
 
     async def _notify_state_change_callbacks(self, session_id: str, new_state: SessionState):
         """Notify registered callbacks about state changes"""
+        session = self._active_sessions.get(session_id)
+        is_processing = session.is_processing if session else False
         for callback in self._state_change_callbacks:
             try:
-                await callback(session_id, new_state)
+                await callback(session_id, new_state, is_processing)
             except Exception as e:
                 logger.error(f"Error in state change callback: {e}")

--- a/src/tests/test_audit_writer.py
+++ b/src/tests/test_audit_writer.py
@@ -134,3 +134,177 @@ async def test_comm_hook():
     row = db.rows[0]
     assert row[6] == "comm"
     assert row[4] == "legion1"  # legion_id
+
+
+# ------------------------------------------------------------------
+# Issue #1159: is_processing deduplication tests
+# ------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_lifecycle_deduplication_skips_identical():
+    """Calling on_session_state_change twice with same args emits only one row."""
+    db = MockDB()
+    writer = AuditWriter(db)
+    writer.start()
+    state = type("S", (), {"value": "active"})()
+    await writer.on_session_state_change("s1", state)
+    await writer.on_session_state_change("s1", state)  # duplicate — must be skipped
+    await asyncio.sleep(0.3)
+    await writer.stop()
+    lifecycle_rows = [r for r in db.rows if r[6] == "lifecycle"]
+    assert len(lifecycle_rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_is_processing_change_emits_new_row():
+    """State unchanged but is_processing flip must produce a second row."""
+    db = MockDB()
+    writer = AuditWriter(db)
+    writer.start()
+    state = type("S", (), {"value": "active"})()
+    await writer.on_session_state_change("s1", state, is_processing=False)
+    await writer.on_session_state_change("s1", state, is_processing=True)
+    await asyncio.sleep(0.3)
+    await writer.stop()
+    lifecycle_rows = [r for r in db.rows if r[6] == "lifecycle"]
+    assert len(lifecycle_rows) == 2
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_extra_includes_is_processing():
+    """extra_json must contain is_processing field."""
+    import json
+    db = MockDB()
+    writer = AuditWriter(db)
+    writer.start()
+    state = type("S", (), {"value": "active"})()
+    await writer.on_session_state_change("s1", state, is_processing=True)
+    await asyncio.sleep(0.3)
+    await writer.stop()
+    row = db.rows[0]
+    extra = json.loads(row[11])  # extra_json column
+    assert extra.get("is_processing") is True
+
+
+# ------------------------------------------------------------------
+# Issue #1160: ToolCallUpdate audit event tests
+# ------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_tool_call_update_pending_emits_started():
+    """ToolCallUpdate with status=pending emits tool_call/started."""
+    db = MockDB()
+    writer = AuditWriter(db)
+    writer.start()
+    msg = {
+        "_type": "ToolCallUpdate",
+        "timestamp": 10.0,
+        "data": {
+            "tool_use_id": "tu1",
+            "name": "Edit",
+            "status": "pending",
+            "input": {"file_path": "foo.py"},
+        },
+    }
+    await writer.on_message_append("s1", "proj1", msg)
+    await asyncio.sleep(0.3)
+    await writer.stop()
+    tool_rows = [r for r in db.rows if r[6] == "tool_call"]
+    assert len(tool_rows) == 1
+    assert tool_rows[0][7] == "Edit"   # tool_name
+    assert tool_rows[0][8] == "started"  # status
+
+
+@pytest.mark.asyncio
+async def test_tool_call_update_completed_emits_ok():
+    """ToolCallUpdate with status=completed emits tool_call/ok."""
+    db = MockDB()
+    writer = AuditWriter(db)
+    writer.start()
+    msg = {
+        "_type": "ToolCallUpdate",
+        "timestamp": 20.0,
+        "data": {
+            "tool_use_id": "tu2",
+            "name": "Bash",
+            "status": "completed",
+            "input": {},
+        },
+    }
+    await writer.on_message_append("s1", "proj1", msg)
+    await asyncio.sleep(0.3)
+    await writer.stop()
+    tool_rows = [r for r in db.rows if r[6] == "tool_call"]
+    assert len(tool_rows) == 1
+    assert tool_rows[0][8] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_tool_call_update_awaiting_permission_emits_permission():
+    """ToolCallUpdate with status=awaiting_permission emits permission/requested."""
+    db = MockDB()
+    writer = AuditWriter(db)
+    writer.start()
+    msg = {
+        "_type": "ToolCallUpdate",
+        "timestamp": 30.0,
+        "data": {
+            "tool_use_id": "tu3",
+            "name": "Write",
+            "status": "awaiting_permission",
+            "input": {},
+        },
+    }
+    await writer.on_message_append("s1", "proj1", msg)
+    await asyncio.sleep(0.3)
+    await writer.stop()
+    perm_rows = [r for r in db.rows if r[6] == "permission"]
+    assert len(perm_rows) == 1
+    assert perm_rows[0][7] == "Write"   # tool_name
+    assert perm_rows[0][8] == "requested"
+
+
+@pytest.mark.asyncio
+async def test_tool_call_update_denied_emits_permission_denied():
+    """ToolCallUpdate with status=denied emits permission/denied."""
+    db = MockDB()
+    writer = AuditWriter(db)
+    writer.start()
+    msg = {
+        "_type": "ToolCallUpdate",
+        "timestamp": 40.0,
+        "data": {
+            "tool_use_id": "tu4",
+            "name": "Write",
+            "status": "denied",
+            "input": {},
+        },
+    }
+    await writer.on_message_append("s1", "proj1", msg)
+    await asyncio.sleep(0.3)
+    await writer.stop()
+    perm_rows = [r for r in db.rows if r[6] == "permission"]
+    assert len(perm_rows) == 1
+    assert perm_rows[0][8] == "denied"
+
+
+@pytest.mark.asyncio
+async def test_tool_call_update_running_emits_no_row():
+    """ToolCallUpdate with status=running is intentionally skipped (noise)."""
+    db = MockDB()
+    writer = AuditWriter(db)
+    writer.start()
+    msg = {
+        "_type": "ToolCallUpdate",
+        "timestamp": 50.0,
+        "data": {
+            "tool_use_id": "tu5",
+            "name": "Read",
+            "status": "running",
+            "input": {},
+        },
+    }
+    await writer.on_message_append("s1", "proj1", msg)
+    await asyncio.sleep(0.3)
+    await writer.stop()
+    assert len(db.rows) == 0


### PR DESCRIPTION
## Summary

Resolves #1159, Resolves #1160

Fixes two backend audit event capture bugs in `AuditWriter`:

1. **#1159 — Lifecycle event flood + missing is_processing**: The audit timeline was emitting a duplicate `active` event for every session metadata update (name change, latest message update, etc.) since `_notify_state_change_callbacks` fires for non-state reasons. `is_processing` transitions were invisible entirely.

2. **#1160 — Missing tool calls and permission events**: `_process_message` was checking for `msg_type == "tool_use"/"tool_result"` — types that are never stored in JSONL. Actual stored messages use `_type == "ToolCallUpdate"` with `data.status` for the full tool lifecycle.

## Changes Made

### `src/session_manager.py`
- `_notify_state_change_callbacks` now reads `session.is_processing` and passes it as a third arg to all registered callbacks (backward-compatible: existing callbacks accept it via `is_processing: bool = False`)

### `src/session_coordinator.py`
- `_on_session_manager_state_change` accepts the new `is_processing` parameter (ignored — coordinator uses its own state change path)

### `src/analytics/audit_writer.py`
- `_session_state_cache`: dict tracking `(state_name, is_processing)` per session — skips emitting if nothing changed (#1159 deduplication)
- `on_session_state_change`: accepts `is_processing: bool = False`; uses cache to skip duplicates; includes `is_processing` in `extra_json`; clears cache entry on terminate/error
- `_process_message`: handles `_type == "ToolCallUpdate"` as the authoritative source for tool lifecycle events:
  - `pending` → `tool_call/started`
  - `awaiting_permission` → `permission/requested`
  - `denied` → `permission/denied`
  - `completed` → `tool_call/ok`
  - `failed` → `tool_call/error`
  - `interrupted` → `tool_call/interrupted`
  - `running` → skipped (noise between started and completion)

### `src/tests/test_audit_writer.py`
- 8 new tests: deduplication, is_processing flip emits new row, is_processing in extra_json, ToolCallUpdate pending/completed/awaiting_permission/denied/running

## Testing

- `uv run pytest src/tests/test_audit_writer.py src/tests/test_audit_endpoints.py -v` → 22/22 passed
- `uv run ruff check src/analytics/audit_writer.py src/session_manager.py src/session_coordinator.py` → no violations
- Full suite: 1284 passed, 8 pre-existing failures (mitmproxy import error, unrelated)

## Screenshots

**Issue #1159 — Deduplicated lifecycle events (3 meaningful state transitions instead of flood):**

![is_processing states](https://github.com/EdanStarfire/claudecode_webui/assets/screenshot-1159)

**Issue #1160 — Tool calls and permission events now appear in audit timeline:**

Expanded turn shows: Read started, Edit permission requested, Read ok, Bash error, Write permission denied

🤖 Generated with [Claude Code](https://claude.com/claude-code)