### PR TITLE
fix: mount SSH key dir rw so entrypoint can wipe key after ssh-add

### DIFF
--- a/src/docker/claude-docker
+++ b/src/docker/claude-docker
@@ -233,7 +233,7 @@ if [ -n "$PROXY_IMAGE" ]; then
     # in the shared dir that both containers access at /run/ssh.
     SSH_PROXY_MOUNTS=""
     if [ -n "${CLAUDE_DOCKER_SSH_KEY_DIR:-}" ] && [ -d "${CLAUDE_DOCKER_SSH_KEY_DIR:-}" ]; then
-        SSH_PROXY_MOUNTS="$SSH_PROXY_MOUNTS -v ${CLAUDE_DOCKER_SSH_KEY_DIR}:/run/ssh-private:ro"
+        SSH_PROXY_MOUNTS="$SSH_PROXY_MOUNTS -v ${CLAUDE_DOCKER_SSH_KEY_DIR}:/run/ssh-private"
     fi
     if [ -n "${CLAUDE_DOCKER_SSH_SHARED_DIR:-}" ]; then
         mkdir -p "${CLAUDE_DOCKER_SSH_SHARED_DIR}"


### PR DESCRIPTION
## Summary
- Remove `:ro` flag from SSH key dir bind-mount in `src/docker/claude-docker`
- Proxy entrypoint can now delete the private key file immediately after `ssh-add`, reducing the window during which the key exists on disk inside the container

## Changes
Single-line change in `src/docker/claude-docker` (line 236): removed `:ro` from the `-v` mount flag for `CLAUDE_DOCKER_SSH_KEY_DIR`.

## Test plan
- [x] `bash -n src/docker/claude-docker` — syntax check passes
- [x] `uv run pytest src/tests/ -v` — 1317 tests pass
- No unit test added: the change is a shell flag removal with no code path to unit test; integration coverage requires a running Docker environment

Resolves #1193

🤖 Generated with [Claude Code](https://claude.com/claude-code)