### PR TITLE
fix: use SSH Include for proxy config instead of wrapper/GIT_SSH_COMMAND workarounds

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -72,6 +72,9 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
     && apt-get update && apt-get install -y --no-install-recommends gh
 
+# ssh 7.3+ silently ignores an Include of a non-existent path — safe when no SSH secrets are configured.
+RUN echo "Include /run/ssh/config" >> /etc/ssh/ssh_config
+
 # ---------- Layer 5: Non-root user ----------
 RUN useradd -m -s /bin/bash claude
 

--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -15,6 +15,9 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     ncat \
     netcat-openbsd
 
+# ssh 7.3+ silently ignores an Include of a non-existent path — safe when no SSH secrets are configured.
+RUN echo "Include /run/ssh/config" >> /etc/ssh/ssh_config
+
 # Create non-root user
 RUN useradd -m -s /bin/bash claude
 

--- a/src/docker/claude-docker
+++ b/src/docker/claude-docker
@@ -162,7 +162,6 @@ SSH_DIR_FLAGS=""
 if [ -n "${CLAUDE_DOCKER_SSH_SHARED_DIR:-}" ] && [ -d "${CLAUDE_DOCKER_SSH_SHARED_DIR:-}" ]; then
     SSH_DIR_FLAGS="-v ${CLAUDE_DOCKER_SSH_SHARED_DIR}:/run/ssh"
     SSH_DIR_FLAGS="$SSH_DIR_FLAGS -e SSH_AUTH_SOCK=/run/ssh/agent.sock"
-    SSH_DIR_FLAGS="$SSH_DIR_FLAGS -e GIT_SSH_COMMAND=/run/ssh/ssh-wrapper"
 fi
 
 # Issue #781: Build resource limit flags

--- a/src/docker/proxy/entrypoint.sh
+++ b/src/docker/proxy/entrypoint.sh
@@ -323,19 +323,6 @@ if [ -f "$SSH_PRIVATE_KEY" ]; then
     # Ensure the socket is accessible by the agent container's claude user (uid 1000).
     chmod 0666 "$SSH_AGENT_SOCK" 2>/dev/null || true
 
-    # Create ssh-wrapper to route SSH via SOCKS5 and use a writable known_hosts
-    SSH_WRAPPER="$SSH_SHARED_DIR/ssh-wrapper"
-    cat > "$SSH_WRAPPER" <<'WRAPPER'
-#!/bin/sh
-exec ssh \
-  -o "ProxyCommand=nc -X 5 -x 127.0.0.1:1080 %h %p" \
-  -o "UserKnownHostsFile=/run/ssh/known_hosts" \
-  -o "StrictHostKeyChecking=accept-new" \
-  "$@"
-WRAPPER
-    chmod 0755 "$SSH_WRAPPER"
-    chown 1000:1000 "$SSH_WRAPPER"
-
     # Create writable known_hosts owned by claude user (uid 1000)
     touch "$SSH_SHARED_DIR/known_hosts"
     chown 1000:1000 "$SSH_SHARED_DIR/known_hosts"

--- a/src/docker_utils.py
+++ b/src/docker_utils.py
@@ -160,12 +160,7 @@ Host *
     IdentitiesOnly yes
     StrictHostKeyChecking accept-new
     UserKnownHostsFile /run/ssh/known_hosts
-    ProxyCommand ncat --proxy 127.0.0.1:1080 --proxy-type socks5 %h %p
-"""
-
-_SSH_WRAPPER_SCRIPT = """\
-#!/bin/sh
-exec ssh -F /run/ssh/config "$@"
+    ProxyCommand nc -X 5 -x 127.0.0.1:1080 %h %p
 """
 
 
@@ -183,7 +178,7 @@ def prepare_session_ssh(
                   Mounted into the PROXY SIDECAR ONLY at /run/ssh-private:ro.
                   The proxy entrypoint ssh-adds the key, then wipes this file.
 
-      shared_dir — contains config, known_hosts, and ssh-wrapper.
+      shared_dir — contains config, known_hosts, and agent socket.
                   Mounted into BOTH containers at /run/ssh (read-write on proxy
                   so ssh-agent can create the socket; read-only on agent).
 
@@ -223,10 +218,6 @@ def prepare_session_ssh(
     known_hosts = shared_dir / "known_hosts"
     known_hosts.touch()
     os.chmod(known_hosts, 0o644)
-
-    wrapper = shared_dir / "ssh-wrapper"
-    wrapper.write_text(_SSH_WRAPPER_SCRIPT)
-    os.chmod(wrapper, 0o755)
 
     logger.info(
         f"SSH key prepared for secret '{secret.get('name')}' "

--- a/src/tests/test_docker_utils_ssh.py
+++ b/src/tests/test_docker_utils_ssh.py
@@ -3,16 +3,16 @@ Tests for prepare_session_ssh() in src/docker_utils.py (issue #1052).
 
 Two-dir isolation architecture:
   key_dir    — private key only; mounted into proxy sidecar at /run/ssh-private:ro
-  shared_dir — socket + config + known_hosts + wrapper; mounted into both containers at /run/ssh
+  shared_dir — socket + config + known_hosts; mounted into both containers at /run/ssh
 
 Tests cover:
-- prepare_session_ssh() writes private key to key_dir and config/known_hosts/wrapper to shared_dir
+- prepare_session_ssh() writes private key to key_dir and config/known_hosts to shared_dir
+- No ssh-wrapper file is created (issue #1208: replaced by ssh_config Include)
 - Private key is NOT present in shared_dir
 - Raises ValueError when multiple ssh_key secrets are assigned
 - SSH config has NO IdentityFile line; has expected ProxyCommand + IdentitiesOnly
 - Returns False (no files written) when no ssh_key secrets present
-- Key file has mode 0o600; config/known_hosts have mode 0o644; wrapper is 0o755
-- Env vars SSH_AUTH_SOCK and GIT_SSH_COMMAND are implied by config content
+- Key file has mode 0o600; config/known_hosts have mode 0o644
 """
 
 import os
@@ -76,10 +76,11 @@ class TestPrepareSessionSsh:
         prepare_session_ssh([secret], tmp_path / "key", tmp_path / "shared")
         assert (tmp_path / "shared" / "known_hosts").exists()
 
-    def test_creates_wrapper_in_shared_dir(self, tmp_path):
+    def test_no_wrapper_in_shared_dir(self, tmp_path):
+        """Issue #1208: ssh-wrapper replaced by global ssh_config Include — not written."""
         secret = _make_secret()
         prepare_session_ssh([secret], tmp_path / "key", tmp_path / "shared")
-        assert (tmp_path / "shared" / "ssh-wrapper").exists()
+        assert not (tmp_path / "shared" / "ssh-wrapper").exists()
 
     def test_private_key_not_in_shared_dir(self, tmp_path):
         """The agent container must never see raw key bytes."""
@@ -102,14 +103,6 @@ class TestPrepareSessionSsh:
         perms = stat.S_IMODE(os.stat(key_path).st_mode)
         assert perms == 0o600, f"Expected 0o600, got {oct(perms)}"
 
-    def test_wrapper_script_executable(self, tmp_path):
-        secret = _make_secret()
-        shared_dir = tmp_path / "shared"
-        prepare_session_ssh([secret], tmp_path / "key", shared_dir)
-        wrapper = shared_dir / "ssh-wrapper"
-        perms = stat.S_IMODE(os.stat(wrapper).st_mode)
-        assert perms & 0o111, f"ssh-wrapper not executable: {oct(perms)}"
-
     def test_ssh_config_has_no_identity_file(self, tmp_path):
         """No IdentityFile — ssh-agent socket provides identity."""
         secret = _make_secret()
@@ -126,8 +119,7 @@ class TestPrepareSessionSsh:
         prepare_session_ssh([secret], tmp_path / "key", shared_dir)
         config_text = (shared_dir / "config").read_text()
         assert "ProxyCommand" in config_text
-        assert "ncat" in config_text
-        assert "socks5" in config_text
+        assert "nc -X 5 -x" in config_text
         assert "127.0.0.1:1080" in config_text
 
     def test_ssh_config_identities_only(self, tmp_path):
@@ -136,13 +128,6 @@ class TestPrepareSessionSsh:
         prepare_session_ssh([secret], tmp_path / "key", shared_dir)
         config_text = (shared_dir / "config").read_text()
         assert "IdentitiesOnly yes" in config_text
-
-    def test_ssh_wrapper_references_config(self, tmp_path):
-        secret = _make_secret()
-        shared_dir = tmp_path / "shared"
-        prepare_session_ssh([secret], tmp_path / "key", shared_dir)
-        wrapper_text = (shared_dir / "ssh-wrapper").read_text()
-        assert "ssh -F /run/ssh/config" in wrapper_text
 
     def test_raises_on_multiple_ssh_keys(self, tmp_path):
         secrets = [_make_secret("key1"), _make_secret("key2")]


### PR DESCRIPTION
## Summary

- Add `Include /run/ssh/config` to `/etc/ssh/ssh_config` in both agent Dockerfiles; ssh 7.3+ silently ignores a missing Include path, so this is safe when no SSH secrets are configured
- Switch ProxyCommand from `ncat --proxy-type socks5` to `nc -X 5 -x` (netcat-openbsd syntax)
- Remove `_SSH_WRAPPER_SCRIPT` constant and wrapper file creation from `docker_utils.py`
- Remove ssh-wrapper heredoc + chmod/chown from `proxy/entrypoint.sh`
- Remove `GIT_SSH_COMMAND=/run/ssh/ssh-wrapper` env var from `claude-docker`
- Update `test_docker_utils_ssh.py` to assert no wrapper is written and check new ProxyCommand syntax

## Test plan
- [ ] `bash -n src/docker/claude-docker` passes
- [ ] `bash -n src/docker/proxy/entrypoint.sh` passes
- [ ] `uv run ruff check src/docker_utils.py` — zero violations
- [ ] `uv run pytest src/tests/test_docker_utils_ssh.py -v` — all 16 tests pass
- [ ] Full test suite: 1313 passed, 0 failed

Resolves #1208

🤖 Generated with [Claude Code](https://claude.com/claude-code)