### PR TITLE
fix: Audit type filter and project filter for lifecycle events

### DIFF
--- a/src/analytics/audit_query.py
+++ b/src/analytics/audit_query.py
@@ -135,6 +135,15 @@ class AuditQueryService:
 
         where = "WHERE " + " AND ".join(conditions)
 
+        # Build standalone-specific WHERE (adds event_types filter if provided)
+        standalone_conditions = list(conditions)
+        standalone_params: list[Any] = list(params)
+        if event_types:
+            placeholders = ",".join("?" for _ in event_types)
+            standalone_conditions.append(f"event_type IN ({placeholders})")
+            standalone_params.extend(event_types)
+        standalone_where = "WHERE " + " AND ".join(standalone_conditions)
+
         # Query turn-level aggregates
         turn_sql = (
             f"SELECT session_id, turn_id, project_id, "
@@ -156,11 +165,11 @@ class AuditQueryService:
         standalone_sql = (
             f"SELECT id, timestamp, source_ts, session_id, project_id, legion_id, "
             f"event_type, tool_name, status, summary, message_id, extra_json "
-            f"FROM audit_events {where} AND turn_id IS NULL "
+            f"FROM audit_events {standalone_where} AND turn_id IS NULL "
             f"ORDER BY timestamp DESC "
             f"LIMIT 100"
         )
-        standalone_rows = await self._db.execute_read(standalone_sql, params)
+        standalone_rows = await self._db.execute_read(standalone_sql, standalone_params)
 
         turns = [self._build_turn(r) for r in turn_rows]
         standalones = [self._enrich_row(r) for r in standalone_rows]

--- a/src/analytics/audit_writer.py
+++ b/src/analytics/audit_writer.py
@@ -92,7 +92,7 @@ class AuditWriter:
     # Hook: session state changes (from SessionManager)
     # ------------------------------------------------------------------
 
-    async def on_session_state_change(self, session_id: str, new_state: Any, is_processing: bool = False) -> None:
+    async def on_session_state_change(self, session_id: str, new_state: Any, is_processing: bool = False, project_id: str | None = None) -> None:
         """Called by SessionManager when a session changes state."""
         if self._db is None:
             return
@@ -108,7 +108,7 @@ class AuditWriter:
                 self._session_state_cache.pop(session_id, None)
             self._enqueue(
                 session_id=session_id,
-                project_id=None,
+                project_id=project_id,
                 legion_id=None,
                 turn_id=None,
                 event_type="lifecycle",

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -4306,7 +4306,7 @@ class SessionCoordinator:
         except Exception:
             logger.exception(f"Error notifying state change for {session_id}")
 
-    async def _on_session_manager_state_change(self, session_id: str, new_state: SessionState, is_processing: bool = False):
+    async def _on_session_manager_state_change(self, session_id: str, new_state: SessionState, is_processing: bool = False, project_id: str | None = None):
         """Handle state changes from session manager"""
         # logger.info(f"Received state change from session manager: {session_id} -> {new_state.value}")
         await self._notify_state_change(session_id, new_state)

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -1177,8 +1177,9 @@ class SessionManager:
         """Notify registered callbacks about state changes"""
         session = self._active_sessions.get(session_id)
         is_processing = session.is_processing if session else False
+        project_id = session.project_id if session else None
         for callback in self._state_change_callbacks:
             try:
-                await callback(session_id, new_state, is_processing)
+                await callback(session_id, new_state, is_processing, project_id=project_id)
             except Exception as e:
                 logger.error(f"Error in state change callback: {e}")

--- a/src/tests/test_audit_query.py
+++ b/src/tests/test_audit_query.py
@@ -113,3 +113,33 @@ def test_parse_sparkline():
 
 def test_parse_sparkline_empty():
     assert _parse_sparkline("") == []
+
+
+# ------------------------------------------------------------------
+# Issue #1163: event_types filter must apply to standalones in query_turns
+# ------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_issue_1163_event_types_filter_applied_to_standalones(db):
+    """query_turns with event_types filter excludes non-matching standalone events."""
+    ts = time.time()
+    # Insert a lifecycle standalone (no turn_id)
+    await _insert(db, event_type="lifecycle", turn_id=None, tool_name=None, ts=ts - 3)
+    # Insert a comm standalone (no turn_id)
+    await _insert(db, event_type="comm", turn_id=None, tool_name=None, ts=ts - 2)
+    qs = AuditQueryService(db)
+    # Filter to only "comm" events
+    result = await qs.query_turns(since=ts - 60, event_types=["comm"])
+    assert len(result["standalones"]) == 1
+    assert result["standalones"][0]["event_type"] == "comm"
+
+
+@pytest.mark.asyncio
+async def test_issue_1163_no_event_types_filter_returns_all_standalones(db):
+    """query_turns without event_types returns all standalone events."""
+    ts = time.time()
+    await _insert(db, event_type="lifecycle", turn_id=None, tool_name=None, ts=ts - 3)
+    await _insert(db, event_type="comm", turn_id=None, tool_name=None, ts=ts - 2)
+    qs = AuditQueryService(db)
+    result = await qs.query_turns(since=ts - 60)
+    assert len(result["standalones"]) == 2

--- a/src/tests/test_audit_writer.py
+++ b/src/tests/test_audit_writer.py
@@ -380,3 +380,36 @@ async def test_issue_1162_on_comm_stores_comm_summary():
     summary = row[9]
     assert "→" in summary
     assert "please review the PR" in summary
+
+
+# ------------------------------------------------------------------
+# Issue #1164: lifecycle events must store project_id
+# ------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_issue_1164_lifecycle_event_stores_project_id():
+    """on_session_state_change with project_id stores it in the row."""
+    db = MockDB()
+    writer = AuditWriter(db)
+    writer.start()
+    state = type("S", (), {"value": "active"})()
+    await writer.on_session_state_change("s1", state, is_processing=False, project_id="proj-123")
+    await asyncio.sleep(0.3)
+    await writer.stop()
+    assert len(db.rows) == 1
+    row = db.rows[0]
+    assert row[3] == "proj-123"  # project_id column index 3
+
+
+@pytest.mark.asyncio
+async def test_issue_1164_lifecycle_event_without_project_id_stores_none():
+    """on_session_state_change without project_id stores None (no regression)."""
+    db = MockDB()
+    writer = AuditWriter(db)
+    writer.start()
+    state = type("S", (), {"value": "active"})()
+    await writer.on_session_state_change("s1", state)
+    await asyncio.sleep(0.3)
+    await writer.stop()
+    assert len(db.rows) == 1
+    assert db.rows[0][3] is None  # project_id remains None when not supplied


### PR DESCRIPTION
## Summary

Resolves #1163
Resolves #1164

Fixes two audit filter bugs that caused filters to silently have no effect.

## Changes Made

**#1163 — Type filter toggle has no effect on standalones:**
- `src/analytics/audit_query.py`: `query_turns()` now builds a separate `standalone_conditions`/`standalone_params` list that includes `event_type IN (...)` when `event_types` is provided. The main turn aggregation query intentionally remains unfiltered (it groups by turn_id; filtering by event_type there would hide entire turns).

**#1164 — Project filter hides all lifecycle entries:**
- `src/session_manager.py`: `_notify_state_change_callbacks()` now extracts `project_id = session.project_id if session else None` and passes it as a keyword arg to all callbacks.
- `src/session_coordinator.py`: `_on_session_manager_state_change()` updated to accept `project_id: str | None = None`.
- `src/analytics/audit_writer.py`: `on_session_state_change()` updated to accept and use `project_id: str | None = None` instead of hardcoded `None`.

## Testing

- Unit tests added: `test_issue_1163_event_types_filter_applied_to_standalones`, `test_issue_1163_no_event_types_filter_returns_all_standalones` in `test_audit_query.py`
- Unit tests added: `test_issue_1164_lifecycle_event_stores_project_id`, `test_issue_1164_lifecycle_event_without_project_id_stores_none` in `test_audit_writer.py`
- All 1288 existing tests pass (8 pre-existing mitmproxy failures unrelated to this change)
- Manual verification: toggling Lifecycle chip off removes standalone lifecycle rows; selecting a project shows lifecycle entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)