### PR TITLE
fix: redirect mitmdump (uid 9999) DNS queries to CoreDNS so SOCKS5 TCP can resolve hostnames

### DIFF
--- a/src/docker/proxy/entrypoint.sh
+++ b/src/docker/proxy/entrypoint.sh
@@ -187,6 +187,10 @@ iptables -A OUTPUT -p tcp -m conntrack --ctstate NEW -j DROP
 # To add future protocol proxies: insert uid ACCEPT before the DROP.
 echo "Configuring default-deny UDP OUTPUT..."
 iptables -A OUTPUT -p udp -m owner --uid-owner 9998 -j ACCEPT
+# Route mitmdump DNS queries to CoreDNS via loopback
+iptables -t nat -A OUTPUT -p udp --dport 53 \
+    -m owner --uid-owner 9999 \
+    -j REDIRECT --to-ports 53
 # Issue #1060: NFLOG before DROP for per-connection dropped UDP logging.
 if [ -d "$LOG_DIR" ]; then
     iptables -A OUTPUT -p udp \


### PR DESCRIPTION
## Summary
Resolves #1204

Route uid 9999 (mitmdump) DNS queries to CoreDNS via a NAT REDIRECT rule so SOCKS5 hostname resolution works through the proxy.

## Changes Made
- Added `iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --uid-owner 9999 -j REDIRECT --to-ports 53` in the UDP OUTPUT section of `src/docker/proxy/entrypoint.sh`, after the uid 9998 (CoreDNS) exemption

## Testing
- `bash -n src/docker/proxy/entrypoint.sh` — syntax check passes
- `uv run pytest src/tests/ -v` — 1317 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)