### PR TITLE
fix: add --add-host flag so proxy resolves host.docker.internal on Linux

### DIFF
--- a/src/docker/claude-docker
+++ b/src/docker/claude-docker
@@ -256,6 +256,7 @@ if [ -n "$PROXY_IMAGE" ]; then
     docker run -d \
         --name "$PROXY_NAME" \
         --cap-add NET_ADMIN \
+        --add-host=host.docker.internal:host-gateway \
         --sysctl net.ipv4.ip_forward=1 \
         --sysctl net.ipv4.conf.lo.accept_local=1 \
         -v "$PROXY_CERTS:/var/lib/mitmproxy" \


### PR DESCRIPTION
## Summary

Resolves #1184

On Linux, Docker does not inject `host.docker.internal` into container `/etc/hosts` automatically (unlike Docker Desktop on Mac/Windows). The proxy sidecar's `addon.py` defaults to `http://host.docker.internal:8000` to reach the host WebUI secrets endpoint. Without the hosts entry, every startup attempt fails with:

```
ConnectError(gaierror(-3, 'Temporary failure in name resolution'))
[proxy] Failed to fetch secrets for session <id>: [Errno -3] Temporary failure in name resolution
ERROR: mitmdump (PID 66) exited during startup.
```

## Changes Made

- Added `--add-host=host.docker.internal:host-gateway \` to the proxy `docker run -d` block in `src/docker/claude-docker`, inserted between `--cap-add NET_ADMIN \` and `--sysctl net.ipv4.ip_forward=1 \`

`host-gateway` (Docker 20.10+) resolves to the Docker bridge gateway IP and writes a static `/etc/hosts` entry — no DNS query is involved, so the proxy container's CoreDNS default-deny UDP OUTPUT policy is bypassed entirely. TCP egress from the proxy to the host is already permitted for uid 9999 (mitmdump) via `entrypoint.sh` line 168.

On Mac/Windows (Docker Desktop), `host.docker.internal` is already injected automatically; the `--add-host` flag is a no-op on those platforms.

## Testing

- `bash -n src/docker/claude-docker` — syntax check passes (exit 0)
- `uv run pytest src/tests/ -v` — 1311 passed, 0 failures
- **No unit test is feasible for this change**: there is no test infrastructure for the `claude-docker` bash wrapper. A `bash -n` syntax check is the accepted automated verification per project precedent (see prior fixes #1178, #1180, #1182). Manual Linux smoke test (proxy session launch, `docker logs`, `/etc/hosts` inspection) is documented in the issue plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)