### PR TITLE
fix: template tag-field overrides replace profile values instead of merging

### DIFF
--- a/src/config_resolution.py
+++ b/src/config_resolution.py
@@ -74,13 +74,6 @@ _LIST_FIELDS: frozenset[str] = frozenset({
     "assigned_secrets", "docker_proxy_allowlist_domains",
 })
 
-# Fields that use additive (union) merge across tiers instead of last-wins.
-# All tiers contribute their values; duplicates are removed and result is sorted.
-ADDITIVE_LIST_FIELDS: frozenset[str] = frozenset({
-    "docker_proxy_allowlist_domains",
-    "assigned_secrets",
-})
-
 
 def _coerce_list(value: object) -> object:
     """Convert a comma-separated string to a list for fields that require list[str]."""
@@ -140,41 +133,6 @@ async def resolve_effective_config(
     for field_name in CONFIG_FIELDS:
         if field_name in session_overrides:
             config_data[field_name] = session_overrides[field_name]
-
-    # Additive merge for ADDITIVE_LIST_FIELDS: union all tiers instead of last-wins.
-    # Must happen after standard resolution so all sources are consulted.
-    if ADDITIVE_LIST_FIELDS:
-        profile_cache: dict[str, object] = {}
-        template_profile_ids = template.profile_ids or {}
-        template_overrides_dict = template.template_overrides or {}
-        for field in ADDITIVE_LIST_FIELDS:
-            merged: set[str] = set()
-            # Tier 1: template flat field
-            flat_val = getattr(template, field, None)
-            if flat_val:
-                merged.update(flat_val if isinstance(flat_val, list) else [flat_val])
-            # Tier 2: profile value for the field's area
-            area = FIELD_TO_AREA.get(field)
-            if area and area in template_profile_ids and profile_manager:
-                profile = await _load_profile_cached(
-                    template_profile_ids[area], profile_manager, profile_cache
-                )
-                if profile is not None and field in profile.config:
-                    raw = profile.config[field]
-                    coerced = _coerce_list(raw)
-                    if coerced:
-                        merged.update(coerced if isinstance(coerced, list) else [coerced])
-            # Tier 3: template overrides
-            if field in template_overrides_dict:
-                val = template_overrides_dict[field]
-                if val:
-                    merged.update(val if isinstance(val, list) else [val])
-            # Tier 4: session overrides
-            if field in session_overrides:
-                val = session_overrides[field]
-                if val:
-                    merged.update(val if isinstance(val, list) else [val])
-            config_data[field] = sorted(merged) if merged else None
 
     # Carry template_id through for downstream reference
     config_data["template_id"] = session_info.template_id

--- a/src/tests/test_config_resolution.py
+++ b/src/tests/test_config_resolution.py
@@ -25,7 +25,6 @@ from unittest.mock import AsyncMock
 import pytest
 
 from ..config_resolution import (
-    ADDITIVE_LIST_FIELDS,
     CONFIG_FIELDS,
     FIELD_TO_AREA,
     PROFILE_AREAS,
@@ -594,15 +593,33 @@ class TestResolveTemplateConfig:
 
 
 @pytest.mark.asyncio
-class TestAdditiveAllowlistMerge:
-    """Test #15 — ADDITIVE_LIST_FIELDS union merge for docker_proxy_allowlist_domains (issue #1053)."""
+class TestTagFieldReplaceSemantics:
+    """Test #15 — tag-style list fields use last-wins (replace) semantics (issue #1223).
 
-    def test_additive_list_fields_contains_allowlist_domain(self):
-        """docker_proxy_allowlist_domains must be in ADDITIVE_LIST_FIELDS."""
-        assert "docker_proxy_allowlist_domains" in ADDITIVE_LIST_FIELDS
+    docker_proxy_allowlist_domains and assigned_secrets no longer use additive merge;
+    they follow standard last-wins precedence like all other config fields.
+    """
 
-    async def test_additive_merge_allowlist_domains_unions_all_tiers(self):
-        """Domains from profile + template_overrides + session_overrides are unioned, not last-wins."""
+    async def test_template_override_replaces_profile_secrets(self):
+        """template_overrides.assigned_secrets replaces (not unions) the profile value."""
+        profile = _make_profile(
+            area="isolation",
+            config={"assigned_secrets": ["ssh_test"]},
+        )
+        pm = _make_profile_manager([profile])
+        template = _make_template(
+            template_overrides={"assigned_secrets": ["ssh_test2"]},
+            profile_ids={"isolation": profile.profile_id},
+        )
+        session = _make_session(template_id="tmpl-001")
+        tm = _make_template_manager(template)
+
+        config = await resolve_effective_config(session, tm, pm)
+
+        assert config.assigned_secrets == ["ssh_test2"]
+
+    async def test_template_override_replaces_profile_allowlist_domains(self):
+        """template_overrides.docker_proxy_allowlist_domains replaces (not unions) the profile value."""
         profile = _make_profile(
             area="isolation",
             config={"docker_proxy_allowlist_domains": "profile.com"},
@@ -612,38 +629,21 @@ class TestAdditiveAllowlistMerge:
             template_overrides={"docker_proxy_allowlist_domains": ["override.com"]},
             profile_ids={"isolation": profile.profile_id},
         )
-        session = _make_session(
-            template_id="tmpl-001",
-            session_overrides={"docker_proxy_allowlist_domains": ["session.com"]},
-        )
+        session = _make_session(template_id="tmpl-001")
         tm = _make_template_manager(template)
 
         config = await resolve_effective_config(session, tm, pm)
 
-        assert config.docker_proxy_allowlist_domains is not None
-        domains = set(config.docker_proxy_allowlist_domains)
-        assert "profile.com" in domains
-        assert "override.com" in domains
-        assert "session.com" in domains
+        assert config.docker_proxy_allowlist_domains == ["override.com"]
 
-    async def test_empty_allowlist_no_crash(self):
-        """None/empty at all tiers produces None (no crash)."""
-        template = _make_template()
-        session = _make_session(template_id="tmpl-001")
-        tm = _make_template_manager(template)
-
-        config = await resolve_effective_config(session, tm)
-        assert config.docker_proxy_allowlist_domains is None
-
-    async def test_allowlist_deduplication(self):
-        """Duplicate domains across tiers produce a unique sorted set."""
+    async def test_template_omits_field_inherits_profile_secrets(self):
+        """When template sets no override, profile assigned_secrets is inherited unchanged."""
         profile = _make_profile(
             area="isolation",
-            config={"docker_proxy_allowlist_domains": "dup.com, unique.com"},
+            config={"assigned_secrets": ["ssh_test"]},
         )
         pm = _make_profile_manager([profile])
         template = _make_template(
-            template_overrides={"docker_proxy_allowlist_domains": ["dup.com", "other.com"]},
             profile_ids={"isolation": profile.profile_id},
         )
         session = _make_session(template_id="tmpl-001")
@@ -651,12 +651,93 @@ class TestAdditiveAllowlistMerge:
 
         config = await resolve_effective_config(session, tm, pm)
 
-        domains = config.docker_proxy_allowlist_domains
-        assert domains is not None
-        # No duplicates
-        assert len(domains) == len(set(domains))
-        assert "dup.com" in domains
-        assert "unique.com" in domains
+        assert config.assigned_secrets == ["ssh_test"]
+
+    async def test_template_omits_field_inherits_profile_allowlist_domains(self):
+        """When template sets no override, profile docker_proxy_allowlist_domains is inherited."""
+        profile = _make_profile(
+            area="isolation",
+            config={"docker_proxy_allowlist_domains": ["profile.com"]},
+        )
+        pm = _make_profile_manager([profile])
+        template = _make_template(
+            profile_ids={"isolation": profile.profile_id},
+        )
+        session = _make_session(template_id="tmpl-001")
+        tm = _make_template_manager(template)
+
+        config = await resolve_effective_config(session, tm, pm)
+
+        assert config.docker_proxy_allowlist_domains == ["profile.com"]
+
+    async def test_template_override_empty_list_produces_empty_secrets(self):
+        """template_overrides.assigned_secrets=[] resolves to [] (not None fallback to profile)."""
+        profile = _make_profile(
+            area="isolation",
+            config={"assigned_secrets": ["ssh_test"]},
+        )
+        pm = _make_profile_manager([profile])
+        template = _make_template(
+            template_overrides={"assigned_secrets": []},
+            profile_ids={"isolation": profile.profile_id},
+        )
+        session = _make_session(template_id="tmpl-001")
+        tm = _make_template_manager(template)
+
+        config = await resolve_effective_config(session, tm, pm)
+
+        assert config.assigned_secrets == []
+
+    async def test_template_override_empty_list_produces_empty_allowlist_domains(self):
+        """template_overrides.docker_proxy_allowlist_domains=[] resolves to []."""
+        profile = _make_profile(
+            area="isolation",
+            config={"docker_proxy_allowlist_domains": ["profile.com"]},
+        )
+        pm = _make_profile_manager([profile])
+        template = _make_template(
+            template_overrides={"docker_proxy_allowlist_domains": []},
+            profile_ids={"isolation": profile.profile_id},
+        )
+        session = _make_session(template_id="tmpl-001")
+        tm = _make_template_manager(template)
+
+        config = await resolve_effective_config(session, tm, pm)
+
+        assert config.docker_proxy_allowlist_domains == []
+
+    async def test_session_override_replaces_profile_value(self):
+        """session_overrides fully replaces (not unions) the profile value for tag fields."""
+        profile = _make_profile(
+            area="isolation",
+            config={"assigned_secrets": ["ssh_test"]},
+        )
+        pm = _make_profile_manager([profile])
+        template = _make_template(
+            profile_ids={"isolation": profile.profile_id},
+        )
+        session = _make_session(
+            template_id="tmpl-001",
+            session_overrides={"assigned_secrets": ["session_secret"]},
+        )
+        tm = _make_template_manager(template)
+
+        config = await resolve_effective_config(session, tm, pm)
+
+        assert config.assigned_secrets == ["session_secret"]
+
+    async def test_template_override_supersedes_template_flat_field(self):
+        """template_overrides wins over template flat field for tag fields."""
+        template = _make_template(
+            assigned_secrets=["flat_secret"],
+            template_overrides={"assigned_secrets": ["override_secret"]},
+        )
+        session = _make_session(template_id="tmpl-001")
+        tm = _make_template_manager(template)
+
+        config = await resolve_effective_config(session, tm)
+
+        assert config.assigned_secrets == ["override_secret"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Resolves #1223

Removes additive (union) merge semantics for `docker_proxy_allowlist_domains` and `assigned_secrets` in `resolve_effective_config()`. Both fields now follow standard last-wins precedence, consistent with every other config field.

## Changes Made
- Deleted `ADDITIVE_LIST_FIELDS` constant from `src/config_resolution.py`
- Deleted the 34-line additive-merge block in `resolve_effective_config()` (lines 144–177)
- Replaced `TestAdditiveAllowlistMerge` test class with `TestTagFieldReplaceSemantics` (8 new tests) in `src/tests/test_config_resolution.py`
- Removed `ADDITIVE_LIST_FIELDS` from test file import

## Behavior Change (intentional — called out in issue)

**Before:** template_overrides + profile values were unioned. A template could not remove a secret or domain that its inherited profile granted.

**After:** last-wins precedence applies.
- `template_overrides=[x]` with profile `[y]` → resolved `[x]` only
- `template_overrides=[]` → resolved `[]` (explicit empty, not fallback to profile)
- template omits field → profile value inherited unchanged

**Release notes must document this.** Deployments with templates that relied on additive merge will see only the values explicitly listed in the template's override after this change.

## Testing
- 41 tests in `test_config_resolution.py` pass (8 new `TestTagFieldReplaceSemantics` tests + all pre-existing tests)
- Full suite: 1321 passed, 0 failures
- `uv run ruff check src/config_resolution.py src/tests/test_config_resolution.py` — zero violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)