### PR TITLE
fix: proxy container missing session_token/session_id mounts

### DIFF
--- a/src/docker/claude-docker
+++ b/src/docker/claude-docker
@@ -240,6 +240,19 @@ if [ -n "$PROXY_IMAGE" ]; then
         SSH_PROXY_MOUNTS="$SSH_PROXY_MOUNTS -v ${CLAUDE_DOCKER_SSH_SHARED_DIR}:/run/ssh"
     fi
 
+    # Issue #1179: Proxy-only mounts (e.g., session_token, session_id) — kept
+    # separate from CLAUDE_DOCKER_EXTRA_MOUNTS (agent-only).
+    PROXY_EXTRA_MOUNT_FLAGS=""
+    if [ -n "${CLAUDE_DOCKER_PROXY_EXTRA_MOUNTS:-}" ]; then
+        IFS=',' read -ra PROXY_MOUNTS <<< "$CLAUDE_DOCKER_PROXY_EXTRA_MOUNTS"
+        for mount in "${PROXY_MOUNTS[@]}"; do
+            mount="$(echo "$mount" | xargs)"
+            if [ -n "$mount" ]; then
+                PROXY_EXTRA_MOUNT_FLAGS="$PROXY_EXTRA_MOUNT_FLAGS -v $mount"
+            fi
+        done
+    fi
+
     docker run -d \
         --name "$PROXY_NAME" \
         --cap-add NET_ADMIN \
@@ -249,6 +262,7 @@ if [ -n "$PROXY_IMAGE" ]; then
         ${PROXY_LOG_DIR:+-v "$PROXY_LOG_DIR:/var/log/proxy"} \
         $PROXY_ALLOWLIST_FLAGS \
         $SSH_PROXY_MOUNTS \
+        $PROXY_EXTRA_MOUNT_FLAGS \
         "$PROXY_IMAGE" >/dev/null
 
     # Wait up to 30s for the proxy to be fully ready.

--- a/src/docker_utils.py
+++ b/src/docker_utils.py
@@ -90,6 +90,8 @@ def resolve_docker_cli_path(
     delivery_envs: dict[str, str] | None = None,
     # Issue #1053: Dynamic allowlist override
     proxy_allowlist_file: str | None = None,
+    # Issue #1179: Proxy-sidecar-only mounts (session_token, session_id, etc.)
+    docker_proxy_extra_mounts: list[str] | None = None,
 ) -> tuple[str, dict[str, str]]:
     """
     Resolve the cli_path and environment variables for Docker mode.
@@ -109,6 +111,8 @@ def resolve_docker_cli_path(
         delivery_envs: Dict of env_var_name → placeholder string. Passed inline to
                        claude-docker via CLAUDE_DOCKER_DELIVERY_ENVS (JSON). The wrapper
                        forwards these as -e flags to the agent container.
+        docker_proxy_extra_mounts: Additional volume mount specs applied exclusively to the
+                                   proxy sidecar container (never the agent container).
 
     Returns:
         Tuple of (cli_path_string, env_vars_dict)
@@ -141,6 +145,9 @@ def resolve_docker_cli_path(
 
     if proxy_allowlist_file:
         env_vars["CLAUDE_DOCKER_PROXY_ALLOWLIST_FILE"] = proxy_allowlist_file
+
+    if docker_proxy_extra_mounts:
+        env_vars["CLAUDE_DOCKER_PROXY_EXTRA_MOUNTS"] = ",".join(docker_proxy_extra_mounts)
 
     return wrapper_path, env_vars
 

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -1201,6 +1201,9 @@ class SessionCoordinator:
                 docker_data_dir = str(session_dir / "docker_claude_data")
                 # Issue #759: Mount session memory dir into Docker container (RW, at host path)
                 extra_mounts = list(effective_config.docker_extra_mounts or [])
+                # Issue #1179: Proxy-sidecar-only mounts (session_token, session_id).
+                # Agent mounts go in extra_mounts; proxy mounts go here.
+                proxy_extra_mounts: list[str] = []
                 if effective_config.auto_memory_mode == "session":
                     memory_dir = session_dir / "memory"
                     memory_dir.mkdir(exist_ok=True)
@@ -1334,17 +1337,18 @@ class SessionCoordinator:
 
                     # Issue #827 / #1134: Write per-session token + session_id files for proxy.
                     # Proxy calls GET /api/sessions/{id}/secrets/resolve with this Bearer token.
+                    # Issue #1179: These mounts target /etc/proxy/ — proxy sidecar only, not agent.
                     session_token = getattr(session_info, "secret_fetch_token", None)
                     if session_token:
                         token_path = tmp_dir / "session_token"
                         token_path.write_text(session_token)
                         os.chmod(token_path, 0o600)
-                        extra_mounts.append(f"{token_path}:/etc/proxy/session_token:ro")
+                        proxy_extra_mounts.append(f"{token_path}:/etc/proxy/session_token:ro")
 
                         session_id_path = tmp_dir / "session_id"
                         session_id_path.write_text(session_id)
                         os.chmod(session_id_path, 0o600)
-                        extra_mounts.append(f"{session_id_path}:/etc/proxy/session_id:ro")
+                        proxy_extra_mounts.append(f"{session_id_path}:/etc/proxy/session_id:ro")
 
                 # Issue #1089: Deduplicate mounts by container destination path (first-seen wins).
                 # Format: "host_path:container_path[:options]" — extract the second colon-delimited field.
@@ -1357,6 +1361,17 @@ class SessionCoordinator:
                         _seen_container_paths.add(_container_path)
                         _deduped_mounts.append(_mount)
                 extra_mounts = _deduped_mounts
+
+                # Issue #1179: Deduplicate proxy_extra_mounts independently (same strategy).
+                _seen_proxy_paths: set[str] = set()
+                _deduped_proxy_mounts: list[str] = []
+                for _mount in proxy_extra_mounts:
+                    _parts = _mount.split(":", 2)
+                    _container_path = _parts[1] if len(_parts) >= 2 else _mount
+                    if _container_path not in _seen_proxy_paths:
+                        _seen_proxy_paths.add(_container_path)
+                        _deduped_proxy_mounts.append(_mount)
+                proxy_extra_mounts = _deduped_proxy_mounts
 
                 effective_cli_path, docker_env_vars = resolve_docker_cli_path(
                     docker_image=effective_config.docker_image,
@@ -1373,6 +1388,8 @@ class SessionCoordinator:
                     # Issue #1134: pass delivery env vars inline (no file); keep allowlist path
                     delivery_envs=delivery_envs or None,
                     proxy_allowlist_file=proxy_allowlist_file,
+                    # Issue #1179: Proxy-sidecar-only mounts
+                    docker_proxy_extra_mounts=proxy_extra_mounts or None,
                 )
                 # Issue #1052: Tell claude-docker where the two SSH tmpdirs live.
                 # key_dir  → proxy-only mount at /run/ssh-private:ro

--- a/src/tests/test_proxy_lifecycle_1050.py
+++ b/src/tests/test_proxy_lifecycle_1050.py
@@ -195,3 +195,131 @@ def test_resolve_docker_cli_path_proxy_image_none():
     """resolve_docker_cli_path with proxy_image=None does not set CLAUDE_DOCKER_PROXY_IMAGE."""
     _, env = resolve_docker_cli_path(proxy_image=None)
     assert "CLAUDE_DOCKER_PROXY_IMAGE" not in env
+
+
+# ---------------------------------------------------------------------------
+# 7. Issue #1179 — proxy_extra_mounts plumbing
+# ---------------------------------------------------------------------------
+
+def test_proxy_extra_mounts_env_var_set_when_provided():
+    """docker_proxy_extra_mounts list is joined and set as CLAUDE_DOCKER_PROXY_EXTRA_MOUNTS."""
+    _, env = resolve_docker_cli_path(
+        docker_proxy_extra_mounts=["/host/a:/etc/proxy/a:ro", "/host/b:/etc/proxy/b:ro"],
+        proxy_image="claude-proxy:local",
+    )
+    assert env.get("CLAUDE_DOCKER_PROXY_EXTRA_MOUNTS") == "/host/a:/etc/proxy/a:ro,/host/b:/etc/proxy/b:ro"
+
+
+def test_proxy_extra_mounts_env_var_unset_when_empty():
+    """CLAUDE_DOCKER_PROXY_EXTRA_MOUNTS is absent when docker_proxy_extra_mounts is None or []."""
+    _, env = resolve_docker_cli_path(docker_proxy_extra_mounts=None)
+    assert "CLAUDE_DOCKER_PROXY_EXTRA_MOUNTS" not in env
+
+    _, env = resolve_docker_cli_path(docker_proxy_extra_mounts=[])
+    assert "CLAUDE_DOCKER_PROXY_EXTRA_MOUNTS" not in env
+
+
+def test_proxy_extra_mounts_does_not_leak_into_agent_mounts():
+    """Agent and proxy mount env vars are populated independently without cross-contamination."""
+    _, env = resolve_docker_cli_path(
+        docker_extra_mounts=["/agent/x:/agent/x"],
+        docker_proxy_extra_mounts=["/host/token:/etc/proxy/session_token:ro"],
+    )
+    assert env.get("CLAUDE_DOCKER_EXTRA_MOUNTS") == "/agent/x:/agent/x"
+    assert env.get("CLAUDE_DOCKER_PROXY_EXTRA_MOUNTS") == "/host/token:/etc/proxy/session_token:ro"
+
+
+@pytest.mark.asyncio
+async def test_session_coordinator_routes_token_to_proxy_only(tmp_path):
+    """
+    session_token and session_id mount specs land in CLAUDE_DOCKER_PROXY_EXTRA_MOUNTS,
+    not CLAUDE_DOCKER_EXTRA_MOUNTS, when docker_proxy_enabled=True.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from src.session_coordinator import SessionCoordinator
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    coordinator = SessionCoordinator(data_dir=tmp_path)
+    await coordinator.initialize()
+
+    project = await coordinator.project_manager.create_project(
+        name="Proxy Token Test",
+        working_directory=str(workspace),
+    )
+
+    config = SessionConfig(
+        docker_enabled=True,
+        docker_proxy_enabled=True,
+    )
+    session_id = await coordinator.create_session(
+        session_id="test-1179-token",
+        project_id=project.project_id,
+        config=config,
+    )
+
+    captured: dict = {}
+
+    def fake_resolve(**kwargs):
+        captured.update(kwargs)
+        return ("/mock/cli", {})
+
+    mock_sdk = MagicMock()
+    mock_sdk.is_running.return_value = False
+    mock_sdk.start = AsyncMock(return_value=True)
+    mock_sdk.auto_approval_callback = None
+
+    coordinator._sdk_factory = lambda **kwargs: mock_sdk
+
+    with patch("src.docker_utils.resolve_docker_cli_path", side_effect=fake_resolve):
+        await coordinator.start_session(session_id)
+
+    agent_mounts: list[str] = captured.get("docker_extra_mounts") or []
+    proxy_mounts: list[str] = captured.get("docker_proxy_extra_mounts") or []
+
+    assert any("/etc/proxy/session_token" in m for m in proxy_mounts), (
+        f"session_token not found in proxy mounts: {proxy_mounts}"
+    )
+    assert any("/etc/proxy/session_id" in m for m in proxy_mounts), (
+        f"session_id not found in proxy mounts: {proxy_mounts}"
+    )
+    assert not any("/etc/proxy/session_token" in m for m in agent_mounts), (
+        f"session_token leaked into agent mounts: {agent_mounts}"
+    )
+    assert not any("/etc/proxy/session_id" in m for m in agent_mounts), (
+        f"session_id leaked into agent mounts: {agent_mounts}"
+    )
+
+
+def test_proxy_extra_mounts_dedup():
+    """
+    Coordinator dedup logic: when proxy_extra_mounts has duplicate container destinations,
+    first-seen wins. Verify the algorithm mirrors the agent-mounts dedup (issue #1089).
+    """
+    # Simulate the coordinator's proxy_extra_mounts dedup algorithm verbatim.
+    proxy_extra_mounts = [
+        "/host/path1:/etc/proxy/session_token:ro",
+        "/host/path2:/etc/proxy/session_token:ro",  # duplicate container dest
+        "/host/session_id:/etc/proxy/session_id:ro",
+    ]
+
+    _seen: set[str] = set()
+    _deduped: list[str] = []
+    for _mount in proxy_extra_mounts:
+        _parts = _mount.split(":", 2)
+        _container_path = _parts[1] if len(_parts) >= 2 else _mount
+        if _container_path not in _seen:
+            _seen.add(_container_path)
+            _deduped.append(_mount)
+
+    assert len(_deduped) == 2
+    assert _deduped[0] == "/host/path1:/etc/proxy/session_token:ro"
+    assert _deduped[1] == "/host/session_id:/etc/proxy/session_id:ro"
+
+    # Verify the deduped list translates correctly through resolve_docker_cli_path.
+    _, env = resolve_docker_cli_path(docker_proxy_extra_mounts=_deduped)
+    val = env.get("CLAUDE_DOCKER_PROXY_EXTRA_MOUNTS", "")
+    assert "/host/path1:/etc/proxy/session_token:ro" in val
+    assert "/host/path2:/etc/proxy/session_token:ro" not in val


### PR DESCRIPTION
## Summary
Resolves #1179

The proxy sidecar was crashing on startup with "Session files not found" because `session_token` and `session_id` mount specs were appended to `extra_mounts` (which feeds `CLAUDE_DOCKER_EXTRA_MOUNTS` — agent container only) and never reached the proxy sidecar's `docker run -d` invocation.

## Changes Made

- **`src/session_coordinator.py`**: Initialize a separate `proxy_extra_mounts` list alongside `extra_mounts`. Move `session_token` and `session_id` appends into it. Apply the same first-seen-wins dedup (mirrors issue #1089 logic). Pass as `docker_proxy_extra_mounts` to `resolve_docker_cli_path()`.

- **`src/docker_utils.py`**: Add `docker_proxy_extra_mounts: list[str] | None = None` parameter to `resolve_docker_cli_path()`. When non-empty, set `CLAUDE_DOCKER_PROXY_EXTRA_MOUNTS` env var (comma-joined, mirrors `CLAUDE_DOCKER_EXTRA_MOUNTS` pattern). Update docstring.

- **`src/docker/claude-docker`**: Inside the `if [ -n "$PROXY_IMAGE" ]` block, parse `CLAUDE_DOCKER_PROXY_EXTRA_MOUNTS` into `PROXY_EXTRA_MOUNT_FLAGS` (same `IFS=','` + xargs trim pattern as the existing agent block). Append to the proxy `docker run -d` invocation.

- **`src/tests/test_proxy_lifecycle_1050.py`**: 5 new tests — env var set/unset, no agent/proxy cross-contamination, coordinator routing (integration-ish with patched `resolve_docker_cli_path`), and dedup correctness.

## Testing

- `uv run pytest src/tests/ -v` — 1310 passed, 0 failures
- `bash -n src/docker/claude-docker` — syntax OK
- `uv run ruff check --fix src/docker_utils.py src/session_coordinator.py src/tests/test_proxy_lifecycle_1050.py` — zero violations

## How to Verify Manually

1. Start backend with `--port 8001 --debug-all`
2. Create a session with `docker_proxy_enabled: true` and at least one assigned secret
3. Start session — proxy logs should show credentials loaded, no "Session files not found" error
4. `docker exec claude-proxy-<pid> cat /etc/proxy/session_token` should return token content
5. Session should reach ACTIVE state within 30s proxy ready timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)