### PR TITLE
fix: convert proxy addon load() to sync and add running() for async init

### DIFF
--- a/src/docker/proxy/addon.py
+++ b/src/docker/proxy/addon.py
@@ -330,8 +330,8 @@ class ProxyAddon:
             socks5_path = Path(LOG_DIR) / SOCKS5_LOG_FILENAME
             self._socks5_log_file = open(socks5_path, "a", buffering=1)  # noqa: SIM115
 
-    async def load(self, loader) -> None:
-        """Read session credentials and fetch secrets from WebUI resolve endpoint."""
+    def load(self, loader) -> None:
+        """Read session config files. Secret fetch happens in running()."""
         try:
             self._session_token = Path(SESSION_TOKEN_PATH).read_text().strip()
             self._session_id = Path(SESSION_ID_PATH).read_text().strip()
@@ -343,6 +343,10 @@ class ProxyAddon:
         self.allowed_domains = set(data.get("domains", []))
         ctx.log.info(f"[proxy] Loaded {len(self.allowed_domains)} allowed domains")
 
+    async def running(self) -> None:
+        """Fetch secrets after proxy is fully started (async-capable hook)."""
+        if not self._session_id:
+            return  # load() didn't complete successfully
         try:
             self._records = await self._fetch_resolve()
             self._refresh_locks = {ph: asyncio.Lock() for ph in self._records}

--- a/src/tests/test_proxy_addon_1175.py
+++ b/src/tests/test_proxy_addon_1175.py
@@ -1,0 +1,77 @@
+"""
+Regression tests for issue #1175 — ProxyAddon.load() must be synchronous.
+
+mitmproxy calls load() from a sync context; async def load() raises
+AddonManagerError at startup. These tests guard against that regression.
+
+mitmproxy is not available in the test environment, so we patch the import
+before importing addon.py.
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+def _install_mitmproxy_stubs():
+    """Install minimal mitmproxy stubs (non-spec MagicMock-safe HTTPFlow)."""
+    mitmproxy = types.ModuleType("mitmproxy")
+    ctx_mod = types.ModuleType("mitmproxy.ctx")
+    ctx_obj = MagicMock()
+    ctx_mod.ctx = ctx_obj
+
+    http_mod = types.ModuleType("mitmproxy.http")
+
+    class _HTTPFlow:
+        def __init__(self, host=""):
+            self.request = MagicMock()
+            self.request.pretty_host = host
+            self.request.path = "/test"
+            self.request.method = "GET"
+            self.request.scheme = "https"
+            self.request.port = 443
+            self.request.headers = {}
+            self.response = None
+            self.client_conn = MagicMock()
+            self.client_conn.peername = ("127.0.0.1", 12345)
+            self.metadata = {}
+
+    http_mod.HTTPFlow = _HTTPFlow
+    http_mod.Response = MagicMock()
+
+    tcp_mod = types.ModuleType("mitmproxy.tcp")
+    tcp_mod.TCPFlow = MagicMock
+
+    mitmproxy.ctx = ctx_obj
+    mitmproxy.http = http_mod
+    mitmproxy.tcp = tcp_mod
+
+    for mod_name, mod in [
+        ("mitmproxy", mitmproxy),
+        ("mitmproxy.ctx", ctx_mod),
+        ("mitmproxy.http", http_mod),
+        ("mitmproxy.tcp", tcp_mod),
+    ]:
+        sys.modules.setdefault(mod_name, mod)
+
+    return ctx_obj
+
+
+@pytest.fixture(scope="module")
+def proxy_addon_class():
+    _install_mitmproxy_stubs()
+    from src.docker.proxy.addon import ProxyAddon  # noqa: PLC0415
+    return ProxyAddon
+
+
+def test_load_is_not_async(proxy_addon_class):
+    """load() must be sync — mitmproxy calls it from a sync context (issue #1175)."""
+    import inspect  # noqa: PLC0415
+    assert not inspect.iscoroutinefunction(proxy_addon_class.load)
+
+
+def test_running_is_async(proxy_addon_class):
+    """running() must be async to safely call _fetch_resolve."""
+    import inspect  # noqa: PLC0415
+    assert inspect.iscoroutinefunction(proxy_addon_class.running)

--- a/src/tests/test_proxy_credentials_1051.py
+++ b/src/tests/test_proxy_credentials_1051.py
@@ -382,8 +382,7 @@ def test_addon_access_log_credential_name_not_value(tmp_path):
 # 14. Graceful no-op when session token files absent
 # ---------------------------------------------------------------------------
 
-@pytest.mark.asyncio
-async def test_addon_load_no_session_files_leaves_records_empty():
+def test_addon_load_no_session_files_leaves_records_empty():
     """Issue #1134: load() is a no-op and leaves _records empty when session files absent."""
     _ensure_mitmproxy_stubs()
     from src.docker.proxy import addon as addon_mod
@@ -400,6 +399,6 @@ async def test_addon_load_no_session_files_leaves_records_empty():
         mock_path = MagicMock()
         mock_path.read_text.side_effect = FileNotFoundError("no file")
         mock_path_cls.return_value = mock_path
-        await f.load(None)
+        f.load(None)
 
     assert f._records == {}


### PR DESCRIPTION
## Summary
Resolves #1175

mitmproxy calls `load()` from a synchronous context at startup. The previous `async def load()` caused `AddonManagerError: Async handler load (<ProxyAddon>) cannot be called from sync context`, crashing the proxy sidecar immediately.

## Changes Made
- `src/docker/proxy/addon.py`: Convert `load()` from `async def` to `def` — retains only synchronous file reads (session token, session ID, allowlist domains)
- `src/docker/proxy/addon.py`: Add `async def running()` immediately after `load()` — moves `await self._fetch_resolve()` here, guarded by `if not self._session_id` in case `load()` failed
- `src/tests/test_proxy_addon_1175.py`: New regression tests asserting `load` is not a coroutine function and `running` is
- `src/tests/test_proxy_credentials_1051.py`: Update `test_addon_load_no_session_files_leaves_records_empty` to call `f.load(None)` synchronously (no longer `await`-able)

## Testing
- All 1305 tests pass with zero failures
- Ruff linting passes on all modified files
- New tests guard the hook signatures explicitly

🤖 Generated with [Claude Code](https://claude.com/claude-code)