### PR TITLE
chore: pin Claude Code CLI version in Dockerfiles via build ARG

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -84,7 +84,9 @@ USER claude
 RUN curl -fsSL https://astral.sh/uv/install.sh | bash
 
 # ---------- Layer 7: Claude Code CLI ----------
-RUN curl -fsSL https://claude.ai/install.sh | bash
+# Bump in lockstep with claude-agent-sdk in pyproject.toml/uv.lock.
+ARG CLAUDE_CODE_VERSION=2.1.121
+RUN curl -fsSL https://claude.ai/install.sh | bash -s ${CLAUDE_CODE_VERSION}
 
 # ---------- Layer 8: PATH and entrypoint ----------
 ENV PATH="/home/claude/.local/bin:${PATH}"

--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -25,7 +25,9 @@ USER claude
 
 # Install Claude Code using the official native installer
 # This downloads the correct platform binary, verifies checksum, and installs it
-RUN curl -fsSL https://claude.ai/install.sh | bash
+# Bump in lockstep with claude-agent-sdk in pyproject.toml/uv.lock.
+ARG CLAUDE_CODE_VERSION=2.1.121
+RUN curl -fsSL https://claude.ai/install.sh | bash -s ${CLAUDE_CODE_VERSION}
 
 # Ensure the binary is on PATH
 ENV PATH="/home/claude/.local/bin:${PATH}"


### PR DESCRIPTION
## Summary
Resolves #1252

Pin the Claude Code CLI version in both Dockerfiles using a Docker build ARG so that image builds are deterministic and upgrades invalidate only the install layer.

## Changes Made
- `src/docker/Dockerfile`: Added `ARG CLAUDE_CODE_VERSION=2.1.121` immediately before the Claude Code install `RUN` layer; updated `RUN` to `bash -s ${CLAUDE_CODE_VERSION}`
- `docker/Dockerfile.dev`: Same change at the `# ---------- Layer 7: Claude Code CLI ----------` block
- Added comment in both files instructing maintainers to bump the version in lockstep with `claude-agent-sdk` in `pyproject.toml`/`uv.lock`

## Testing
- Default builds install `2.1.121` (matches CLI bundled with `claude-agent-sdk==0.1.69`)
- Bumping the ARG default invalidates only the install layer and onward (cache-safe)
- `--build-arg CLAUDE_CODE_VERSION=<other>` overrides the pinned version for ad-hoc builds
- No Python source modified; Ruff and pytest are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)