### PR TITLE
fix: guard --add-host flag to native Linux only in proxy sidecar

### DIFF
--- a/src/docker/claude-docker
+++ b/src/docker/claude-docker
@@ -252,10 +252,27 @@ if [ -n "$PROXY_IMAGE" ]; then
         done
     fi
 
+    # Issue #1233: --add-host overrides macOS/Windows runtime-provided host.docker.internal
+    # entry, breaking Rancher Desktop. Apply only on native Linux where Docker doesn't
+    # auto-inject. WSL2 reports uname -s as Linux but uses Docker Desktop's host gateway
+    # injection, so detect and skip there as well.
+    ADD_HOST_FLAG=""
+    if [ "$(uname -s)" = "Linux" ]; then
+        IS_WSL=0
+        if [ -r /proc/sys/kernel/osrelease ]; then
+            case "$(cat /proc/sys/kernel/osrelease)" in
+                *microsoft*|*Microsoft*|*WSL*) IS_WSL=1 ;;
+            esac
+        fi
+        if [ "$IS_WSL" = "0" ]; then
+            ADD_HOST_FLAG="--add-host=host.docker.internal:host-gateway"
+        fi
+    fi
+
     docker run -d \
         --name "$PROXY_NAME" \
         --cap-add NET_ADMIN \
-        --add-host=host.docker.internal:host-gateway \
+        $ADD_HOST_FLAG \
         --sysctl net.ipv4.ip_forward=1 \
         --sysctl net.ipv4.conf.lo.accept_local=1 \
         -v "$PROXY_CERTS:/var/lib/mitmproxy" \


### PR DESCRIPTION
## Summary
Resolves #1233

PR #1185 added `--add-host=host.docker.internal:host-gateway` unconditionally to fix Linux hosts where Docker doesn't auto-inject the entry. This breaks Rancher Desktop on macOS, which auto-injects `host.docker.internal` → `192.168.5.2` (the macOS host); the unconditional flag overrides it with `172.17.0.1` (the Lima VM bridge), causing `addon.py`'s `running()` hook to receive `[Errno 111] Connection refused`, preventing the `.ready` file from being written and failing session startup.

## Changes Made
- Add OS detection block in `src/docker/claude-docker` before the proxy `docker run -d` invocation
- Set `ADD_HOST_FLAG=--add-host=host.docker.internal:host-gateway` only on native Linux
- Skip flag on WSL2 (detected via `/proc/sys/kernel/osrelease` substring match: `microsoft|Microsoft|WSL`) since Docker Desktop on Windows auto-injects the entry
- Skip flag on macOS and Windows where `uname -s` is not `Linux`
- Replace unconditional `--add-host` line in `docker run` with `$ADD_HOST_FLAG`

## Testing
- `bash -n src/docker/claude-docker` passes (syntax check)
- Full pytest suite: 1375 passed, 0 failures
- No Python code modified; Ruff not applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)