### PR TITLE
fix: skip host credential mount when proxy is active

### DIFF
--- a/src/docker/claude-docker
+++ b/src/docker/claude-docker
@@ -321,6 +321,12 @@ for k, v in d.items():
 " "$CLAUDE_DOCKER_DELIVERY_ENVS" 2>/dev/null || true)
 fi
 
+# Issue #1215: Skip host credential mount when proxy is active (proxy handles auth via WebUI secret)
+CRED_MOUNT_FLAGS=""
+if [ -z "$PROXY_IMAGE" ]; then
+    CRED_MOUNT_FLAGS="-v $HOME/.claude/.credentials.json:$DOCKER_HOME/.claude/.credentials.json"
+fi
+
 # Run the container (capture exit code for diagnostics)
 docker run \
     --rm \
@@ -328,7 +334,7 @@ docker run \
     --name "$CONTAINER_NAME" \
     -v "$WORKSPACE:$WORKSPACE" \
     -w "$WORKSPACE" \
-    -v "$HOME/.claude/.credentials.json:$DOCKER_HOME/.claude/.credentials.json" \
+    $CRED_MOUNT_FLAGS \
     -v "$HOME/.claude/settings.json:$DOCKER_HOME/.claude/settings.json:ro" \
     -e "CLAUDE_CODE_DISABLE_AUTO_UPDATE=1" \
     $ENV_FLAGS \


### PR DESCRIPTION
## Summary

- Add conditional `CRED_MOUNT_FLAGS` variable in `src/docker/claude-docker`
- When `PROXY_IMAGE` is set, the credential mount is omitted (proxy handles auth via WebUI secret)
- When `PROXY_IMAGE` is empty, mount behavior is unchanged

## Changes Made
- Added `CRED_MOUNT_FLAGS` conditional block before `docker run` invocation
- Replaced hardcoded `-v .credentials.json` mount with `$CRED_MOUNT_FLAGS`

## Testing
- [x] `bash -n src/docker/claude-docker` passes (syntax check)
- No shell-mock test exists for docker run argv; bash script is not automatable in Python — skipped per plan
- Manual: run container with proxy active and verify no `/credentials.json` mount in `docker inspect` output
- Manual: run container without proxy and verify mount is present as before

Resolves #1215

🤖 Generated with [Claude Code](https://claude.com/claude-code)