### PR TITLE
feat: include working_directory in list_minions and get_minion_info responses

### DIFF
--- a/src/legion/mcp/legion_mcp_tools.py
+++ b/src/legion/mcp/legion_mcp_tools.py
@@ -28,7 +28,8 @@ except ImportError:
 
 from src.config_resolution import resolve_template_config
 from src.docker_utils import translate_docker_tmp_path
-from src.session_config import DEFAULTS as _SESSION_DEFAULTS, SessionConfig
+from src.session_config import DEFAULTS as _SESSION_DEFAULTS
+from src.session_config import SessionConfig
 from src.task_utils import task_done_log_exception
 
 logger = logging.getLogger(__name__)
@@ -1534,11 +1535,13 @@ class LegionMCPTools:
                 role = minion.role or "No role specified"
                 state = minion.state.value if hasattr(minion.state, 'value') else str(minion.state)
                 capabilities = ", ".join(minion.capabilities) if minion.capabilities else "None"
+                cwd = minion.working_directory or "N/A"
 
                 minion_lines.append(
                     f"• **{name}** (slug: {slug}, ID: {minion.session_id})\n"
                     f"  - Role: {role}\n"
                     f"  - State: {state}\n"
+                    f"  - Working Directory: {cwd}\n"
                     f"  - Capabilities: {capabilities}"
                 )
 
@@ -1634,6 +1637,7 @@ class LegionMCPTools:
         profile_lines.append(f"**ID:** {minion.session_id[:8]}...")
         profile_lines.append(f"**Slug:** {minion.slug or 'N/A'}")
         profile_lines.append(f"**Role:** {minion.role or 'No role specified'}")
+        profile_lines.append(f"**Working Directory:** {minion.working_directory or 'N/A'}")
 
         # State
         state_str = minion.state.value if hasattr(minion.state, 'value') else str(minion.state)

--- a/src/tests/integration/test_discovery_tools.py
+++ b/src/tests/integration/test_discovery_tools.py
@@ -406,3 +406,103 @@ async def test_get_minion_info_empty_name(legion_test_env):
 
     response_text = result["content"][0]["text"]
     assert "required" in response_text.lower()
+
+
+# ============================================================================
+# working_directory field Tests
+# ============================================================================
+
+@pytest.mark.asyncio
+async def test_list_minions_includes_working_directory(legion_test_env):
+    """
+    Test list_minions includes working_directory for each minion entry.
+
+    Verifies:
+    - Each real minion entry shows a Working Directory line
+    - The configured path value is present in the output
+    """
+    env = legion_test_env
+    legion_system = env["legion_system"]
+    session_manager = env["session_coordinator"].session_manager
+
+    minion1, minion2 = await _setup_siblings(
+        env,
+        ("wd-worker1", "Worker"),
+        ("wd-worker2", "Analyst"),
+    )
+
+    # Set distinct working directories on each minion
+    await session_manager.update_session(minion1.session_id, working_directory="/tmp/worker1")
+    await session_manager.update_session(minion2.session_id, working_directory="/tmp/worker2")
+
+    result = await legion_system.mcp_tools._handle_list_minions({
+        "_from_minion_id": minion1.session_id
+    })
+
+    assert result.get("is_error") is not True
+    response_text = result["content"][0]["text"]
+
+    # worker2 is visible as a sibling; its path must appear
+    assert "Working Directory:" in response_text
+    assert "/tmp/worker2" in response_text
+
+
+@pytest.mark.asyncio
+async def test_get_minion_info_includes_working_directory(legion_test_env):
+    """
+    Test get_minion_info profile includes Working Directory field.
+
+    Verifies:
+    - Profile contains a Working Directory line
+    - The configured path value is present
+    """
+    env = legion_test_env
+    legion_system = env["legion_system"]
+    session_manager = env["session_coordinator"].session_manager
+
+    target = await env["create_minion"]("wd-target", role="Target")
+    caller = await env["create_minion"]("wd-caller", role="Caller")
+
+    await session_manager.update_session(target.session_id, working_directory="/tmp/target_work")
+
+    result = await legion_system.mcp_tools._handle_get_minion_info({
+        "_from_minion_id": caller.session_id,
+        "minion_name": "wd-target"
+    })
+
+    assert result.get("is_error") is not True
+    response_text = result["content"][0]["text"]
+
+    assert "Working Directory:" in response_text
+    assert "/tmp/target_work" in response_text
+
+
+@pytest.mark.asyncio
+async def test_get_minion_info_working_directory_null(legion_test_env):
+    """
+    Test get_minion_info shows Working Directory: N/A when cwd is None.
+
+    Verifies:
+    - Field is always present (not omitted)
+    - Null/missing cwd renders as N/A
+    """
+    env = legion_test_env
+    legion_system = env["legion_system"]
+    session_manager = env["session_coordinator"].session_manager
+
+    target = await env["create_minion"]("null-cwd-target", role="Target")
+    caller = await env["create_minion"]("null-cwd-caller", role="Caller")
+
+    # Explicitly clear working_directory to simulate missing cwd
+    await session_manager.update_session(target.session_id, working_directory=None)
+
+    result = await legion_system.mcp_tools._handle_get_minion_info({
+        "_from_minion_id": caller.session_id,
+        "minion_name": "null-cwd-target"
+    })
+
+    assert result.get("is_error") is not True
+    response_text = result["content"][0]["text"]
+
+    assert "Working Directory:" in response_text
+    assert "N/A" in response_text


### PR DESCRIPTION
## Summary
Resolves #1212

Expose each minion's working directory in the two MCP discovery tool responses so overseers and peers can determine filesystem context without consulting out-of-band sources.

## Changes Made
- `_handle_list_minions` (`src/legion/mcp/legion_mcp_tools.py`): append `Working Directory: <cwd>` line to each real minion entry; synthetic `user` entry is unchanged; renders `N/A` when `working_directory` is `None`
- `_handle_get_minion_info` (`src/legion/mcp/legion_mcp_tools.py`): insert `**Working Directory:** <cwd>` line after `**Role:**` so identity/location fields cluster together before runtime state
- Add 3 integration tests in `src/tests/integration/test_discovery_tools.py` covering the new field in list output, profile output, and null/missing cwd case

## Testing
- `uv run pytest src/tests/integration/test_discovery_tools.py -v -m slow` — 13/13 passed (10 existing + 3 new)
- `uv run pytest src/tests/test_legion_mcp_tools.py -v` — 18/18 passed (no regressions)
- `uv run ruff check --fix src/legion/mcp/legion_mcp_tools.py src/tests/integration/test_discovery_tools.py` — zero violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)