### PR TITLE
fix(proxy): remove macOS-incompatible timeout from probe; generalize .internal Corefile skip

### DIFF
--- a/src/docker/claude-docker
+++ b/src/docker/claude-docker
@@ -259,7 +259,9 @@ if [ -n "$PROXY_IMAGE" ]; then
     # NET_ADMIN/sysctl flags (the proxy sidecar uses both). A plain Alpine container
     # without those flags always receives the correct entry — extract that IP and
     # pin it as cc-webui.internal via --add-host.
-    _PROBE_IP=$(timeout 5 docker run --rm --pull=missing alpine \
+    # Issue #1266: Do NOT use `timeout` — it is GNU coreutils and unavailable on macOS,
+    # causing the probe to fail silently on the platform where it is most needed.
+    _PROBE_IP=$(docker run --rm --pull=missing alpine \
         sh -c "getent hosts host.docker.internal 2>/dev/null | awk 'NR==1{print \$1}'" \
         2>/dev/null || true)
     if [ -n "$_PROBE_IP" ]; then

--- a/src/docker/proxy/entrypoint.sh
+++ b/src/docker/proxy/entrypoint.sh
@@ -16,10 +16,9 @@ cat > "$COREFILE" <<'HEADER'
 HEADER
 
 for domain in $DOMAINS; do
-    if [ "$domain" = "cc-webui.internal" ]; then
-        # Resolved via /etc/hosts (--add-host injection from claude-docker).
-        # 8.8.8.8 cannot resolve WebUI-internal names, so generating a forward
-        # zone here would produce broken NXDOMAIN responses.
+    if echo "$domain" | grep -q '\.internal$'; then
+        # .internal names are resolved via /etc/hosts (--add-host injection).
+        # 8.8.8.8 cannot resolve Docker/WebUI-internal names; skip forward zone.
         continue
     fi
     cat >> "$COREFILE" <<EOF


### PR DESCRIPTION
## Summary

Follow-up to #1265 with two corrections:

- **Remove `timeout` wrapper from Alpine probe** (`src/docker/claude-docker`): `timeout` is GNU coreutils and not available on macOS — it caused the host-IP probe to fail silently on Rancher Desktop (the exact platform the probe was added to fix). Bare `docker run` is used instead; the `2>/dev/null || true` guard already handles all failure modes cleanly.
- **Generalise Corefile skip to `*.internal`** (`src/docker/proxy/entrypoint.sh`): replaces the exact `cc-webui.internal` string match with `echo "$domain" | grep -q '\.internal$'` so any future `.internal` hostname is automatically excluded from the CoreDNS forward-zone generation.

## Testing

- `uv run pytest src/tests/ -q` — 1423/1423 passed
- Manual Docker verification on Rancher Desktop (macOS/ARM64) is the user's responsibility

Resolves #1266

🤖 Generated with [Claude Code](https://claude.com/claude-code)