### PR TITLE
fix: remove duplicate /run/ssh mount causing agent exit code 125

### DIFF
--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -1324,11 +1324,6 @@ class SessionCoordinator:
                         try:
                             if prepare_session_ssh(resolved_metas, _ssh_key_dir, _ssh_shared_dir):
                                 _ssh_key_prepared = True
-                                # Shared dir into agent at /run/ssh:ro (socket + config)
-                                extra_mounts.append(f"{_ssh_shared_dir}:/run/ssh:ro")
-                                # Agent accesses the ssh-agent socket for signing
-                                delivery_envs["SSH_AUTH_SOCK"] = "/run/ssh/agent.sock"
-                                delivery_envs["GIT_SSH_COMMAND"] = "/run/ssh/ssh-wrapper"
                         except ValueError as ssh_err:
                             coord_logger.error(
                                 f"SSH key setup failed for session {session_id}: {ssh_err}"


### PR DESCRIPTION
## Summary
Resolves #1202

The SSH shared directory was mounted twice into the agent container: once manually via `extra_mounts` and `delivery_envs` in `session_coordinator.py`, and again by `claude-docker` when it processes `CLAUDE_DOCKER_SSH_SHARED_DIR`. Docker rejects duplicate `-v` flags for the same container destination path with exit code 125.

## Changes Made
- Removed `extra_mounts.append(f"{_ssh_shared_dir}:/run/ssh:ro")` from `start_session()` SSH key setup block
- Removed `delivery_envs["SSH_AUTH_SOCK"] = "/run/ssh/agent.sock"` (set by claude-docker)
- Removed `delivery_envs["GIT_SSH_COMMAND"] = "/run/ssh/ssh-wrapper"` (set by claude-docker)

`claude-docker` already handles these via `CLAUDE_DOCKER_SSH_SHARED_DIR`, which is set a few lines later in the same block.

## Testing
- All 1317 tests pass (`uv run pytest src/tests/ -v`)
- Ruff linting passes with zero violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)