### PR TITLE
fix: resolve proxy secret write-back for template-linked sessions

### DIFF
--- a/src/application_service.py
+++ b/src/application_service.py
@@ -690,6 +690,19 @@ class ApplicationService:
             value=None,
         )
 
+    def _resolve_writeable_secret_names(self, session) -> list[str]:
+        """Names the proxy can both resolve and write back for this session.
+
+        Source order (deduped, preserves first occurrence):
+          1. session.config["assigned_secrets"] — direct session-level overrides
+          2. session.secret_placeholders.values() — template/profile-derived names captured at start_session()
+        """
+        names: list[str] = list(session.config.get("assigned_secrets") or [])
+        for name in (session.secret_placeholders or {}).values():
+            if name not in names:
+                names.append(name)
+        return names
+
     async def resolve_secrets_for_session(self, session_id: str) -> dict:
         """Return resolved secrets (including values) for a session's assigned_secrets list.
 
@@ -701,13 +714,7 @@ class ApplicationService:
         if session is None:
             return {"secrets": []}
 
-        assigned = list(session.config.get("assigned_secrets") or [])
-        # Issue #1219: also include secrets from secret_placeholders — these capture
-        # template/profile-derived assigned_secrets that were never written back to
-        # session.assigned_secrets.
-        for name in (session.secret_placeholders or {}).values():
-            if name not in assigned:
-                assigned.append(name)
+        assigned = self._resolve_writeable_secret_names(session)
 
         # Collect transitive names (sibling refresh-token and client-secret records).
         all_names: list[str] = list(assigned)
@@ -741,7 +748,7 @@ class ApplicationService:
         session = await self.coordinator.session_manager.get_session_info(session_id)
         if session is None:
             return None
-        assigned = session.config.get("assigned_secrets") or []
+        assigned = self._resolve_writeable_secret_names(session)
         allowed: set[str] = set(assigned)
         # Also allow transitive sibling records referenced by assigned refresh specs.
         for secret in await self.coordinator.credential_vault.list_secrets():

--- a/src/tests/test_application_service.py
+++ b/src/tests/test_application_service.py
@@ -520,3 +520,105 @@ async def test_issue_1219_no_duplicates_when_both_assigned_and_placeholder_set(s
 
     names_passed = mock_coordinator.credential_vault.resolve_secrets_for_assignment.call_args[0][0]
     assert names_passed.count("claudecode_token") == 1
+
+
+# ---------------------------------------------------------------------------
+# Secrets / Issue #1241 — proxy write-back fix for template-linked sessions
+# ---------------------------------------------------------------------------
+
+
+def _make_session_post_1230(assigned_secrets=None, secret_placeholders=None):
+    s = MagicMock()
+    s.config = {"assigned_secrets": assigned_secrets} if assigned_secrets is not None else {}
+    s.secret_placeholders = secret_placeholders or {}
+    return s
+
+
+@pytest.mark.asyncio
+async def test_issue_1241_patch_template_derived_secret_succeeds(service, mock_coordinator):
+    session = _make_session_post_1230(
+        assigned_secrets=None,
+        secret_placeholders={"CC_SECRET_x": "claudecode_token"},
+    )
+    mock_coordinator.session_manager.get_session_info.return_value = session
+    mock_coordinator.credential_vault = MagicMock()
+    mock_coordinator.credential_vault.list_secrets = AsyncMock(return_value=[])
+    service.update_secret = AsyncMock(return_value={"name": "claudecode_token"})
+
+    result = await service.update_secret_for_session("s1", "claudecode_token", value="new_tok")
+
+    service.update_secret.assert_called_once_with(name="claudecode_token", value="new_tok")
+    assert result == {"name": "claudecode_token"}
+
+
+@pytest.mark.asyncio
+async def test_issue_1241_patch_profile_derived_secret_succeeds(service, mock_coordinator):
+    # Profile-derived names flow through secret_placeholders identically to template-derived ones.
+    session = _make_session_post_1230(
+        assigned_secrets=None,
+        secret_placeholders={"CC_SECRET_profile": "profile_token"},
+    )
+    mock_coordinator.session_manager.get_session_info.return_value = session
+    mock_coordinator.credential_vault = MagicMock()
+    mock_coordinator.credential_vault.list_secrets = AsyncMock(return_value=[])
+    service.update_secret = AsyncMock(return_value={"name": "profile_token"})
+
+    result = await service.update_secret_for_session("s1", "profile_token", value="refreshed")
+
+    service.update_secret.assert_called_once_with(name="profile_token", value="refreshed")
+    assert result == {"name": "profile_token"}
+
+
+@pytest.mark.asyncio
+async def test_issue_1241_patch_unrelated_secret_rejected(service, mock_coordinator):
+    session = _make_session_post_1230(
+        assigned_secrets=None,
+        secret_placeholders={"CC_SECRET_x": "claudecode_token"},
+    )
+    mock_coordinator.session_manager.get_session_info.return_value = session
+    mock_coordinator.credential_vault = MagicMock()
+    mock_coordinator.credential_vault.list_secrets = AsyncMock(return_value=[])
+
+    with pytest.raises(PermissionError):
+        await service.update_secret_for_session("s1", "some_other_secret")
+
+
+@pytest.mark.asyncio
+async def test_issue_1241_patch_transitive_sibling_succeeds(service, mock_coordinator):
+    session = _make_session_post_1230(
+        assigned_secrets=None,
+        secret_placeholders={"CC_SECRET_tok": "oauth_token"},
+    )
+    mock_coordinator.session_manager.get_session_info.return_value = session
+    mock_coordinator.credential_vault = MagicMock()
+    mock_coordinator.credential_vault.list_secrets = AsyncMock(
+        return_value=[
+            {
+                "name": "oauth_token",
+                "refresh": {"refresh_token_secret_name": "oauth_refresh"},
+            }
+        ]
+    )
+    service.update_secret = AsyncMock(return_value={"name": "oauth_refresh"})
+
+    result = await service.update_secret_for_session("s1", "oauth_refresh", value="new_refresh")
+
+    service.update_secret.assert_called_once_with(name="oauth_refresh", value="new_refresh")
+    assert result == {"name": "oauth_refresh"}
+
+
+@pytest.mark.asyncio
+async def test_issue_1241_patch_session_overridden_secret_succeeds(service, mock_coordinator):
+    session = _make_session_post_1230(
+        assigned_secrets=["my_secret"],
+        secret_placeholders=None,
+    )
+    mock_coordinator.session_manager.get_session_info.return_value = session
+    mock_coordinator.credential_vault = MagicMock()
+    mock_coordinator.credential_vault.list_secrets = AsyncMock(return_value=[])
+    service.update_secret = AsyncMock(return_value={"name": "my_secret"})
+
+    result = await service.update_secret_for_session("s1", "my_secret", value="direct_val")
+
+    service.update_secret.assert_called_once_with(name="my_secret", value="direct_val")
+    assert result == {"name": "my_secret"}


### PR DESCRIPTION
## Summary
Fixes #1241

Post-#1230, template-linked sessions have empty `session.config` — `assigned_secrets` live in `session.secret_placeholders` instead. `update_secret_for_session` read only `session.config["assigned_secrets"]`, so proxy PATCH requests for template-derived token names were incorrectly denied with 403, breaking OAuth token refresh and leaving sessions with expired credentials.

## Changes Made
- Extract `_resolve_writeable_secret_names(session)` helper on `ApplicationService` that merges `session.config["assigned_secrets"]` (direct overrides) with `session.secret_placeholders.values()` (template/profile-derived names), deduped in insertion order
- Replace inline name-set construction in `resolve_secrets_for_session` with a call to the helper (behavior identical — literal extraction)
- Replace `session.config.get("assigned_secrets") or []` in `update_secret_for_session` with a call to the helper (the fix)
- Transitive sibling expansion (`refresh_token_secret_name`, `client_secret_secret_name`) remains at each call site unchanged

## Testing
- 5 new unit tests in `src/tests/test_application_service.py`:
  - `test_issue_1241_patch_template_derived_secret_succeeds`
  - `test_issue_1241_patch_profile_derived_secret_succeeds`
  - `test_issue_1241_patch_unrelated_secret_rejected` (security boundary preserved)
  - `test_issue_1241_patch_transitive_sibling_succeeds`
  - `test_issue_1241_patch_session_overridden_secret_succeeds` (legacy path preserved)
- Full test suite: 1392 passed, 0 failures

## Notes
- Backend-only change; no frontend, no migration, no API contract changes
- Security boundary is preserved: only names resolvable by the session are writeable

🤖 Generated with [Claude Code](https://claude.com/claude-code)