### PR TITLE
fix: skip inject_file for ssh_key in proxy mode; remove IdentitiesOnly yes

### DIFF
--- a/src/docker_utils.py
+++ b/src/docker_utils.py
@@ -155,9 +155,9 @@ def resolve_docker_cli_path(
 # SSH config mounted into the shared dir (agent container at /run/ssh).
 # No IdentityFile — the ssh-agent socket inside the proxy sidecar provides
 # the identity; the agent container never holds the raw private key bytes.
+# IdentitiesOnly is intentionally absent so SSH_AUTH_SOCK (agent socket) is consulted.
 _SSH_CONFIG_TEMPLATE = """\
 Host *
-    IdentitiesOnly yes
     StrictHostKeyChecking accept-new
     UserKnownHostsFile /run/ssh/known_hosts
     ProxyCommand nc -X 5 -x 127.0.0.1:1080 %h %p

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -1293,7 +1293,7 @@ class SessionCoordinator:
 
                             # inject_file: render placeholder into a mounted file
                             inject_file = secret.get("inject_file")
-                            if inject_file:
+                            if inject_file and not (secret.get("type") == "ssh_key" and effective_config.docker_proxy_enabled):
                                 file_path = inject_file.get("path")
                                 if file_path:
                                     fmt = inject_file.get("format", "raw")

--- a/src/tests/test_docker_utils_ssh.py
+++ b/src/tests/test_docker_utils_ssh.py
@@ -122,12 +122,12 @@ class TestPrepareSessionSsh:
         assert "nc -X 5 -x" in config_text
         assert "127.0.0.1:1080" in config_text
 
-    def test_ssh_config_identities_only(self, tmp_path):
+    def test_ssh_config_no_identities_only(self, tmp_path):
         secret = _make_secret()
         shared_dir = tmp_path / "shared"
         prepare_session_ssh([secret], tmp_path / "key", shared_dir)
         config_text = (shared_dir / "config").read_text()
-        assert "IdentitiesOnly yes" in config_text
+        assert "IdentitiesOnly" not in config_text
 
     def test_raises_on_multiple_ssh_keys(self, tmp_path):
         secrets = [_make_secret("key1"), _make_secret("key2")]


### PR DESCRIPTION
## Summary
Resolves #1211

Two SSH proxy-mode fixes preventing key delivery corruption and restoring agent socket consultation.

## Changes Made
- **`src/session_coordinator.py`**: Guard `inject_file` processing to skip `ssh_key` secrets when `docker_proxy_enabled` is set. `prepare_session_ssh()` handles key delivery via the two-dir isolation mechanism; writing the placeholder string to the SSH key path would corrupt the file that OpenSSH treats as a private key.
- **`src/docker_utils.py`**: Remove `IdentitiesOnly yes` from `_SSH_CONFIG_TEMPLATE`. With `IdentitiesOnly yes` and no `IdentityFile` directive, OpenSSH suppresses agent consultation and ignores `SSH_AUTH_SOCK`. Removing it restores the default (`IdentitiesOnly no`) so the agent socket is used.
- **`src/tests/test_docker_utils_ssh.py`**: Update `test_ssh_config_identities_only` → `test_ssh_config_no_identities_only` to assert `IdentitiesOnly` is absent from the generated SSH config.

## Testing
- `uv run pytest src/tests/ -v`: 1315 passed, 0 failed
- `uv run ruff check --fix src/session_coordinator.py src/docker_utils.py`: All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)