### PR TITLE
feat(archive): unified session archival + reset cleanup

### DIFF
--- a/src/data_storage.py
+++ b/src/data_storage.py
@@ -155,6 +155,31 @@ class DataStorageManager:
             logger.exception("Failed to clear messages")
             return False
 
+    async def clear_queue(self) -> bool:
+        """Truncate queue.jsonl to empty (issue #1244 reset cleanup)."""
+        try:
+            queue_file = self.session_dir / "queue.jsonl"
+            if queue_file.exists():
+                queue_file.write_bytes(b"")
+                storage_logger.info(f"Cleared queue.jsonl for session {self.session_dir.name}")
+            return True
+        except Exception:
+            logger.exception("Failed to clear queue")
+            return False
+
+    async def clear_attachments(self) -> bool:
+        """Remove attachments/ directory entirely (issue #1244 reset cleanup)."""
+        try:
+            import shutil
+            att_dir = self.session_dir / "attachments"
+            if att_dir.is_dir():
+                shutil.rmtree(att_dir)
+                storage_logger.info(f"Cleared attachments/ for session {self.session_dir.name}")
+            return True
+        except Exception:
+            logger.exception("Failed to clear attachments")
+            return False
+
     async def cleanup(self):
         """Cleanup and ensure all file handles and directory references are closed"""
         try:

--- a/src/legion/archive_manager.py
+++ b/src/legion/archive_manager.py
@@ -28,6 +28,27 @@ archive_logger = get_logger('archive', category='ARCHIVE')
 logger = logging.getLogger(__name__)
 
 
+_SCRUB_KEYS = {"secret_fetch_token"}
+_RUNTIME_KEYS = {
+    "is_processing",
+    "latest_message",
+    "latest_message_type",
+    "latest_message_time",
+    "claude_code_session_id",
+}
+
+
+def scrub_state_for_archive(state: dict) -> dict:
+    """Return a copy of state with sensitive and runtime-only keys removed."""
+    out = {k: v for k, v in state.items() if k not in _SCRUB_KEYS}
+    for k in _RUNTIME_KEYS:
+        out.pop(k, None)
+    err = out.pop("error_message", None)
+    if err:
+        out["error_summary"] = (err[:200] + "…") if len(err) > 200 else err
+    return out
+
+
 class ArchiveManager:
     """Manages archiving of disposed minion session data."""
 

--- a/src/legion/archive_manager.py
+++ b/src/legion/archive_manager.py
@@ -582,6 +582,134 @@ class ArchiveManager:
             archive_logger.error(f"Failed to read archive resource file: {e}")
             return None
 
+    async def get_archive_queue(
+        self, session_id: str, archive_id: str
+    ) -> list[dict]:
+        """Read queue.jsonl from an archive, returning parsed records."""
+        archive_dir = self.archives_dir / session_id / archive_id
+        queue_file = archive_dir / "queue.jsonl"
+        if not queue_file.exists():
+            return []
+        records: list[dict] = []
+        try:
+            with open(queue_file, encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if line:
+                        try:
+                            records.append(json.loads(line))
+                        except json.JSONDecodeError:
+                            pass
+        except OSError as e:
+            archive_logger.error(f"Failed to read archive queue: {e}")
+        return records
+
+    async def get_archive_proxy_logs(
+        self, session_id: str, archive_id: str
+    ) -> list[dict]:
+        """List archived proxy log files with size and line count.
+
+        Returns list of {name, size_bytes, line_count} for each log present.
+        """
+        archive_dir = self.archives_dir / session_id / archive_id
+        proxy_dir = archive_dir / "proxy"
+        if not proxy_dir.is_dir():
+            return []
+        result: list[dict] = []
+        for name in _PROXY_LOG_NAMES:
+            log_file = proxy_dir / name
+            if not log_file.exists():
+                continue
+            try:
+                content = log_file.read_bytes()
+                line_count = content.count(b"\n")
+                result.append({
+                    "name": name,
+                    "size_bytes": len(content),
+                    "line_count": line_count,
+                })
+            except OSError as e:
+                archive_logger.error(f"Failed to stat proxy log {name}: {e}")
+        return result
+
+    async def get_archive_history(
+        self, session_id: str, archive_id: str
+    ) -> list[dict]:
+        """List history .md files in an archive, returning {name, size_bytes, mtime}."""
+        archive_dir = self.archives_dir / session_id / archive_id
+        history_dir = archive_dir / "history"
+        if not history_dir.is_dir():
+            return []
+        entries: list[dict] = []
+        for md_file in sorted(history_dir.glob("*.md")):
+            try:
+                stat = md_file.stat()
+                entries.append({
+                    "name": md_file.name,
+                    "size_bytes": stat.st_size,
+                    "mtime": stat.st_mtime,
+                })
+            except OSError:
+                pass
+        return entries
+
+    async def get_archive_schedules(
+        self, session_id: str, archive_id: str
+    ) -> dict:
+        """Read archived schedules.json and schedule_history.jsonl from an archive.
+
+        Returns {schedules: list, history: list}.
+        """
+        archive_dir = self.archives_dir / session_id / archive_id
+        schedules: list = []
+        history: list = []
+
+        sched_file = archive_dir / "schedules.json"
+        if sched_file.exists():
+            try:
+                schedules = json.loads(sched_file.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError) as e:
+                archive_logger.error(f"Failed to read archived schedules: {e}")
+
+        hist_file = archive_dir / "schedule_history.jsonl"
+        if hist_file.exists():
+            try:
+                with open(hist_file, encoding="utf-8") as f:
+                    for line in f:
+                        line = line.strip()
+                        if line:
+                            try:
+                                history.append(json.loads(line))
+                            except json.JSONDecodeError:
+                                pass
+            except OSError as e:
+                archive_logger.error(f"Failed to read archived schedule history: {e}")
+
+        return {"schedules": schedules, "history": history}
+
+    async def get_archive_attachments(
+        self, session_id: str, archive_id: str
+    ) -> list[dict]:
+        """List files in archived attachments/ directory.
+
+        Returns list of {name, size_bytes} for each file present.
+        """
+        archive_dir = self.archives_dir / session_id / archive_id
+        att_dir = archive_dir / "attachments"
+        if not att_dir.is_dir():
+            return []
+        entries: list[dict] = []
+        for att_file in sorted(att_dir.iterdir()):
+            if att_file.is_file():
+                try:
+                    entries.append({
+                        "name": att_file.name,
+                        "size_bytes": att_file.stat().st_size,
+                    })
+                except OSError:
+                    pass
+        return entries
+
     async def list_project_deleted_agents(self, project_id: str) -> list[dict]:
         """
         List deleted agents for a project by scanning archives.

--- a/src/legion/archive_manager.py
+++ b/src/legion/archive_manager.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 import logging
 import shutil
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -49,6 +50,21 @@ def scrub_state_for_archive(state: dict) -> dict:
     return out
 
 
+_PROXY_LOG_NAMES = ("access.log", "dns.log", "socks5.log", "dropped.log")
+
+
+@dataclass
+class SnapshotContext:
+    """Describes what to include in an archive snapshot."""
+    session_id: str
+    legion_id: str | None
+    auto_memory_directory: Path | None
+    docker_enabled: bool
+    proxy_enabled: bool
+    is_reset: bool
+    will_be_deleted: bool
+
+
 class ArchiveManager:
     """Manages archiving of disposed minion session data."""
 
@@ -70,6 +86,126 @@ class ArchiveManager:
             self._archives_dir = data_dir / "archives" / "minions"
             self._archives_dir.mkdir(parents=True, exist_ok=True)
         return self._archives_dir
+
+    # ------------------------------------------------------------------
+    # Unified snapshot helper (issue #1244)
+    # ------------------------------------------------------------------
+
+    async def snapshot_artifacts(
+        self,
+        session_dir: Path,
+        archive_dir: Path,
+        ctx: SnapshotContext,
+    ) -> list[str]:
+        """Copy the unified artifact set into archive_dir.
+
+        Returns list of artifact name tokens archived (for telemetry).
+        archive_dir is created by the caller before this method is invoked.
+        """
+        archived: list[str] = []
+
+        # Always-archive artifacts
+        self._copy_if_exists(session_dir / "messages.jsonl", archive_dir, archived)
+        self._scrub_and_copy_state(session_dir, archive_dir, archived)
+        self._copy_if_exists(session_dir / "queue.jsonl", archive_dir, archived)
+        self._copy_dir_if_exists(session_dir / "resources", archive_dir, archived)
+        self._copy_dir_if_exists(session_dir / "attachments", archive_dir, archived)
+
+        # Disposal-only artifacts
+        if not ctx.is_reset:
+            self._copy_dir_if_exists(session_dir / "history", archive_dir, archived)
+
+            if ctx.auto_memory_directory is not None:
+                self._copy_external_memory(
+                    ctx.auto_memory_directory, session_dir, archive_dir, archived
+                )
+            else:
+                self._copy_dir_if_exists(session_dir / "memory", archive_dir, archived)
+
+            if ctx.legion_id:
+                self._copy_legion_schedules(ctx.legion_id, archive_dir, archived)
+
+        # Proxy logs — both disposal and reset (decision #11)
+        if ctx.proxy_enabled:
+            self._copy_proxy_logs(session_dir, archive_dir, archived)
+
+        return archived
+
+    def _copy_if_exists(self, src: Path, dst_dir: Path, archived: list[str]) -> None:
+        if src.exists():
+            shutil.copy2(src, dst_dir / src.name)
+            archived.append(src.name)
+
+    def _scrub_and_copy_state(
+        self, session_dir: Path, archive_dir: Path, archived: list[str]
+    ) -> None:
+        state_file = session_dir / "state.json"
+        if not state_file.exists():
+            return
+        try:
+            state = json.loads(state_file.read_text(encoding="utf-8"))
+            scrubbed = scrub_state_for_archive(state)
+            (archive_dir / "state.json").write_text(
+                json.dumps(scrubbed, indent=2, ensure_ascii=False),
+                encoding="utf-8",
+            )
+            archived.append("state.json")
+        except Exception:
+            logger.exception("Failed to scrub/copy state.json for archive")
+
+    def _copy_dir_if_exists(self, src: Path, dst_dir: Path, archived: list[str]) -> None:
+        if src.is_dir():
+            shutil.copytree(src, dst_dir / src.name)
+            archived.append(f"{src.name}/")
+
+    def _copy_external_memory(
+        self,
+        custom_dir: Path,
+        session_dir: Path,
+        archive_dir: Path,
+        archived: list[str],
+    ) -> None:
+        """Copy out-of-tree memory dir into archive_dir/memory_external/."""
+        try:
+            resolved_custom = custom_dir.resolve()
+            resolved_session = session_dir.resolve()
+            if resolved_custom.is_relative_to(resolved_session):
+                # In-tree — handled by normal _copy_dir_if_exists on memory/
+                self._copy_dir_if_exists(custom_dir, archive_dir, archived)
+                return
+            if custom_dir.is_dir():
+                shutil.copytree(custom_dir, archive_dir / "memory_external")
+                archived.append("memory_external/")
+        except Exception:
+            logger.exception("Failed to copy external memory for archive")
+
+    def _copy_proxy_logs(
+        self, session_dir: Path, archive_dir: Path, archived: list[str]
+    ) -> None:
+        proxy_src = session_dir / "docker_claude_data" / "proxy"
+        if not proxy_src.is_dir():
+            return
+        proxy_dst = archive_dir / "proxy"
+        any_copied = False
+        for name in _PROXY_LOG_NAMES:
+            src = proxy_src / name
+            if src.exists():
+                proxy_dst.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(src, proxy_dst / name)
+                any_copied = True
+        if any_copied:
+            archived.append("proxy/")
+
+    def _copy_legion_schedules(
+        self, legion_id: str, archive_dir: Path, archived: list[str]
+    ) -> None:
+        data_dir = self.system.session_coordinator.session_manager.data_dir
+        legion_dir = data_dir / "legions" / legion_id
+        for fname in ("schedules.json", "schedule_history.jsonl"):
+            src = legion_dir / fname
+            if src.exists():
+                shutil.copy2(src, archive_dir / fname)
+                archived.append(fname)
 
     async def archive_minion(
         self,

--- a/src/legion/archive_manager.py
+++ b/src/legion/archive_manager.py
@@ -255,31 +255,23 @@ class ArchiveManager:
             archive_dir = self.archives_dir / minion_id / timestamp
             archive_dir.mkdir(parents=True, exist_ok=True)
 
-            files_archived = []
-
             # Get source session directory
             session_dir = self.system.session_coordinator.session_manager.sessions_dir / minion_id
 
-            # Copy messages.jsonl if exists
-            messages_file = session_dir / "messages.jsonl"
-            if messages_file.exists():
-                shutil.copy2(messages_file, archive_dir / "messages.jsonl")
-                files_archived.append("messages.jsonl")
-                archive_logger.debug(f"Archived messages.jsonl for minion {minion_id}")
-
-            # Copy state.json if exists
-            state_file = session_dir / "state.json"
-            if state_file.exists():
-                shutil.copy2(state_file, archive_dir / "state.json")
-                files_archived.append("state.json")
-                archive_logger.debug(f"Archived state.json for minion {minion_id}")
-
-            # Copy memory/ directory if exists (issue #709)
-            memory_dir = session_dir / "memory"
-            if memory_dir.exists() and memory_dir.is_dir():
-                shutil.copytree(memory_dir, archive_dir / "memory")
-                files_archived.append("memory/")
-                archive_logger.debug(f"Archived memory/ directory for minion {minion_id}")
+            # Build snapshot context from session config
+            cfg = session_info.config or {}
+            auto_mem_raw = cfg.get("auto_memory_directory")
+            auto_mem_dir: Path | None = Path(auto_mem_raw) if auto_mem_raw else None
+            ctx = SnapshotContext(
+                session_id=minion_id,
+                legion_id=session_info.project_id or None,
+                auto_memory_directory=auto_mem_dir,
+                docker_enabled=bool(cfg.get("docker_enabled", False)),
+                proxy_enabled=bool(cfg.get("docker_proxy_enabled", False)),
+                is_reset=False,
+                will_be_deleted=will_be_deleted,
+            )
+            files_archived = await self.snapshot_artifacts(session_dir, archive_dir, ctx)
 
             # Create disposal metadata
             # Use "deleted" as final_state if session will be deleted after archive
@@ -309,13 +301,15 @@ class ArchiveManager:
                 f"Archived minion {session_info.name} ({minion_id}) to {archive_dir}"
             )
 
-            # Fire-and-forget distillation of session history into markdown
-            # Write into the archive directory — sessions/{id}/ gets deleted after disposal.
+            # Fire-and-forget distillation — writes a final entry into archive_dir/history/.
+            # The live history/ was already copied by snapshot_artifacts (disposal path).
             # Issue #710: Skip distillation when history distillation is disabled
-            if session_info.config.get("history_distillation_enabled", True):
+            if cfg.get("history_distillation_enabled", True):
                 archived_messages = archive_dir / "messages.jsonl"
                 if archived_messages.exists():
-                    history_output = archive_dir / "history.md"
+                    history_dir = archive_dir / "history"
+                    history_dir.mkdir(exist_ok=True)
+                    history_output = history_dir / f"{timestamp}_disposal.md"
                     archive_ts = datetime.now(UTC).isoformat()
                     t = asyncio.create_task(
                         distill_session_history(archived_messages, history_output, minion_id, archive_ts)

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -12,7 +12,6 @@ import logging
 import os
 import re
 import secrets
-import shutil
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
@@ -2366,42 +2365,26 @@ class SessionCoordinator:
     async def _archive_session_for_reset(self, session_id: str) -> bool:
         """Archive session data before a reset so it can be reviewed later.
 
-        Copies messages.jsonl, state.json, and resources/ into
-        data/archives/minions/{session_id}/{timestamp}/ and writes a
-        disposal_metadata.json with reason="reset".
+        Uses snapshot_artifacts() with is_reset=True so that queue.jsonl,
+        attachments/, and proxy logs are captured but history/memory are left
+        in place (decision #5).  Writes disposal_metadata.json with reason="reset".
 
         Returns True on success, False on failure (logged, never raised).
         """
         try:
+            from src.legion.archive_manager import SnapshotContext
+            from src.models.archive_models import DisposalMetadata
+
             session_info = await self.session_manager.get_session_info(session_id)
             session_dir = self.session_manager.sessions_dir / session_id
-            timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
+            # Use microsecond-precision timestamp for cross-path consistency
+            timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S_%f")
             archive_dir = (
                 self.session_manager.data_dir / "archives" / "minions" / session_id / timestamp
             )
             archive_dir.mkdir(parents=True, exist_ok=True)
 
-            # Copy messages.jsonl
-            messages_file = session_dir / "messages.jsonl"
-            if messages_file.exists():
-                shutil.copy2(messages_file, archive_dir / "messages.jsonl")
-
-            # Copy state.json
-            state_file = session_dir / "state.json"
-            if state_file.exists():
-                shutil.copy2(state_file, archive_dir / "state.json")
-
-            # Copy resources/ directory
-            resources_dir = session_dir / "resources"
-            if resources_dir.exists() and resources_dir.is_dir():
-                shutil.copytree(resources_dir, archive_dir / "resources")
-
-            # Copy memory/ directory if exists (issue #709)
-            memory_dir = session_dir / "memory"
-            if memory_dir.exists() and memory_dir.is_dir():
-                shutil.copytree(memory_dir, archive_dir / "memory")
-
-            # Determine project/legion ID for metadata
+            # Determine project/legion ID for metadata + snapshot context
             project_id = ""
             if session_info:
                 for proj in await self.project_manager.list_projects():
@@ -2409,29 +2392,43 @@ class SessionCoordinator:
                         project_id = proj.project_id
                         break
 
-            # Write disposal_metadata.json
-            metadata = {
-                "disposed_at": datetime.now(UTC).timestamp(),
-                "reason": "reset",
-                "parent_overseer_id": None,
-                "parent_overseer_name": None,
-                "legion_id": project_id,
-                "final_state": "reset",
-                "minion_id": session_id,
-                "minion_name": session_info.name if session_info else "",
-                "minion_role": session_info.role if session_info else None,
-                "overseer_level": 0,
-                "child_minion_ids": [],
-                "descendants_count": 0,
-                "metadata": {},
-            }
-            metadata_path = archive_dir / "disposal_metadata.json"
-            metadata_path.write_text(json.dumps(metadata, indent=2))
+            # Build snapshot context
+            cfg = session_info.config if session_info else {}
+            auto_mem_raw = cfg.get("auto_memory_directory")
+            ctx = SnapshotContext(
+                session_id=session_id,
+                legion_id=project_id or None,
+                auto_memory_directory=Path(auto_mem_raw) if auto_mem_raw else None,
+                docker_enabled=bool(cfg.get("docker_enabled", False)),
+                proxy_enabled=bool(cfg.get("docker_proxy_enabled", False)),
+                is_reset=True,
+                will_be_deleted=False,
+            )
 
-            # Fire-and-forget distillation of session history into markdown
-            # Use the archived copy of messages.jsonl, not the live file — the live
-            # file gets truncated by clear_messages() right after this method returns.
-            # Skip distillation when knowledge management is disabled.
+            # Delegate to unified artifact snapshot
+            archive_manager = self.legion_system.archive_manager
+            await archive_manager.snapshot_artifacts(session_dir, archive_dir, ctx)
+
+            # Write disposal_metadata.json using the shared dataclass
+            metadata = DisposalMetadata(
+                disposed_at=datetime.now(UTC).timestamp(),
+                reason="reset",
+                parent_overseer_id=None,
+                parent_overseer_name=None,
+                legion_id=project_id,
+                final_state="reset",
+                minion_id=session_id,
+                minion_name=session_info.name if session_info else "",
+                minion_role=session_info.role if session_info else None,
+                overseer_level=0,
+                child_minion_ids=[],
+                descendants_count=0,
+            )
+            metadata_path = archive_dir / "disposal_metadata.json"
+            metadata_path.write_text(json.dumps(metadata.to_dict(), indent=2))
+
+            # Fire-and-forget distillation — writes to live history/ (decision #5).
+            # Uses the archived copy of messages.jsonl so the live file can be truncated.
             # Issue #1059: Use resolve_effective_config to support template-linked sessions.
             _eff_for_archive = await resolve_effective_config(
                 session_info, self.template_manager, self.profile_manager

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -2337,6 +2337,16 @@ class SessionCoordinator:
                 coord_logger.info(f"Cleared message history for session {session_id}")
                 await storage.clear_resources()
                 coord_logger.info(f"Cleared resources for session {session_id}")
+                # Issue #1244: clear queue + attachments (archive already captured them)
+                await storage.clear_queue()
+                coord_logger.info(f"Cleared queue for session {session_id}")
+                await storage.clear_attachments()
+                coord_logger.info(f"Cleared attachments for session {session_id}")
+
+            # Issue #1244: rotate proxy logs then clear non-proxy docker_claude_data and tmp
+            await self._rotate_proxy_logs(session_id)
+            await self._clear_docker_claude_data(session_id, keep_subdirs={"proxy"})
+            await self._clear_session_tmp(session_id)
 
             # Issue #310: Reset DisplayProjection state (clears tool tracking)
             self._reset_display_projection(session_id)

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -12,6 +12,7 @@ import logging
 import os
 import re
 import secrets
+import shutil
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
@@ -2452,6 +2453,57 @@ class SessionCoordinator:
         except Exception as e:
             coord_logger.warning(f"Archive before reset failed for {session_id}: {e}")
             return False
+
+    async def _rotate_proxy_logs(self, session_id: str) -> None:
+        """Truncate proxy log files to empty after archiving (issue #1244, decision #11).
+
+        Truncate rather than unlink so the file descriptor stays valid if the
+        proxy container is mid-write at reset time.
+        """
+        proxy_dir = self.session_manager.sessions_dir / session_id / "docker_claude_data" / "proxy"
+        if not proxy_dir.is_dir():
+            return
+        for name in ("access.log", "dns.log", "socks5.log", "dropped.log"):
+            log_file = proxy_dir / name
+            if log_file.exists():
+                try:
+                    log_file.write_bytes(b"")
+                    coord_logger.debug(f"Truncated proxy log {name} for {session_id}")
+                except OSError:
+                    logger.exception(f"Failed to truncate proxy log {name} for {session_id}")
+
+    async def _clear_docker_claude_data(
+        self, session_id: str, keep_subdirs: set[str] | None = None
+    ) -> None:
+        """Remove all subdirs under docker_claude_data/ except those in keep_subdirs.
+
+        Subdirs are recreated by claude-docker on next session start.
+        """
+        keep = keep_subdirs or set()
+        docker_data_dir = (
+            self.session_manager.sessions_dir / session_id / "docker_claude_data"
+        )
+        if not docker_data_dir.is_dir():
+            return
+        for child in docker_data_dir.iterdir():
+            if child.is_dir() and child.name not in keep:
+                try:
+                    shutil.rmtree(child)
+                    coord_logger.debug(f"Removed docker_claude_data/{child.name} for {session_id}")
+                except OSError:
+                    logger.exception(
+                        f"Failed to remove docker_claude_data/{child.name} for {session_id}"
+                    )
+
+    async def _clear_session_tmp(self, session_id: str) -> None:
+        """Remove the session's tmp/ directory (issue #1244, decision #3)."""
+        tmp_dir = self.session_manager.sessions_dir / session_id / "tmp"
+        if tmp_dir.is_dir():
+            try:
+                shutil.rmtree(tmp_dir)
+                coord_logger.debug(f"Removed tmp/ for {session_id}")
+            except OSError:
+                logger.exception(f"Failed to remove tmp/ for {session_id}")
 
     async def get_session_info(self, session_id: str) -> dict[str, Any] | None:
         """Get comprehensive session information"""

--- a/src/tests/test_archive_snapshot.py
+++ b/src/tests/test_archive_snapshot.py
@@ -2,10 +2,93 @@
 Tests for archive_manager helpers — covering issue #1244.
 
 Step 1: scrub_state_for_archive()
-Step 2+: snapshot_artifacts(), reset cleanup helpers (added in later steps)
+Step 2: SnapshotContext + snapshot_artifacts()
+Step 5+: reset cleanup helpers (added in later steps)
 """
 
-from src.legion.archive_manager import scrub_state_for_archive
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from src.legion.archive_manager import (
+    ArchiveManager,
+    SnapshotContext,
+    scrub_state_for_archive,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_data():
+    """Temp directory tree mimicking data/ layout."""
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        (root / "sessions").mkdir()
+        (root / "archives" / "minions").mkdir(parents=True)
+        (root / "legions").mkdir()
+        yield root
+
+
+@pytest.fixture
+def mock_system(tmp_data):
+    """Minimal mock LegionSystem."""
+    system = Mock()
+    system.session_coordinator = Mock()
+    system.session_coordinator.session_manager = Mock()
+    system.session_coordinator.session_manager.data_dir = tmp_data
+    system.session_coordinator.session_manager.sessions_dir = tmp_data / "sessions"
+    return system, tmp_data
+
+
+def _make_session_dir(tmp_data: Path, session_id: str) -> Path:
+    d = tmp_data / "sessions" / session_id
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _full_session(session_dir: Path) -> None:
+    """Populate a session dir with every artifact from the matrix."""
+    (session_dir / "messages.jsonl").write_text('{"type":"user","content":"hello"}\n')
+    (session_dir / "state.json").write_text(
+        json.dumps({
+            "session_id": session_dir.name,
+            "secret_fetch_token": "tok-secret",
+            "secret_placeholders": {"FOO": "bar"},
+            "is_processing": True,
+            "claude_code_session_id": "abc",
+        })
+    )
+    (session_dir / "queue.jsonl").write_text('{"id":"q1","content":"queued"}\n')
+
+    res = session_dir / "resources"
+    res.mkdir()
+    (res / "resources.jsonl").write_text('{"resource_id":"r1"}\n')
+    (res / "r1.bin").write_bytes(b"\x00\x01")
+
+    att = session_dir / "attachments"
+    att.mkdir()
+    (att / "file.txt").write_text("hello")
+
+    hist = session_dir / "history"
+    hist.mkdir()
+    (hist / "20240101_120000.md").write_text("# History")
+
+    mem = session_dir / "memory"
+    mem.mkdir()
+    (mem / "short_term.json").write_text("{}")
+
+    proxy = session_dir / "docker_claude_data" / "proxy"
+    proxy.mkdir(parents=True)
+    (proxy / "access.log").write_text("GET / 200")
+    (proxy / "dns.log").write_text("resolved")
+    (proxy / "socks5.log").write_text("connected")
+    (proxy / "dropped.log").write_text("blocked")
 
 
 # ---------------------------------------------------------------------------
@@ -67,3 +150,200 @@ class TestScrubStateForArchive:
         state = {"secret_fetch_token": "tok", "session_id": "s1"}
         scrub_state_for_archive(state)
         assert "secret_fetch_token" in state
+
+
+# ---------------------------------------------------------------------------
+# snapshot_artifacts — disposal path
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshotArtifactsDisposal:
+    @pytest.mark.asyncio
+    async def test_disposal_full_archives_all_artifacts(self, mock_system, tmp_data):
+        system, _ = mock_system
+        session_id = "sess-disposal-full"
+        session_dir = _make_session_dir(tmp_data, session_id)
+        _full_session(session_dir)
+
+        archive_dir = tmp_data / "archives" / "minions" / session_id / "20240101_120000"
+        archive_dir.mkdir(parents=True)
+
+        ctx = SnapshotContext(
+            session_id=session_id,
+            legion_id=None,
+            auto_memory_directory=None,
+            docker_enabled=True,
+            proxy_enabled=True,
+            is_reset=False,
+            will_be_deleted=True,
+        )
+        manager = ArchiveManager(system)
+        archived = await manager.snapshot_artifacts(session_dir, archive_dir, ctx)
+
+        assert "messages.jsonl" in archived
+        assert "state.json" in archived
+        assert "queue.jsonl" in archived
+        assert "resources/" in archived
+        assert "attachments/" in archived
+        assert "history/" in archived
+        assert "memory/" in archived
+        assert "proxy/" in archived
+
+        # Verify scrubbed state
+        state = json.loads((archive_dir / "state.json").read_text())
+        assert "secret_fetch_token" not in state
+        assert "secret_placeholders" in state
+
+        # Verify proxy logs captured
+        for name in ("access.log", "dns.log", "socks5.log", "dropped.log"):
+            assert (archive_dir / "proxy" / name).exists()
+
+    @pytest.mark.asyncio
+    async def test_disposal_archives_resources_path_a_fix(self, mock_system, tmp_data):
+        """Regression: resources/ must be included in disposal archives."""
+        system, _ = mock_system
+        session_id = "sess-res-fix"
+        session_dir = _make_session_dir(tmp_data, session_id)
+        res = session_dir / "resources"
+        res.mkdir()
+        (res / "resources.jsonl").write_text('{"resource_id":"r1"}\n')
+        (res / "r1.bin").write_bytes(b"\xff\xfe")
+
+        archive_dir = tmp_data / "archives" / "minions" / session_id / "ts1"
+        archive_dir.mkdir(parents=True)
+        ctx = SnapshotContext(
+            session_id=session_id, legion_id=None, auto_memory_directory=None,
+            docker_enabled=False, proxy_enabled=False, is_reset=False, will_be_deleted=True,
+        )
+        manager = ArchiveManager(system)
+        await manager.snapshot_artifacts(session_dir, archive_dir, ctx)
+
+        assert (archive_dir / "resources" / "resources.jsonl").exists()
+        assert (archive_dir / "resources" / "r1.bin").exists()
+
+    @pytest.mark.asyncio
+    async def test_disposal_archives_schedules(self, mock_system, tmp_data):
+        """Disposal with legion_id captures schedules from data/legions/{lid}/."""
+        system, _ = mock_system
+        session_id = "sess-sched"
+        legion_id = "legion-sched-001"
+        session_dir = _make_session_dir(tmp_data, session_id)
+
+        legion_dir = tmp_data / "legions" / legion_id
+        legion_dir.mkdir(parents=True)
+        (legion_dir / "schedules.json").write_text(json.dumps([{"cron": "0 * * * *"}]))
+        (legion_dir / "schedule_history.jsonl").write_text('{"exec":"ok"}\n')
+
+        archive_dir = tmp_data / "archives" / "minions" / session_id / "ts2"
+        archive_dir.mkdir(parents=True)
+        ctx = SnapshotContext(
+            session_id=session_id, legion_id=legion_id, auto_memory_directory=None,
+            docker_enabled=False, proxy_enabled=False, is_reset=False, will_be_deleted=True,
+        )
+        manager = ArchiveManager(system)
+        archived = await manager.snapshot_artifacts(session_dir, archive_dir, ctx)
+
+        assert "schedules.json" in archived
+        assert "schedule_history.jsonl" in archived
+        assert (archive_dir / "schedules.json").exists()
+        assert (archive_dir / "schedule_history.jsonl").exists()
+
+    @pytest.mark.asyncio
+    async def test_disposal_external_memory_not_deleted(self, mock_system, tmp_data):
+        """Out-of-tree auto_memory_directory is copied but source preserved."""
+        system, _ = mock_system
+        session_id = "sess-extmem"
+        session_dir = _make_session_dir(tmp_data, session_id)
+
+        ext_mem = tmp_data / "shared_memory"
+        ext_mem.mkdir()
+        (ext_mem / "mem.json").write_text('{"key":"value"}')
+
+        archive_dir = tmp_data / "archives" / "minions" / session_id / "ts3"
+        archive_dir.mkdir(parents=True)
+        ctx = SnapshotContext(
+            session_id=session_id, legion_id=None,
+            auto_memory_directory=ext_mem,
+            docker_enabled=False, proxy_enabled=False, is_reset=False, will_be_deleted=True,
+        )
+        manager = ArchiveManager(system)
+        await manager.snapshot_artifacts(session_dir, archive_dir, ctx)
+
+        assert (archive_dir / "memory_external" / "mem.json").exists()
+        assert (ext_mem / "mem.json").exists()  # source not deleted
+
+    @pytest.mark.asyncio
+    async def test_disposal_archives_proxy_logs(self, mock_system, tmp_data):
+        """All four proxy log files are captured on disposal."""
+        system, _ = mock_system
+        session_id = "sess-proxy"
+        session_dir = _make_session_dir(tmp_data, session_id)
+        _full_session(session_dir)
+
+        archive_dir = tmp_data / "archives" / "minions" / session_id / "ts4"
+        archive_dir.mkdir(parents=True)
+        ctx = SnapshotContext(
+            session_id=session_id, legion_id=None, auto_memory_directory=None,
+            docker_enabled=True, proxy_enabled=True, is_reset=False, will_be_deleted=True,
+        )
+        manager = ArchiveManager(system)
+        await manager.snapshot_artifacts(session_dir, archive_dir, ctx)
+
+        for name in ("access.log", "dns.log", "socks5.log", "dropped.log"):
+            assert (archive_dir / "proxy" / name).exists(), f"Missing {name}"
+
+
+# ---------------------------------------------------------------------------
+# snapshot_artifacts — reset path
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshotArtifactsReset:
+    @pytest.mark.asyncio
+    async def test_reset_subset_no_history_no_memory_no_schedules(self, mock_system, tmp_data):
+        """Reset snapshot excludes history/, memory/, and schedule files."""
+        system, _ = mock_system
+        session_id = "sess-reset-sub"
+        session_dir = _make_session_dir(tmp_data, session_id)
+        _full_session(session_dir)
+
+        archive_dir = tmp_data / "archives" / "minions" / session_id / "ts-reset"
+        archive_dir.mkdir(parents=True)
+        ctx = SnapshotContext(
+            session_id=session_id, legion_id="leg1", auto_memory_directory=None,
+            docker_enabled=True, proxy_enabled=True, is_reset=True, will_be_deleted=False,
+        )
+        manager = ArchiveManager(system)
+        archived = await manager.snapshot_artifacts(session_dir, archive_dir, ctx)
+
+        assert "messages.jsonl" in archived
+        assert "queue.jsonl" in archived
+        assert "resources/" in archived
+        assert "attachments/" in archived
+        assert "proxy/" in archived
+
+        assert "history/" not in archived
+        assert "memory/" not in archived
+        assert "schedules.json" not in archived
+        assert "schedule_history.jsonl" not in archived
+
+    @pytest.mark.asyncio
+    async def test_reset_preserves_history_and_memory_on_disk(self, mock_system, tmp_data):
+        """snapshot_artifacts with is_reset=True does not touch live history/ or memory/."""
+        system, _ = mock_system
+        session_id = "sess-reset-pres"
+        session_dir = _make_session_dir(tmp_data, session_id)
+        _full_session(session_dir)
+
+        archive_dir = tmp_data / "archives" / "minions" / session_id / "ts-pres"
+        archive_dir.mkdir(parents=True)
+        ctx = SnapshotContext(
+            session_id=session_id, legion_id=None, auto_memory_directory=None,
+            docker_enabled=False, proxy_enabled=False, is_reset=True, will_be_deleted=False,
+        )
+        manager = ArchiveManager(system)
+        await manager.snapshot_artifacts(session_dir, archive_dir, ctx)
+
+        # Live dirs must be untouched
+        assert (session_dir / "history").exists()
+        assert (session_dir / "memory").exists()

--- a/src/tests/test_archive_snapshot.py
+++ b/src/tests/test_archive_snapshot.py
@@ -347,3 +347,139 @@ class TestSnapshotArtifactsReset:
         # Live dirs must be untouched
         assert (session_dir / "history").exists()
         assert (session_dir / "memory").exists()
+
+
+# ---------------------------------------------------------------------------
+# Reset cleanup helpers (DataStorageManager + session_coordinator)
+# ---------------------------------------------------------------------------
+
+
+class TestResetCleanupHelpers:
+    @pytest.mark.asyncio
+    async def test_clear_queue_truncates_file(self, tmp_data):
+        """clear_queue() truncates queue.jsonl to empty."""
+        from src.data_storage import DataStorageManager
+
+        session_id = "sess-clr-q"
+        session_dir = tmp_data / "sessions" / session_id
+        session_dir.mkdir(parents=True)
+        queue_file = session_dir / "queue.jsonl"
+        queue_file.write_text('{"id":"q1"}\n')
+
+        mgr = DataStorageManager(session_dir)
+        result = await mgr.clear_queue()
+
+        assert result is True
+        assert queue_file.exists()
+        assert queue_file.read_bytes() == b""
+
+    @pytest.mark.asyncio
+    async def test_clear_queue_no_file_is_noop(self, tmp_data):
+        """clear_queue() succeeds even when queue.jsonl does not exist."""
+        from src.data_storage import DataStorageManager
+
+        session_dir = tmp_data / "sessions" / "sess-no-q"
+        session_dir.mkdir(parents=True)
+        mgr = DataStorageManager(session_dir)
+        result = await mgr.clear_queue()
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_clear_attachments_removes_dir(self, tmp_data):
+        """clear_attachments() removes the attachments/ directory."""
+        from src.data_storage import DataStorageManager
+
+        session_id = "sess-clr-att"
+        session_dir = tmp_data / "sessions" / session_id
+        session_dir.mkdir(parents=True)
+        att = session_dir / "attachments"
+        att.mkdir()
+        (att / "file.txt").write_text("hello")
+
+        mgr = DataStorageManager(session_dir)
+        result = await mgr.clear_attachments()
+
+        assert result is True
+        assert not att.exists()
+
+    @pytest.mark.asyncio
+    async def test_clear_attachments_no_dir_is_noop(self, tmp_data):
+        """clear_attachments() succeeds when attachments/ does not exist."""
+        from src.data_storage import DataStorageManager
+
+        session_dir = tmp_data / "sessions" / "sess-no-att"
+        session_dir.mkdir(parents=True)
+        mgr = DataStorageManager(session_dir)
+        result = await mgr.clear_attachments()
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_rotate_proxy_logs_truncates(self, tmp_data):
+        """_rotate_proxy_logs() truncates each proxy log to empty bytes."""
+        from unittest.mock import Mock
+
+        from src.session_coordinator import SessionCoordinator
+
+        sessions_dir = tmp_data / "sessions"
+        session_id = "sess-plog"
+        proxy_dir = sessions_dir / session_id / "docker_claude_data" / "proxy"
+        proxy_dir.mkdir(parents=True)
+        for name in ("access.log", "dns.log", "socks5.log", "dropped.log"):
+            (proxy_dir / name).write_text("data")
+
+        coord = Mock(spec=SessionCoordinator)
+        coord.session_manager = Mock()
+        coord.session_manager.sessions_dir = sessions_dir
+        coord._rotate_proxy_logs = SessionCoordinator._rotate_proxy_logs.__get__(coord)
+
+        await coord._rotate_proxy_logs(session_id)
+
+        for name in ("access.log", "dns.log", "socks5.log", "dropped.log"):
+            assert (proxy_dir / name).read_bytes() == b""
+
+    @pytest.mark.asyncio
+    async def test_clear_docker_claude_data_except_proxy(self, tmp_data):
+        """_clear_docker_claude_data keeps proxy/ and removes others."""
+        from unittest.mock import Mock
+
+        from src.session_coordinator import SessionCoordinator
+
+        sessions_dir = tmp_data / "sessions"
+        session_id = "sess-docker"
+        docker_dir = sessions_dir / session_id / "docker_claude_data"
+        for sub in ("proxy", "projects", "todos", "tasks"):
+            (docker_dir / sub).mkdir(parents=True)
+            (docker_dir / sub / "f.txt").write_text("data")
+
+        coord = Mock(spec=SessionCoordinator)
+        coord.session_manager = Mock()
+        coord.session_manager.sessions_dir = sessions_dir
+        coord._clear_docker_claude_data = SessionCoordinator._clear_docker_claude_data.__get__(coord)
+
+        await coord._clear_docker_claude_data(session_id, keep_subdirs={"proxy"})
+
+        assert (docker_dir / "proxy").exists()
+        assert not (docker_dir / "projects").exists()
+        assert not (docker_dir / "todos").exists()
+        assert not (docker_dir / "tasks").exists()
+
+    @pytest.mark.asyncio
+    async def test_clear_session_tmp(self, tmp_data):
+        """_clear_session_tmp removes the tmp/ directory."""
+        from unittest.mock import Mock
+
+        from src.session_coordinator import SessionCoordinator
+
+        sessions_dir = tmp_data / "sessions"
+        session_id = "sess-tmp"
+        tmp_dir = sessions_dir / session_id / "tmp"
+        tmp_dir.mkdir(parents=True)
+        (tmp_dir / "a.txt").write_text("temp")
+
+        coord = Mock(spec=SessionCoordinator)
+        coord.session_manager = Mock()
+        coord.session_manager.sessions_dir = sessions_dir
+        coord._clear_session_tmp = SessionCoordinator._clear_session_tmp.__get__(coord)
+
+        await coord._clear_session_tmp(session_id)
+        assert not tmp_dir.exists()

--- a/src/tests/test_archive_snapshot.py
+++ b/src/tests/test_archive_snapshot.py
@@ -1,0 +1,69 @@
+"""
+Tests for archive_manager helpers — covering issue #1244.
+
+Step 1: scrub_state_for_archive()
+Step 2+: snapshot_artifacts(), reset cleanup helpers (added in later steps)
+"""
+
+from src.legion.archive_manager import scrub_state_for_archive
+
+
+# ---------------------------------------------------------------------------
+# scrub_state_for_archive tests
+# ---------------------------------------------------------------------------
+
+
+class TestScrubStateForArchive:
+    def test_drops_secret_fetch_token(self):
+        state = {"session_id": "abc", "secret_fetch_token": "tok-live", "name": "Agent"}
+        result = scrub_state_for_archive(state)
+        assert "secret_fetch_token" not in result
+        assert result["session_id"] == "abc"
+        assert result["name"] == "Agent"
+
+    def test_keeps_secret_placeholders(self):
+        state = {"secret_placeholders": {"API_KEY": "placeholder"}, "secret_fetch_token": "live"}
+        result = scrub_state_for_archive(state)
+        assert result["secret_placeholders"] == {"API_KEY": "placeholder"}
+        assert "secret_fetch_token" not in result
+
+    def test_drops_runtime_keys(self):
+        state = {
+            "session_id": "s1",
+            "is_processing": True,
+            "latest_message": "hi",
+            "latest_message_type": "user",
+            "latest_message_time": 9999,
+            "claude_code_session_id": "ccs-123",
+        }
+        result = scrub_state_for_archive(state)
+        assert "is_processing" not in result
+        assert "latest_message" not in result
+        assert "latest_message_type" not in result
+        assert "latest_message_time" not in result
+        assert "claude_code_session_id" not in result
+        assert result["session_id"] == "s1"
+
+    def test_truncates_error_message_long(self):
+        long_err = "x" * 300
+        state = {"error_message": long_err}
+        result = scrub_state_for_archive(state)
+        assert "error_message" not in result
+        assert "error_summary" in result
+        assert len(result["error_summary"]) == 201  # 200 chars + "…"
+
+    def test_keeps_short_error_message_verbatim(self):
+        state = {"error_message": "short error"}
+        result = scrub_state_for_archive(state)
+        assert result["error_summary"] == "short error"
+
+    def test_no_error_key_when_none(self):
+        state = {"session_id": "s1"}
+        result = scrub_state_for_archive(state)
+        assert "error_message" not in result
+        assert "error_summary" not in result
+
+    def test_original_state_unmodified(self):
+        state = {"secret_fetch_token": "tok", "session_id": "s1"}
+        scrub_state_for_archive(state)
+        assert "secret_fetch_token" in state


### PR DESCRIPTION
## Summary
Resolves #1244
Fixes #1244

Unifies the two session archival paths (disposal and reset), fixes the missing `resources/` bug in disposal archives, scrubs live Bearer tokens from archived state, and wires up aggressive reset cleanup so sessions genuinely start fresh.

## Changes Made

- **Step 1** — `scrub_state_for_archive()`: strips `secret_fetch_token` and runtime-only fields from `state.json` before archiving; truncates `error_message` to 200-char `error_summary`. `secret_placeholders` is intentionally kept (decision #1).

- **Step 2** — `SnapshotContext` dataclass + `snapshot_artifacts()`: single unified method for the full artifact matrix (messages, state, queue, resources, attachments, proxy logs, history/memory/schedules on disposal only).

- **Step 3** — `archive_minion` (Path A) switched to `snapshot_artifacts`: fixes the bug where disposal archives omitted `resources/`. Distillation now writes to `archive_dir/history/{ts}_disposal.md`.

- **Step 4** — `_archive_session_for_reset` (Path B) switched to `snapshot_artifacts` (`is_reset=True`): adds `queue.jsonl`, `attachments/`, and proxy logs to reset archives. Uses `DisposalMetadata` dataclass and microsecond-precision timestamps for cross-path consistency.

- **Step 5** — Reset cleanup helpers: `DataStorageManager.clear_queue()` (truncate), `DataStorageManager.clear_attachments()` (rmtree), `SessionCoordinator._rotate_proxy_logs()` (truncate, not unlink — safe for mid-write proxy), `_clear_docker_claude_data(keep_subdirs)`, `_clear_session_tmp()`.

- **Step 6** — Cleanup wired into `reset_session()`: default-on immediately (no feature flag). Clears queue, attachments, proxy logs (truncate), non-proxy docker_claude_data subdirs, and tmp/ after archiving.

- **Step 7** — Read-side helpers: `get_archive_queue()`, `get_archive_proxy_logs()` (name/size/line_count), `get_archive_history()` (name/size/mtime), `get_archive_schedules()` (schedules + history), `get_archive_attachments()`. All return empty results gracefully for old archives (backwards compat, decision #10).

## Testing

- 41 tests pass: `src/tests/test_archive_snapshot.py` (21 new tests) + `src/tests/test_archive_manager.py` (20 existing tests unchanged)
- Full test suite: 1421 passed, 0 failures
- Ruff: zero violations on all modified files

## Follow-on issues (not in this PR, per plan)

- Frontend: archive viewer tabs for proxy/, queue, attachments, history, schedules (§5)
- Remove dead `images/` storage code and routes (§6.1)
- Deprecate per-minion `comms.jsonl` writes (§6.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)