### PR TITLE
fix: create ssh-wrapper in proxy entrypoint to route port-22 SSH via SOCKS5 and fix known_hosts

### DIFF
--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -12,7 +12,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     jq \
     bubblewrap \
     openssh-client \
-    ncat
+    ncat \
+    netcat-openbsd
 
 # Create non-root user
 RUN useradd -m -s /bin/bash claude

--- a/src/docker/claude-docker
+++ b/src/docker/claude-docker
@@ -160,7 +160,7 @@ fi
 # only (handled below in the proxy launch block).
 SSH_DIR_FLAGS=""
 if [ -n "${CLAUDE_DOCKER_SSH_SHARED_DIR:-}" ] && [ -d "${CLAUDE_DOCKER_SSH_SHARED_DIR:-}" ]; then
-    SSH_DIR_FLAGS="-v ${CLAUDE_DOCKER_SSH_SHARED_DIR}:/run/ssh:ro"
+    SSH_DIR_FLAGS="-v ${CLAUDE_DOCKER_SSH_SHARED_DIR}:/run/ssh"
     SSH_DIR_FLAGS="$SSH_DIR_FLAGS -e SSH_AUTH_SOCK=/run/ssh/agent.sock"
     SSH_DIR_FLAGS="$SSH_DIR_FLAGS -e GIT_SSH_COMMAND=/run/ssh/ssh-wrapper"
 fi

--- a/src/docker/proxy/entrypoint.sh
+++ b/src/docker/proxy/entrypoint.sh
@@ -316,6 +316,24 @@ if [ -f "$SSH_PRIVATE_KEY" ]; then
 
     # Ensure the socket is accessible by the agent container's claude user (uid 1000).
     chmod 0666 "$SSH_AGENT_SOCK" 2>/dev/null || true
+
+    # Create ssh-wrapper to route SSH via SOCKS5 and use a writable known_hosts
+    SSH_WRAPPER="$SSH_SHARED_DIR/ssh-wrapper"
+    cat > "$SSH_WRAPPER" <<'WRAPPER'
+#!/bin/sh
+exec ssh \
+  -o "ProxyCommand=nc -X 5 -x 127.0.0.1:1080 %h %p" \
+  -o "UserKnownHostsFile=/run/ssh/known_hosts" \
+  -o "StrictHostKeyChecking=accept-new" \
+  "$@"
+WRAPPER
+    chmod 0755 "$SSH_WRAPPER"
+    chown 1000:1000 "$SSH_WRAPPER"
+
+    # Create writable known_hosts owned by claude user (uid 1000)
+    touch "$SSH_SHARED_DIR/known_hosts"
+    chown 1000:1000 "$SSH_SHARED_DIR/known_hosts"
+    chmod 0644 "$SSH_SHARED_DIR/known_hosts"
 fi
 
 touch "$CERTS_DIR/.ready"


### PR DESCRIPTION
## Summary
- Proxy entrypoint now creates `/run/ssh/ssh-wrapper` (a minimal shell script that invokes `ssh` via `nc -X 5 -x 127.0.0.1:1080`) and a writable `/run/ssh/known_hosts` owned by uid 1000 (claude user)
- Agent SSH shared dir mount changed from `:ro` to `:rw` so the entrypoint-written wrapper and known_hosts are visible and writable inside the agent container
- `netcat-openbsd` added to agent Dockerfile for OpenBSD `nc` SOCKS5 flag support (`-X 5 -x`)

## Test plan
- [ ] Syntax check: `bash -n src/docker/claude-docker` passes
- [ ] Syntax check: `bash -n src/docker/proxy/entrypoint.sh` passes
- [ ] All 1317 pytest tests pass

Resolves #1197

🤖 Generated with [Claude Code](https://claude.com/claude-code)