### PR TITLE
fix: remove duplicate debug flag entries from --help output

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,26 +25,6 @@ def main():
     # Parse command-line arguments
     parser = argparse.ArgumentParser(
         description="Claude Code WebUI Server",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog="""
-Debug Flags:
-  --debug-websocket         Enable WebSocket lifecycle debugging
-  --debug-ping-pong         Enable WebSocket ping/pong logging (high volume)
-  --debug-sdk               Enable SDK integration debugging
-  --debug-permissions       Enable permission callback debugging
-  --debug-storage           Enable data storage debugging
-  --debug-parser            Enable message parser debugging
-  --debug-error-handler     Enable error handler debugging
-  --debug-legion            Enable Legion multi-agent system debugging
-  --debug-session-manager   Enable session manager debugging
-  --debug-template-manager  Enable template manager debugging
-  --debug-skill-manager     Enable skill manager debugging
-  --debug-queue-manager     Enable queue manager debugging
-  --debug-queue-processor   Enable queue processor debugging
-  --debug-archive           Enable archive manager debugging
-  --debug-project-manager   Enable project manager debugging
-  --debug-all               Enable all debug logging (excludes ping/pong)
-        """
     )
 
     # Server options
@@ -54,27 +34,6 @@ Debug Flags:
     )
     parser.add_argument('--port', type=int, default=8000, help='Port to bind to (default: 8000)')
     parser.add_argument('--data-dir', default='./data', help='Data directory location (default: ./data)')
-
-    # Debug flags
-    parser.add_argument('--debug-websocket', action='store_true', help='Enable WebSocket lifecycle debugging')
-    # Note: debug_all excludes ping/pong logging due to excessive noise that obscures other debug output.
-    # Ping/pong keepalive messages occur every 3 seconds per WebSocket connection, generating thousands
-    # of log entries that make it difficult to identify relevant debugging information.
-    parser.add_argument('--debug-ping-pong', action='store_true', help='Enable WebSocket ping/pong logging (high volume)')
-    parser.add_argument('--debug-sdk', action='store_true', help='Enable SDK integration debugging')
-    parser.add_argument('--debug-permissions', action='store_true', help='Enable permission callback debugging')
-    parser.add_argument('--debug-storage', action='store_true', help='Enable data storage debugging')
-    parser.add_argument('--debug-parser', action='store_true', help='Enable message parser debugging')
-    parser.add_argument('--debug-error-handler', action='store_true', help='Enable error handler debugging')
-    parser.add_argument('--debug-legion', action='store_true', help='Enable Legion multi-agent system debugging')
-    parser.add_argument('--debug-session-manager', action='store_true', help='Enable session manager debugging')
-    parser.add_argument('--debug-template-manager', action='store_true', help='Enable template manager debugging')
-    parser.add_argument('--debug-skill-manager', action='store_true', help='Enable skill manager debugging')
-    parser.add_argument('--debug-queue-manager', action='store_true', help='Enable queue manager debugging')
-    parser.add_argument('--debug-queue-processor', action='store_true', help='Enable queue processor debugging')
-    parser.add_argument('--debug-archive', action='store_true', help='Enable archive manager debugging')
-    parser.add_argument('--debug-project-manager', action='store_true', help='Enable project manager debugging')
-    parser.add_argument('--debug-all', action='store_true', help='Enable all debug logging (excludes ping/pong)')
 
     # Experimental features
     parser.add_argument('--experimental', action='store_true', help='Enable experimental features (Agent Teams)')
@@ -102,6 +61,28 @@ Debug Flags:
         '--fixtures-dir', type=str, default=None,
         help='Directory containing named fixture subdirectories (required with --mock-sdk)'
     )
+
+    # Debug flags (grouped so they appear under their own section)
+    debug_group = parser.add_argument_group("Debug Flags")
+    debug_group.add_argument('--debug-websocket', action='store_true', help='Enable WebSocket lifecycle debugging')
+    # Note: debug_all excludes ping/pong logging due to excessive noise that obscures other debug output.
+    # Ping/pong keepalive messages occur every 3 seconds per WebSocket connection, generating thousands
+    # of log entries that make it difficult to identify relevant debugging information.
+    debug_group.add_argument('--debug-ping-pong', action='store_true', help='Enable WebSocket ping/pong logging (high volume)')
+    debug_group.add_argument('--debug-sdk', action='store_true', help='Enable SDK integration debugging')
+    debug_group.add_argument('--debug-permissions', action='store_true', help='Enable permission callback debugging')
+    debug_group.add_argument('--debug-storage', action='store_true', help='Enable data storage debugging')
+    debug_group.add_argument('--debug-parser', action='store_true', help='Enable message parser debugging')
+    debug_group.add_argument('--debug-error-handler', action='store_true', help='Enable error handler debugging')
+    debug_group.add_argument('--debug-legion', action='store_true', help='Enable Legion multi-agent system debugging')
+    debug_group.add_argument('--debug-session-manager', action='store_true', help='Enable session manager debugging')
+    debug_group.add_argument('--debug-template-manager', action='store_true', help='Enable template manager debugging')
+    debug_group.add_argument('--debug-skill-manager', action='store_true', help='Enable skill manager debugging')
+    debug_group.add_argument('--debug-queue-manager', action='store_true', help='Enable queue manager debugging')
+    debug_group.add_argument('--debug-queue-processor', action='store_true', help='Enable queue processor debugging')
+    debug_group.add_argument('--debug-archive', action='store_true', help='Enable archive manager debugging')
+    debug_group.add_argument('--debug-project-manager', action='store_true', help='Enable project manager debugging')
+    debug_group.add_argument('--debug-all', action='store_true', help='Enable all debug logging (excludes ping/pong)')
 
     args = parser.parse_args()
 


### PR DESCRIPTION
## Summary
Resolves #1201

The `ArgumentParser` was configured with both a hand-written `epilog=` block listing all 16 debug flags **and** `parser.add_argument()` calls for those same flags. argparse rendered both, causing each debug flag to appear twice in `--help` output.

## Changes Made
- Remove `formatter_class=argparse.RawDescriptionHelpFormatter` and the entire `epilog="""..."""` block (former lines 28–47)
- Create `debug_group = parser.add_argument_group("Debug Flags")` after all non-debug flags
- Convert all 16 `parser.add_argument('--debug-*', ...)` calls to `debug_group.add_argument(...)` so argparse renders them natively under a `Debug Flags:` section
- Reorder non-debug flags (`--experimental`, `--no-auth`, `--token`, `--force-auth`, `--mock-sdk`, `--fixtures-dir`) to appear before the debug group, keeping the `options:` section clean and uninterleaved

No behavior change — argument groups only affect `--help` rendering. The parsed `args` namespace is identical.

## Testing
- `uv run main.py --help` — each of the 16 debug flags appears exactly once, under a `Debug Flags:` section; `options:` contains only non-debug flags; no free-form epilog text
- `uv run main.py --mock-sdk` — `parser.error("--fixtures-dir is required ...")` still fires correctly
- `uv run ruff check --fix main.py` — zero violations

## Coordination Note
This PR touches `main.py` lines 26–77 (same block as issue #1200, which renames debug flag names/help text). The changes are **orthogonal**: #1201 changes structural placement only, #1200 changes flag names/text. If #1200 merges first, rebasing #1201 is clean — the same 16 declarations simply move onto `debug_group` with their new names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)