### PR TITLE
fix(proxy): replace host.docker.internal with cc-webui.internal + probe-based host IP discovery

### DIFF
--- a/src/docker/claude-docker
+++ b/src/docker/claude-docker
@@ -252,21 +252,22 @@ if [ -n "$PROXY_IMAGE" ]; then
         done
     fi
 
-    # Issue #1233: --add-host overrides macOS/Windows runtime-provided host.docker.internal
-    # entry, breaking Rancher Desktop. Apply only on native Linux where Docker doesn't
-    # auto-inject. WSL2 reports uname -s as Linux but uses Docker Desktop's host gateway
-    # injection, so detect and skip there as well.
-    ADD_HOST_FLAG=""
-    if [ "$(uname -s)" = "Linux" ]; then
-        IS_WSL=0
-        if [ -r /proc/sys/kernel/osrelease ]; then
-            case "$(cat /proc/sys/kernel/osrelease)" in
-                *microsoft*|*Microsoft*|*WSL*) IS_WSL=1 ;;
-            esac
-        fi
-        if [ "$IS_WSL" = "0" ]; then
-            ADD_HOST_FLAG="--add-host=host.docker.internal:host-gateway"
-        fi
+    # Issue #1264: Probe a plain Alpine container to discover the real host IP.
+    # On Rancher Desktop (macOS/ARM64), --add-host=...:host-gateway resolves to the
+    # Lima VM's docker0 bridge (172.17.0.1), not the macOS host. Docker Desktop and
+    # Rancher Desktop do not auto-inject host.docker.internal into containers with
+    # NET_ADMIN/sysctl flags (the proxy sidecar uses both). A plain Alpine container
+    # without those flags always receives the correct entry — extract that IP and
+    # pin it as cc-webui.internal via --add-host.
+    _PROBE_IP=$(timeout 5 docker run --rm --pull=missing alpine \
+        sh -c "getent hosts host.docker.internal 2>/dev/null | awk 'NR==1{print \$1}'" \
+        2>/dev/null || true)
+    if [ -n "$_PROBE_IP" ]; then
+        echo "[claude-docker] Host IP probe: cc-webui.internal -> $_PROBE_IP" >&2
+        ADD_HOST_FLAG="--add-host=cc-webui.internal:$_PROBE_IP"
+    else
+        echo "[claude-docker] Host IP probe failed; falling back to host-gateway" >&2
+        ADD_HOST_FLAG="--add-host=cc-webui.internal:host-gateway"
     fi
 
     docker run -d \

--- a/src/docker/proxy/addon.py
+++ b/src/docker/proxy/addon.py
@@ -36,7 +36,7 @@ ALLOWLIST_PATH = "/etc/proxy/allowlist.json"
 SESSION_TOKEN_PATH = "/etc/proxy/session_token"
 SESSION_ID_PATH = "/etc/proxy/session_id"
 LOG_DIR = "/var/log/proxy"
-WEBUI_BASE_URL = os.environ.get("WEBUI_BASE_URL", "http://host.docker.internal:8000")
+WEBUI_BASE_URL = os.environ.get("WEBUI_BASE_URL", "http://cc-webui.internal:8000")
 SOCKS5_LOG_FILENAME = "socks5.log"
 
 _BINARY_CONTENT_TYPES = frozenset({

--- a/src/docker/proxy/allowlist.json
+++ b/src/docker/proxy/allowlist.json
@@ -9,6 +9,7 @@
     "github.com",
     "registry.npmjs.org",
     "pypi.org",
-    "files.pythonhosted.org"
+    "files.pythonhosted.org",
+    "cc-webui.internal"
   ]
 }

--- a/src/docker/proxy/entrypoint.sh
+++ b/src/docker/proxy/entrypoint.sh
@@ -16,6 +16,12 @@ cat > "$COREFILE" <<'HEADER'
 HEADER
 
 for domain in $DOMAINS; do
+    if [ "$domain" = "cc-webui.internal" ]; then
+        # Resolved via /etc/hosts (--add-host injection from claude-docker).
+        # 8.8.8.8 cannot resolve WebUI-internal names, so generating a forward
+        # zone here would produce broken NXDOMAIN responses.
+        continue
+    fi
     cat >> "$COREFILE" <<EOF
 
 ${domain} {

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -4289,14 +4289,15 @@ class SessionCoordinator:
         if not raw_error:
             return f"Session failed: {friendly_error}" if friendly_error else "Session process exited with error"
 
-        # Pattern-match well-known error conditions for a clean label
+        # Pattern-match well-known error conditions for a clean label.
+        # More-specific patterns come first (proxy names before generic DNS).
         known_patterns = [
+            (r"cc-webui\.internal|host\.docker\.internal", "Proxy startup failed: cc-webui.internal not reachable"),
             (r"permission denied", "Permission denied"),
             (r"name or service not known|name resolution fail|no such host", "DNS name resolution failed"),
             (r"connection refused", "Connection refused"),
             (r"no such file or directory", "File or directory not found"),
             (r"address already in use", "Port already in use"),
-            (r"host\.docker\.internal", "Proxy startup failed: host.docker.internal"),
         ]
         for pattern, label in known_patterns:
             if re.search(pattern, raw_error, re.IGNORECASE):

--- a/src/tests/test_session_coordinator_failure_format.py
+++ b/src/tests/test_session_coordinator_failure_format.py
@@ -1,0 +1,22 @@
+"""Regression tests for issue #1264 — failure-pill regex covers both proxy host names."""
+import pytest
+
+from src.session_coordinator import SessionCoordinator
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (
+            "connect to cc-webui.internal:8000 failed",
+            "Session failed: Proxy startup failed: cc-webui.internal not reachable",
+        ),
+        (
+            "getaddrinfo: host.docker.internal: Name or service not known",
+            "Session failed: Proxy startup failed: cc-webui.internal not reachable",
+        ),
+    ],
+)
+def test_proxy_failure_pattern_matches_both_names(raw, expected):
+    coord = SessionCoordinator.__new__(SessionCoordinator)
+    assert coord._format_failure_content("", raw) == expected


### PR DESCRIPTION
## Summary

Resolves #1264

Fixes proxy sidecar startup failure on Rancher Desktop (macOS/ARM64, Rosetta disabled). The root cause was that `--add-host=host.docker.internal:host-gateway` resolves to the Lima VM bridge (172.17.0.1) rather than the macOS host, and Docker/Rancher Desktop do not auto-inject `host.docker.internal` into containers using `NET_ADMIN`/`sysctl` flags — causing CoreDNS (AMD64 binary, crashes on ARM64) to be invoked, producing `EAI_AGAIN`, mitmdump exit, and a 30-second timeout.

## Changes Made

- **`src/docker/claude-docker`**: Replace the Issue #1233 Linux-only conditional `--add-host` block with a universal probe: runs a plain Alpine container (no `NET_ADMIN`/`sysctl`) which always gets the correct `host.docker.internal` auto-injection, extracts the IP, and pins it as `--add-host=cc-webui.internal:<ip>`. Falls back to `host-gateway` if the probe times out or fails.
- **`src/docker/proxy/addon.py`**: Update `WEBUI_BASE_URL` default from `http://host.docker.internal:8000` → `http://cc-webui.internal:8000`.
- **`src/docker/proxy/allowlist.json`**: Add `cc-webui.internal` to the `domains` array so the proxy's `_is_allowed()` permits agent traffic to the WebUI endpoint.
- **`src/docker/proxy/entrypoint.sh`**: Skip Corefile forward-zone generation for `cc-webui.internal` — resolved via `/etc/hosts`; forwarding to 8.8.8.8 would produce broken NXDOMAIN responses for a WebUI-internal name.
- **`src/session_coordinator.py`**: Update `_format_failure_content` regex to match both `cc-webui.internal` and `host.docker.internal` (version-skew compatibility); moved before the generic DNS pattern so the more-specific proxy label wins.
- **`src/tests/test_session_coordinator_failure_format.py`**: New regression test (2 parametrized cases) covering both host name patterns in `_format_failure_content`.

## Testing

- `uv run ruff check src/` — zero violations
- `uv run pytest src/tests/test_proxy_*.py src/tests/test_socks5_addon.py src/tests/test_session_coordinator_failure_format.py -v` — 59/59 passed
- `uv run pytest src/tests/ -v` — 1423/1423 passed

**Manual Docker verification** (Rancher Desktop on macOS; native Linux) is the user's responsibility — the probe and `--add-host` only take effect inside Docker containers and cannot be exercised by unit tests. Expected behaviour:
- Probe logs `[claude-docker] Host IP probe: cc-webui.internal -> <ip>` and proxy `.ready` appears within ~10s
- Pre-fix behaviour on Rancher Desktop without Rosetta: 30s timeout, "Proxy not ready" error
- Proxy image must be rebuilt after this change: `docker build -t claude-proxy:local src/docker/proxy/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)