### PR TITLE
fix: add filter/OUTPUT ACCEPT for uid 9999 UDP DNS

### DIFF
--- a/src/docker/proxy/entrypoint.sh
+++ b/src/docker/proxy/entrypoint.sh
@@ -187,6 +187,8 @@ iptables -A OUTPUT -p tcp -m conntrack --ctstate NEW -j DROP
 # To add future protocol proxies: insert uid ACCEPT before the DROP.
 echo "Configuring default-deny UDP OUTPUT..."
 iptables -A OUTPUT -p udp -m owner --uid-owner 9998 -j ACCEPT
+# Allow mitmdump (uid 9999) DNS — nat OUTPUT already redirects these to CoreDNS (see #1204)
+iptables -A OUTPUT -p udp --dport 53 -m owner --uid-owner 9999 -j ACCEPT
 # Route mitmdump DNS queries to CoreDNS via loopback
 iptables -t nat -A OUTPUT -p udp --dport 53 \
     -m owner --uid-owner 9999 \


### PR DESCRIPTION
## Summary
- Adds `iptables -A OUTPUT -p udp --dport 53 -m owner --uid-owner 9999 -j ACCEPT` in the filter table UDP section of `src/docker/proxy/entrypoint.sh`
- Without this rule, the default-deny UDP DROP blocked mitmdump's DNS packets even after the nat REDIRECT sent them to CoreDNS (#1204)

## Test plan
- [x] `bash -n src/docker/proxy/entrypoint.sh` — syntax OK
- [x] `uv run pytest src/tests/ -v` — 1317 passed

Resolves #1206

🤖 Generated with [Claude Code](https://claude.com/claude-code)