### PR TITLE
fix: resolve_secrets_for_session ignores template-derived secrets

### DIFF
--- a/src/application_service.py
+++ b/src/application_service.py
@@ -701,7 +701,13 @@ class ApplicationService:
         if session is None:
             return {"secrets": []}
 
-        assigned = getattr(session, "assigned_secrets", None) or []
+        assigned = list(getattr(session, "assigned_secrets", None) or [])
+        # Issue #1219: also include secrets from secret_placeholders — these capture
+        # template/profile-derived assigned_secrets that were never written back to
+        # session.assigned_secrets.
+        for name in (getattr(session, "secret_placeholders", None) or {}).values():
+            if name not in assigned:
+                assigned.append(name)
 
         # Collect transitive names (sibling refresh-token and client-secret records).
         all_names: list[str] = list(assigned)

--- a/src/tests/test_application_service.py
+++ b/src/tests/test_application_service.py
@@ -468,3 +468,55 @@ async def test_create_template_returns_dict(service, mock_coordinator):
     result = await service.create_template(name="mytemplate")
 
     assert result == template.to_dict()
+
+
+# ---------------------------------------------------------------------------
+# Secrets / Issue #1219
+# ---------------------------------------------------------------------------
+
+
+def _make_session_with_secrets(assigned_secrets=None, secret_placeholders=None):
+    s = MagicMock()
+    s.assigned_secrets = assigned_secrets
+    s.secret_placeholders = secret_placeholders
+    return s
+
+
+@pytest.mark.asyncio
+async def test_issue_1219_resolves_from_placeholder_when_assigned_empty(service, mock_coordinator):
+    session = _make_session_with_secrets(
+        assigned_secrets=None,
+        secret_placeholders={"CC_SECRET_tok_abc": "claudecode_token"},
+    )
+    mock_coordinator.session_manager.get_session_info.return_value = session
+    mock_coordinator.credential_vault = MagicMock()
+    mock_coordinator.credential_vault.list_secrets = AsyncMock(return_value=[])
+    mock_coordinator.credential_vault.resolve_secrets_for_assignment = AsyncMock(
+        return_value=[{"name": "claudecode_token", "value": "tok123"}]
+    )
+
+    result = await service.resolve_secrets_for_session("s1")
+
+    mock_coordinator.credential_vault.resolve_secrets_for_assignment.assert_called_once_with(
+        ["claudecode_token"]
+    )
+    assert any(s["name"] == "claudecode_token" for s in result["secrets"])
+
+
+@pytest.mark.asyncio
+async def test_issue_1219_no_duplicates_when_both_assigned_and_placeholder_set(service, mock_coordinator):
+    session = _make_session_with_secrets(
+        assigned_secrets=["claudecode_token"],
+        secret_placeholders={"CC_SECRET_tok_abc": "claudecode_token"},
+    )
+    mock_coordinator.session_manager.get_session_info.return_value = session
+    mock_coordinator.credential_vault = MagicMock()
+    mock_coordinator.credential_vault.list_secrets = AsyncMock(return_value=[])
+    mock_coordinator.credential_vault.resolve_secrets_for_assignment = AsyncMock(
+        return_value=[{"name": "claudecode_token", "value": "tok123"}]
+    )
+
+    await service.resolve_secrets_for_session("s1")
+
+    names_passed = mock_coordinator.credential_vault.resolve_secrets_for_assignment.call_args[0][0]
+    assert names_passed.count("claudecode_token") == 1


### PR DESCRIPTION
## Summary
Resolves #1219

`resolve_secrets_for_session()` read `session.assigned_secrets` directly. When a session is created from a template, assigned secret names are merged into `secret_placeholders` at start time but never written back to `session.assigned_secrets`, so the field stays `null` and the endpoint returned `{"secrets": []}` — the proxy never injected.

## Changes Made
- `src/application_service.py`: After reading `assigned_secrets`, extend the list with names from `secret_placeholders.values()`, skipping duplicates. Transitive sibling expansion and vault resolution then see all required names.
- `src/tests/test_application_service.py`: Two regression tests covering the empty-assigned case and the no-duplicate case.

## Testing
- `uv run pytest src/tests/test_application_service.py -v` — 32/32 passed
- `uv run ruff check src/application_service.py src/tests/test_application_service.py` — no violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)