### PR TITLE
fix: suppress empty poll log noise and rename debug polling flags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -761,7 +761,7 @@ data/
 │   ├── parser.log                  # Message parsing
 │   ├── sdk_debug.log               # SDK integration
 │   ├── storage.log                 # File operations
-│   └── websocket_debug.log         # WebSocket lifecycle
+│   └── polling.log                 # Poll transport signal logging
 │
 ├── projects/{uuid}/                # One folder per project
 │   └── state.json                  # ProjectInfo serialized
@@ -879,7 +879,7 @@ For the complete endpoint reference with request/response details, see [.claude/
 → **Solution**: `src/session_coordinator.py:177-289` (start_session()) + enable `--debug-sdk`
 
 **Problem**: Long-poll events not arriving
-→ **Solution**: Check `src/web_server.py` poll endpoints and `src/event_queue.py`; enable `--debug-websocket` (covers polling)
+→ **Solution**: Check `src/web_server.py` poll endpoints and `src/event_queue.py`; enable `--debug-polling`
 
 **Problem**: Messages not persisting
 → **Solution**: `src/data_storage.py:51-67` (append_message()) + enable `--debug-storage`

--- a/main.py
+++ b/main.py
@@ -64,11 +64,11 @@ def main():
 
     # Debug flags (grouped so they appear under their own section)
     debug_group = parser.add_argument_group("Debug Flags")
-    debug_group.add_argument('--debug-websocket', action='store_true', help='Enable WebSocket lifecycle debugging')
-    # Note: debug_all excludes ping/pong logging due to excessive noise that obscures other debug output.
-    # Ping/pong keepalive messages occur every 3 seconds per WebSocket connection, generating thousands
-    # of log entries that make it difficult to identify relevant debugging information.
-    debug_group.add_argument('--debug-ping-pong', action='store_true', help='Enable WebSocket ping/pong logging (high volume)')
+    debug_group.add_argument('--debug-polling', action='store_true', help='Enable poll transport signal logging (events-returned lines)')
+    # Note: debug_all excludes debug_all_polling due to excessive noise that obscures other debug output.
+    # Idle long-poll hits occur every 30 seconds per connected client, generating access lines
+    # that make it difficult to identify relevant debugging information.
+    debug_group.add_argument('--debug-all-polling', action='store_true', help='Enable full uvicorn access-log for /api/poll/* (high volume)')
     debug_group.add_argument('--debug-sdk', action='store_true', help='Enable SDK integration debugging')
     debug_group.add_argument('--debug-permissions', action='store_true', help='Enable permission callback debugging')
     debug_group.add_argument('--debug-storage', action='store_true', help='Enable data storage debugging')
@@ -82,7 +82,7 @@ def main():
     debug_group.add_argument('--debug-queue-processor', action='store_true', help='Enable queue processor debugging')
     debug_group.add_argument('--debug-archive', action='store_true', help='Enable archive manager debugging')
     debug_group.add_argument('--debug-project-manager', action='store_true', help='Enable project manager debugging')
-    debug_group.add_argument('--debug-all', action='store_true', help='Enable all debug logging (excludes ping/pong)')
+    debug_group.add_argument('--debug-all', action='store_true', help='Enable all debug logging (excludes --debug-all-polling)')
 
     args = parser.parse_args()
 
@@ -108,8 +108,8 @@ def main():
 
     # Configure logging with debug flags
     configure_logging(
-        debug_websocket=args.debug_websocket,
-        debug_ping_pong=args.debug_ping_pong,
+        debug_polling=args.debug_polling,
+        debug_all_polling=args.debug_all_polling,
         debug_sdk=args.debug_sdk,
         debug_permissions=args.debug_permissions,
         debug_storage=args.debug_storage,

--- a/src/logging_config.py
+++ b/src/logging_config.py
@@ -1,7 +1,7 @@
 """Comprehensive logging configuration for Claude Code WebUI.
 
 This module provides a multi-tier logging system with:
-- Category-based debug logging to separate files (e.g., websocket_debug.log, sdk_debug.log)
+- Category-based debug logging to separate files (e.g., polling.log, sdk_debug.log)
 - Unified error logging to error.log (all ERROR+ messages route here)
 - Console output for errors (always) and debug messages (when enabled via CLI flags)
 - Standardized log formatting with timestamps and category tags
@@ -56,6 +56,37 @@ import logging
 import logging.handlers
 from pathlib import Path
 
+
+class PollAccessLogFilter(logging.Filter):
+    """Filter for uvicorn.access that suppresses idle /api/poll/* log lines.
+
+    When allow_all=False (default), records whose request path starts with
+    /api/poll/ are dropped so idle long-poll lines don't flood stdout.
+    When allow_all=True (--debug-all-polling), all records pass through.
+
+    Robust against uvicorn access-log record shapes: if args is not the
+    expected tuple, falls back to getMessage() substring match; on any
+    unexpected shape the record is allowed through (never silently drops
+    unrelated logs).
+    """
+
+    def __init__(self, *, allow_all: bool):
+        super().__init__()
+        self.allow_all = allow_all
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if self.allow_all:
+            return True
+        try:
+            # uvicorn formats: '%s - "%s %s HTTP/%s" %d' % (client, method, path, http_ver, status)
+            if isinstance(record.args, (tuple, list)) and len(record.args) >= 3:
+                path = str(record.args[2])
+            else:
+                path = record.getMessage()
+        except Exception:
+            return True
+        return "/api/poll/" not in path
+
 # Logging configuration constants
 MAX_LOG_FILE_SIZE = 10 * 1024 * 1024  # 10 MB
 LOG_BACKUP_COUNT = 5
@@ -99,8 +130,8 @@ _log_config = {}
 
 
 def configure_logging(
-    debug_websocket: bool = False,
-    debug_ping_pong: bool = False,
+    debug_polling: bool = False,
+    debug_all_polling: bool = False,
     debug_sdk: bool = False,
     debug_permissions: bool = False,
     debug_storage: bool = False,
@@ -120,8 +151,8 @@ def configure_logging(
     """Configure the logging system with CLI flag controls.
 
     Args:
-        debug_websocket: Enable WebSocket lifecycle debugging
-        debug_ping_pong: Enable WebSocket ping/pong logging (excluded from debug_all)
+        debug_polling: Enable poll transport signal logging (events-returned lines)
+        debug_all_polling: Enable full uvicorn access-log lines for /api/poll/* (excluded from debug_all)
         debug_sdk: Enable SDK integration debugging
         debug_permissions: Enable permission callback debugging
         debug_storage: Enable data storage debugging
@@ -135,7 +166,7 @@ def configure_logging(
         debug_queue_processor: Enable queue processor debugging
         debug_archive: Enable archive manager debugging
         debug_project_manager: Enable project manager debugging
-        debug_all: Enable all debug logging (excludes ping/pong due to excessive noise)
+        debug_all: Enable all debug logging (excludes debug_all_polling due to excessive noise)
         log_dir: Directory for log files
 
     Behavior:
@@ -145,10 +176,10 @@ def configure_logging(
           and console output, regardless of debug flag settings.
         - This ensures critical errors are never lost due to disabled debug
           settings.
-        - Ping/pong logging is intentionally excluded from debug_all to prevent
-          excessive noise. WebSocket keepalive messages occur every 3 seconds per
-          connection, generating thousands of log entries that obscure other debug
-          information. Use --debug-ping-pong explicitly if needed.
+        - Full polling access-log lines are intentionally excluded from debug_all
+          to prevent excessive noise. Idle long-poll hits occur every 30 seconds
+          per connected client, generating many access lines that obscure other
+          debug information. Use --debug-all-polling explicitly if needed.
     """
     global _log_config
 
@@ -156,10 +187,10 @@ def configure_logging(
     Path(log_dir).mkdir(parents=True, exist_ok=True)
 
     # Store configuration for get_logger to reference
-    # Note: debug_all excludes ping/pong logging due to excessive noise that obscures other debug output
+    # Note: debug_all excludes debug_all_polling due to excessive noise that obscures other debug output
     _log_config = {
-        'debug_websocket': debug_websocket or debug_all,
-        'debug_ping_pong': debug_ping_pong,  # Only enabled with explicit --debug-ping-pong (excluded from debug_all)
+        'debug_polling': debug_polling or debug_all,
+        'debug_all_polling': debug_all_polling,  # Only enabled with explicit --debug-all-polling (excluded from debug_all)
         'debug_sdk': debug_sdk or debug_all,
         'debug_permissions': debug_permissions or debug_all,
         'debug_storage': debug_storage or debug_all,
@@ -196,16 +227,16 @@ def configure_logging(
 
     # Configure logger definitions
     logger_configs = {
-        'websocket_debug': {
-            'file': f"{log_dir}/websocket_debug.log",
-            'enabled': _log_config['debug_websocket'],
-            'console': _log_config['debug_websocket'],
+        'polling': {
+            'file': f"{log_dir}/polling.log",
+            'enabled': _log_config['debug_polling'],
+            'console': _log_config['debug_polling'],
             'level': logging.DEBUG
         },
-        'websocket_verbose': {
-            'file': f"{log_dir}/websocket_verbose.log",
-            'enabled': _log_config['debug_ping_pong'],
-            'console': _log_config['debug_ping_pong'],
+        'polling_verbose': {
+            'file': f"{log_dir}/polling_verbose.log",
+            'enabled': _log_config['debug_all_polling'],
+            'console': _log_config['debug_all_polling'],
             'level': logging.DEBUG
         },
         # Enable SDK logging when either SDK or permissions debugging is active,
@@ -329,6 +360,13 @@ def configure_logging(
     root_logger.addHandler(error_handler)
     root_logger.addHandler(console_error_handler)
 
+    # Attach PollAccessLogFilter to uvicorn.access (idempotent: clear prior instances first)
+    uvicorn_access_logger = logging.getLogger('uvicorn.access')
+    uvicorn_access_logger.filters = [
+        f for f in uvicorn_access_logger.filters if not isinstance(f, PollAccessLogFilter)
+    ]
+    uvicorn_access_logger.addFilter(PollAccessLogFilter(allow_all=_log_config['debug_all_polling']))
+
     # Log configuration status
     coord_logger = logging.getLogger('coordinator')
     coord_logger.info("Logging system configured")
@@ -338,7 +376,7 @@ def get_logger(name: str, category: str | None = None) -> logging.Logger:
     """Get a logger instance with optional category.
 
     Args:
-        name: Logger name (e.g., 'websocket_debug', 'sdk_debug', 'coordinator')
+        name: Logger name (e.g., 'polling', 'sdk_debug', 'coordinator')
         category: Optional category tag for log messages (e.g., 'WS_LIFECYCLE', 'SDK')
 
     Returns:

--- a/src/routers/poll.py
+++ b/src/routers/poll.py
@@ -4,6 +4,9 @@ from fastapi import APIRouter, HTTPException
 
 from ..event_queue import EventQueue
 from ..exception_handlers import handle_exceptions
+from ..logging_config import get_logger
+
+_polling_logger = get_logger('polling', category='POLL')
 
 
 def build_router(webui) -> APIRouter:
@@ -16,6 +19,11 @@ def build_router(webui) -> APIRouter:
         effective_timeout = min(float(timeout), 30.0)
         await webui.ui_queue.wait_for_events(since, timeout=effective_timeout)
         events, next_cursor = webui.ui_queue.events_since(since)
+        if events:
+            _polling_logger.info(
+                "poll ui returned %d event(s) since=%d next_cursor=%d",
+                len(events), since, next_cursor
+            )
         return {"events": events, "next_cursor": next_cursor}
 
     @router.get("/api/poll/cursor")
@@ -46,6 +54,11 @@ def build_router(webui) -> APIRouter:
         effective_timeout = min(float(timeout), 30.0)
         await queue.wait_for_events(since, timeout=effective_timeout)
         events, next_cursor = queue.events_since(since)
+        if events:
+            _polling_logger.info(
+                "poll session %s returned %d event(s) since=%d next_cursor=%d",
+                session_id, len(events), since, next_cursor
+            )
         return {"events": events, "next_cursor": next_cursor}
 
     return router

--- a/src/tests/integration/test_issue_1200_poll_logging.py
+++ b/src/tests/integration/test_issue_1200_poll_logging.py
@@ -1,0 +1,260 @@
+"""
+Issue #1200: Tests for PollAccessLogFilter and polling app-level logging.
+
+Tests:
+- PollAccessLogFilter: allows/rejects records based on path and allow_all flag
+- configure_logging attaches PollAccessLogFilter to uvicorn.access
+- debug_polling=True enables polling logger; debug_all_polling excluded from debug_all
+- App-level polling logger emits when events > 0, silent on empty poll
+"""
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from src.logging_config import PollAccessLogFilter, configure_logging, get_logger
+
+# ===========================================================================
+# PollAccessLogFilter unit tests
+# ===========================================================================
+
+
+def _make_access_record(method: str, path: str, status: int = 200) -> logging.LogRecord:
+    """Build a fake uvicorn access-log LogRecord with the expected args shape."""
+    record = logging.LogRecord(
+        name="uvicorn.access",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg='%s - "%s %s HTTP/%s" %d',
+        args=("127.0.0.1:12345", method, path, "1.1", status),
+        exc_info=None,
+    )
+    return record
+
+
+@pytest.fixture(autouse=True)
+def reset_logging_after():
+    yield
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.setLevel(logging.WARNING)
+    for name in ("polling", "polling_verbose", "sdk_debug", "coordinator",
+                 "storage", "parser", "error_handler", "session_manager",
+                 "legion", "template_manager"):
+        lg = logging.getLogger(name)
+        lg.handlers.clear()
+        lg.setLevel(logging.NOTSET)
+        lg.propagate = True
+    uvicorn_access = logging.getLogger("uvicorn.access")
+    uvicorn_access.filters = [
+        f for f in uvicorn_access.filters if not isinstance(f, PollAccessLogFilter)
+    ]
+
+
+class TestPollAccessLogFilter:
+    """Unit tests for PollAccessLogFilter."""
+
+    def test_poll_path_suppressed_when_allow_all_false(self):
+        f = PollAccessLogFilter(allow_all=False)
+        record = _make_access_record("GET", "/api/poll/ui")
+        assert f.filter(record) is False
+
+    def test_poll_session_path_suppressed_when_allow_all_false(self):
+        f = PollAccessLogFilter(allow_all=False)
+        record = _make_access_record("GET", "/api/poll/session/abc-123")
+        assert f.filter(record) is False
+
+    def test_poll_path_allowed_when_allow_all_true(self):
+        f = PollAccessLogFilter(allow_all=True)
+        record = _make_access_record("GET", "/api/poll/ui")
+        assert f.filter(record) is True
+
+    def test_non_poll_path_always_allowed(self):
+        f = PollAccessLogFilter(allow_all=False)
+        for path in ("/api/sessions", "/api/projects", "/", "/api/poll-unrelated"):
+            record = _make_access_record("GET", path)
+            assert f.filter(record) is True, f"expected True for path={path}"
+
+    def test_robust_against_unexpected_args_shape(self):
+        """Filter must return True (allow) when args don't match expected shape."""
+        f = PollAccessLogFilter(allow_all=False)
+        record = logging.LogRecord(
+            name="uvicorn.access",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="some unexpected format",
+            args=(),
+            exc_info=None,
+        )
+        assert f.filter(record) is True
+
+    def test_robust_against_none_args(self):
+        f = PollAccessLogFilter(allow_all=False)
+        record = logging.LogRecord(
+            name="uvicorn.access",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="plain message /api/poll/ui",
+            args=None,
+            exc_info=None,
+        )
+        # Falls back to getMessage() substring match
+        assert f.filter(record) is False
+
+    def test_robust_against_short_args_tuple(self):
+        """Tuple shorter than 3 elements falls back to getMessage() and should allow."""
+        f = PollAccessLogFilter(allow_all=False)
+        record = logging.LogRecord(
+            name="uvicorn.access",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="only two %s %s",
+            args=("a", "b"),
+            exc_info=None,
+        )
+        assert f.filter(record) is True
+
+
+class TestConfigureLoggingPollFilter:
+    """Tests for filter attachment behaviour in configure_logging."""
+
+    def test_filter_attached_to_uvicorn_access(self, tmp_path):
+        configure_logging(log_dir=str(tmp_path))
+        uvicorn_access = logging.getLogger("uvicorn.access")
+        poll_filters = [f for f in uvicorn_access.filters if isinstance(f, PollAccessLogFilter)]
+        assert len(poll_filters) == 1
+
+    def test_filter_allow_all_false_by_default(self, tmp_path):
+        configure_logging(log_dir=str(tmp_path))
+        uvicorn_access = logging.getLogger("uvicorn.access")
+        poll_filter = next(f for f in uvicorn_access.filters if isinstance(f, PollAccessLogFilter))
+        assert poll_filter.allow_all is False
+
+    def test_filter_allow_all_true_when_debug_all_polling(self, tmp_path):
+        configure_logging(debug_all_polling=True, log_dir=str(tmp_path))
+        uvicorn_access = logging.getLogger("uvicorn.access")
+        poll_filter = next(f for f in uvicorn_access.filters if isinstance(f, PollAccessLogFilter))
+        assert poll_filter.allow_all is True
+
+    def test_filter_idempotent_on_reconfigure(self, tmp_path):
+        configure_logging(log_dir=str(tmp_path))
+        configure_logging(log_dir=str(tmp_path))
+        uvicorn_access = logging.getLogger("uvicorn.access")
+        poll_filters = [f for f in uvicorn_access.filters if isinstance(f, PollAccessLogFilter)]
+        assert len(poll_filters) == 1
+
+    def test_debug_polling_enables_polling_logger(self, tmp_path):
+        configure_logging(debug_polling=True, log_dir=str(tmp_path))
+        polling_logger = logging.getLogger("polling")
+        assert len(polling_logger.handlers) > 2
+
+    def test_debug_all_polling_excluded_from_debug_all(self, tmp_path):
+        configure_logging(debug_all=True, log_dir=str(tmp_path))
+        polling_verbose = logging.getLogger("polling_verbose")
+        # Only error handlers — not enabled by debug_all
+        assert len(polling_verbose.handlers) == 2
+
+    def test_debug_all_enables_polling(self, tmp_path):
+        configure_logging(debug_all=True, log_dir=str(tmp_path))
+        polling_logger = logging.getLogger("polling")
+        assert len(polling_logger.handlers) > 2
+
+
+class TestPollingLogFileContent:
+    """Tests that verify polling logger writes correct content."""
+
+    def test_empty_poll_produces_no_polling_log(self, tmp_path):
+        configure_logging(debug_polling=True, log_dir=str(tmp_path))
+        poll_log = Path(tmp_path) / "polling.log"
+        # No messages written — file should not exist or be empty
+        if poll_log.exists():
+            assert poll_log.read_text() == ""
+
+    def test_events_returned_log_line(self, tmp_path):
+        configure_logging(debug_polling=True, log_dir=str(tmp_path))
+        logger = get_logger("polling", category="POLL")
+        logger.info("poll ui returned %d event(s) since=%d next_cursor=%d", 3, 0, 3)
+
+        poll_log = Path(tmp_path) / "polling.log"
+        assert poll_log.exists()
+        content = poll_log.read_text()
+        assert "poll ui returned 3 event(s)" in content
+        assert "[POLL]" in content
+
+    def test_polling_logger_silent_when_not_enabled(self, tmp_path):
+        configure_logging(debug_polling=False, log_dir=str(tmp_path))
+        logger = get_logger("polling", category="POLL")
+        logger.info("this should not appear")
+
+        poll_log = Path(tmp_path) / "polling.log"
+        assert not poll_log.exists()
+
+
+# ===========================================================================
+# Integration tests: poll endpoint + logging (via api_integration_env)
+# ===========================================================================
+
+
+class TestPollEndpointLogging:
+    """Integration tests verifying the polling logger fires on real poll responses."""
+
+    async def test_empty_poll_no_log_entry(self, api_integration_env, tmp_path):
+        """Empty /api/poll/ui?since=0&timeout=0 produces no polling.log line."""
+        configure_logging(debug_polling=True, log_dir=str(tmp_path))
+
+        client = api_integration_env["client"]
+        resp = await client.get("/api/poll/ui?since=0&timeout=0")
+        assert resp.status_code == 200
+        assert resp.json()["events"] == []
+
+        poll_log = Path(tmp_path) / "polling.log"
+        if poll_log.exists():
+            content = poll_log.read_text()
+            assert "returned" not in content
+
+    async def test_events_poll_emits_log_line(self, api_integration_env, tmp_path):
+        """Poll returning events emits exactly one polling.log line."""
+        configure_logging(debug_polling=True, log_dir=str(tmp_path))
+
+        client = api_integration_env["client"]
+        webui = api_integration_env["webui"]
+
+        webui.ui_queue.append({"type": "test_evt"})
+        webui.ui_queue.append({"type": "test_evt_2"})
+
+        resp = await client.get("/api/poll/ui?since=0&timeout=0")
+        assert resp.status_code == 200
+        assert len(resp.json()["events"]) >= 2
+
+        poll_log = Path(tmp_path) / "polling.log"
+        assert poll_log.exists()
+        content = poll_log.read_text()
+        assert "poll ui returned" in content
+
+    async def test_session_poll_log_includes_session_id(self, api_integration_env, tmp_path):
+        """Session poll log line includes the session_id."""
+        configure_logging(debug_polling=True, log_dir=str(tmp_path))
+
+        client = api_integration_env["client"]
+        webui = api_integration_env["webui"]
+
+        project = await api_integration_env["create_test_project"]()
+        session = await api_integration_env["create_test_session"](project["project_id"])
+        sid = session["session_id"]
+
+        webui.session_queues[sid].append({"type": "msg"})
+
+        resp = await client.get(f"/api/poll/session/{sid}?since=0&timeout=0")
+        assert resp.status_code == 200
+        assert len(resp.json()["events"]) == 1
+
+        poll_log = Path(tmp_path) / "polling.log"
+        assert poll_log.exists()
+        content = poll_log.read_text()
+        assert "poll session" in content
+        assert sid in content

--- a/src/tests/test_logging_config.py
+++ b/src/tests/test_logging_config.py
@@ -46,7 +46,7 @@ def reset_logging():
 
     # Clear all category loggers
     logger_names = [
-        'websocket_debug', 'websocket_verbose', 'sdk_debug',
+        'polling', 'polling_verbose', 'sdk_debug',
         'coordinator', 'storage', 'parser', 'error_handler',
         'session_manager', 'legion', 'template_manager'
     ]
@@ -187,15 +187,15 @@ class TestConfigureLoggingBasics:
         configure_logging(debug_all=True, log_dir=temp_log_dir)
 
         # Check that key loggers are enabled
-        assert len(logging.getLogger('websocket_debug').handlers) > 2
+        assert len(logging.getLogger('polling').handlers) > 2
         assert len(logging.getLogger('sdk_debug').handlers) > 2
         assert len(logging.getLogger('storage').handlers) > 2
 
-    def test_ping_pong_excluded_from_debug_all(self, temp_log_dir):
-        """Test that ping/pong logging is NOT enabled by debug_all."""
+    def test_all_polling_excluded_from_debug_all(self, temp_log_dir):
+        """Test that full poll access-log is NOT enabled by debug_all."""
         configure_logging(debug_all=True, log_dir=temp_log_dir)
 
-        verbose_logger = logging.getLogger('websocket_verbose')
+        verbose_logger = logging.getLogger('polling_verbose')
         # Should only have error handlers, not debug handlers
         assert len(verbose_logger.handlers) == 2  # error.log + console error
 
@@ -203,13 +203,13 @@ class TestConfigureLoggingBasics:
 class TestIndividualDebugFlags:
     """Test individual debug flag behavior."""
 
-    def test_debug_websocket_flag(self, temp_log_dir):
-        """Test debug_websocket flag enables websocket logging."""
-        configure_logging(debug_websocket=True, log_dir=temp_log_dir)
+    def test_debug_polling_flag(self, temp_log_dir):
+        """Test debug_polling flag enables polling signal logging."""
+        configure_logging(debug_polling=True, log_dir=temp_log_dir)
 
-        ws_logger = logging.getLogger('websocket_debug')
+        poll_logger = logging.getLogger('polling')
         # Should have: file handler + console + error.log + console error
-        assert len(ws_logger.handlers) >= 3
+        assert len(poll_logger.handlers) >= 3
 
     def test_debug_sdk_flag(self, temp_log_dir):
         """Test debug_sdk flag enables SDK logging."""
@@ -420,14 +420,14 @@ class TestIntegration:
         configure_logging(
             debug_sdk=True,
             debug_storage=True,
-            debug_websocket=True,
+            debug_polling=True,
             log_dir=temp_log_dir
         )
 
         # Create loggers with categories
         sdk_logger = get_logger('sdk_debug', category='SDK')
         storage_logger = get_logger('storage', category='STORAGE')
-        ws_logger = get_logger('websocket_debug', category='WS')
+        poll_logger = get_logger('polling', category='POLL')
 
         # Write various log levels
         sdk_logger.debug('SDK debug message')
@@ -436,12 +436,12 @@ class TestIntegration:
         storage_logger.info('Storage info message')
         storage_logger.error('Storage error message')
 
-        ws_logger.debug('WebSocket debug message')
+        poll_logger.info('poll ui returned 3 event(s)')
 
         # Verify files exist
         assert (Path(temp_log_dir) / 'sdk_debug.log').exists()
         assert (Path(temp_log_dir) / 'storage.log').exists()
-        assert (Path(temp_log_dir) / 'websocket_debug.log').exists()
+        assert (Path(temp_log_dir) / 'polling.log').exists()
         assert (Path(temp_log_dir) / 'error.log').exists()
 
         # Verify content routing


### PR DESCRIPTION
## Summary
Resolves #1200

Suppresses idle long-poll access-log noise and renames the two polling-related debug flags from WebSocket naming to polling transport naming.

## Changes Made

- **`src/logging_config.py`**: Add `PollAccessLogFilter` class; attach to `uvicorn.access` logger inside `configure_logging` to suppress `/api/poll/*` access-log lines when `--debug-all-polling` is not set. Rename `configure_logging` kwargs (`debug_websocket`→`debug_polling`, `debug_ping_pong`→`debug_all_polling`), `_log_config` keys, and logger names (`websocket_debug`→`polling`, `websocket_verbose`→`polling_verbose`); log files renamed accordingly (`polling.log`, `polling_verbose.log`).
- **`src/routers/poll.py`**: Import `get_logger`, create module-level `_polling_logger`; emit one `INFO` line per poll response carrying ≥1 event (endpoint, session id, count, cursors). Silent on empty polls.
- **`main.py`**: Rename `--debug-websocket`→`--debug-polling`, `--debug-ping-pong`→`--debug-all-polling` inside `debug_group` (PR #1224 structure); update help text and `configure_logging` call.
- **`src/tests/test_logging_config.py`**: Rename test methods and logger name references throughout.
- **`src/tests/integration/test_issue_1200_poll_logging.py`** *(new)*: Unit tests for `PollAccessLogFilter` (allow/reject/robustness) + integration tests verifying polling logger fires on real poll endpoint responses.
- **`CLAUDE.md`**: Update data directory tree (`polling.log`) and troubleshooting hint (`--debug-polling`).

## Testing
- 1337 unit + integration tests pass with zero failures
- Targeted test files: `test_logging_config.py` (29 tests), `test_issue_1200_poll_logging.py` (20 tests) — all green

## Notes

**Hard rename — no aliasing.** Old `--debug-websocket` / `--debug-ping-pong` will produce argparse "unrecognized arguments" error on next invocation. The new names are discoverable via `--help`.

**Coordination with #1201:** Renames applied inside `debug_group.add_argument()` calls (lines 64–82 of `main.py`), introduced by PR #1224. If #1201 touches argparse again, conflict surface is two flag names at known lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)