### PR TITLE
chore: remove per-minion comms.jsonl dead write path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -786,7 +786,6 @@ data/
     └── minions/{minion_id}/
         ├── minion_state.json
         ├── session_messages.jsonl  # SDK messages
-        ├── comms.jsonl             # Minion-specific comm log
         ├── short_term_memory.json  # (Future)
         └── long_term_memory.json   # (Future)
 ```

--- a/src/legion/comm_router.py
+++ b/src/legion/comm_router.py
@@ -536,8 +536,6 @@ class CommRouter:
 
         Comms are stored in:
         1. Legion timeline (main timeline.jsonl)
-        2. Source minion's comm log (if from minion)
-        3. Destination minion's comm log (if to minion)
 
         Args:
             comm: Comm to persist
@@ -553,12 +551,6 @@ class CommRouter:
             if minion:
                 legion_id = minion.project_id  # project_id IS the legion_id
                 from_minion_name = minion.name
-                # Persist to source minion's log
-                await self._append_to_comm_log(
-                    legion_id,
-                    f"minions/{comm.from_minion_id}",
-                    comm
-                )
 
         if comm.to_minion_id:
             # Get minion info to find legion_id (project_id)
@@ -566,12 +558,6 @@ class CommRouter:
             if minion:
                 legion_id = minion.project_id  # project_id IS the legion_id
                 to_minion_name = minion.name
-                # Persist to destination minion's log
-                await self._append_to_comm_log(
-                    legion_id,
-                    f"minions/{comm.to_minion_id}",
-                    comm
-                )
 
         # If legion_id still not found and this is from user, need to get it from to_minion
         if not legion_id and comm.from_user:
@@ -626,36 +612,6 @@ class CommRouter:
                 )
             except Exception as e:
                 legion_logger.error(f"Failed to emit comm to audit writer: {e}")
-
-    async def _append_to_comm_log(
-        self,
-        legion_id: str,
-        subpath: str,
-        comm: Comm
-    ) -> None:
-        """
-        Append Comm to a JSONL log file.
-
-        Args:
-            legion_id: Legion ID
-            subpath: Subpath within legion directory (e.g., "minions/{minion_id}")
-            comm: Comm to append
-        """
-        # Get data_dir from SessionCoordinator
-        data_dir = self.system.session_coordinator.data_dir
-
-        # Construct path: {data_dir}/legions/{legion_id}/{subpath}/comms.jsonl
-        log_dir = data_dir / "legions" / legion_id / subpath
-        log_dir.mkdir(parents=True, exist_ok=True)
-
-        log_file = log_dir / "comms.jsonl"
-
-        # Append comm as JSON line
-        with open(log_file, "a", encoding="utf-8") as f:
-            json.dump(comm.to_dict(), f)
-            f.write("\n")
-
-        legion_logger.debug(f"Appended comm {comm.comm_id} to {log_file}")
 
     async def _append_to_timeline(self, legion_id: str, comm: Comm) -> None:
         """

--- a/src/tests/integration/test_comm_tools.py
+++ b/src/tests/integration/test_comm_tools.py
@@ -62,8 +62,6 @@ async def test_send_comm_to_active_minion(legion_test_env):
     Verifies:
     - Tool returns success
     - Timeline JSONL contains comm
-    - Sender comms.jsonl contains comm
-    - Recipient comms.jsonl contains comm
     - Recipient messages.jsonl contains formatted message
     """
     env = legion_test_env
@@ -123,27 +121,7 @@ async def test_send_comm_to_active_minion(legion_test_env):
     assert comm["content"] == "Please process data.csv"
     assert comm["comm_type"] == "task"
 
-    # SIDE EFFECT 2: Sender comms.jsonl
-    sender_comms_file = data_dir / "legions" / legion_id / "minions" / sender.session_id / "comms.jsonl"
-    assert sender_comms_file.exists(), "Sender comms file should exist"
-
-    with open(sender_comms_file) as f:
-        sender_comms = [json.loads(line) for line in f]
-
-    assert len(sender_comms) > 0, "Sender should have comm in log"
-    assert any(c["summary"] == "Task assigned" for c in sender_comms)
-
-    # SIDE EFFECT 3: Recipient comms.jsonl
-    recipient_comms_file = data_dir / "legions" / legion_id / "minions" / recipient.session_id / "comms.jsonl"
-    assert recipient_comms_file.exists(), "Recipient comms file should exist"
-
-    with open(recipient_comms_file) as f:
-        recipient_comms = [json.loads(line) for line in f]
-
-    assert len(recipient_comms) > 0, "Recipient should have comm in log"
-    assert any(c["summary"] == "Task assigned" for c in recipient_comms)
-
-    # SIDE EFFECT 4: Recipient SDK message queue injection
+    # SIDE EFFECT 2: Recipient SDK message queue injection
     # Note: SessionCoordinator.send_message() queues messages to the SDK.
     # LIMITATION: In integration tests without Claude API access, the SDK conversation
     # loop cannot fully process messages (would require actual API calls to Claude).
@@ -152,7 +130,6 @@ async def test_send_comm_to_active_minion(legion_test_env):
     #
     # What we CAN verify:
     # - Comm routed to timeline.jsonl ✓ (verified above)
-    # - Comm logged to sender/recipient comms.jsonl ✓ (verified above)
     # - Message queued to SDK (verified by successful send_message call)
     #
     # What requires end-to-end testing with live API:

--- a/src/tests/test_comm_router.py
+++ b/src/tests/test_comm_router.py
@@ -284,32 +284,8 @@ class TestCommRouter:
         assert result is True
 
     @pytest.mark.asyncio
-    async def test_append_to_comm_log(self, comm_router, tmp_path):
-        """Test appending Comm to JSONL log file."""
-        # Point data_dir to tmp_path so _append_to_comm_log writes there
-        comm_router.system.session_coordinator.data_dir = tmp_path
-
-        comm = Comm(
-            comm_id=str(uuid.uuid4()),
-            from_user=True,
-            to_minion_id="test-minion-123",
-            content="Test message"
-        )
-
-        await comm_router._append_to_comm_log(
-            "test-legion-456",
-            "minions/test-minion-123",
-            comm
-        )
-
-        # Verify log file was created with comm data
-        log_file = tmp_path / "legions" / "test-legion-456" / "minions" / "test-minion-123" / "comms.jsonl"
-        assert log_file.exists()
-        assert log_file.read_text().strip() != ""
-
-    @pytest.mark.asyncio
     async def test_persist_comm_from_minion(self, comm_router, sample_minion, legion_system):
-        """Test persisting Comm from minion."""
+        """Test persisting Comm from minion writes to timeline."""
         # Mock legion_coordinator.get_minion_info
         legion_system.legion_coordinator.get_minion_info = AsyncMock(return_value=sample_minion)
 
@@ -320,14 +296,13 @@ class TestCommRouter:
             content="Test message"
         )
 
-        with patch.object(comm_router, '_append_to_comm_log', new=AsyncMock()) as mock_append:
+        with patch.object(comm_router, '_append_to_timeline', new=AsyncMock()) as mock_append_timeline:
             await comm_router._persist_comm(comm)
-            # Should append to source minion's log
-            mock_append.assert_called_once()
+            mock_append_timeline.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_persist_comm_to_minion(self, comm_router, sample_minion, legion_system):
-        """Test persisting Comm to minion."""
+        """Test persisting Comm to minion writes to timeline."""
         legion_system.legion_coordinator.get_minion_info = AsyncMock(return_value=sample_minion)
 
         comm = Comm(
@@ -337,10 +312,9 @@ class TestCommRouter:
             content="Test message"
         )
 
-        with patch.object(comm_router, '_append_to_comm_log', new=AsyncMock()) as mock_append:
+        with patch.object(comm_router, '_append_to_timeline', new=AsyncMock()) as mock_append_timeline:
             await comm_router._persist_comm(comm)
-            # Should append to destination minion's log
-            mock_append.assert_called_once()
+            mock_append_timeline.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_issue_939_attachment_metadata_in_comm(self, comm_router, tmp_path):


### PR DESCRIPTION
## Summary
Resolves #1262

Remove the write-only `_append_to_comm_log` method and its two callsites from `CommRouter._persist_comm`. The per-minion `comms.jsonl` had zero production readers — all timeline reads go through `timeline.jsonl`. This is pure dead-code removal with no behavior change.

## Changes Made
- `src/legion/comm_router.py`: Remove `_append_to_comm_log` method and its two callsites; update `_persist_comm` docstring. `get_minion_info()` lookups preserved — they feed `legion_id`, `from_minion_name`, `to_minion_name` to `_append_to_timeline`, broadcast callback, UI notification, and audit writer.
- `src/tests/test_comm_router.py`: Delete `test_append_to_comm_log`; rewrite `test_persist_comm_from_minion` and `test_persist_comm_to_minion` to assert against `_append_to_timeline`.
- `src/tests/integration/test_comm_tools.py`: Remove SIDE EFFECT 2 and 3 blocks (per-minion `comms.jsonl` assertions).
- `CLAUDE.md`: Remove stale `comms.jsonl` entry from data directory tree.

## Testing
- `uv run ruff check src/legion/comm_router.py src/tests/test_comm_router.py src/tests/integration/test_comm_tools.py` — zero violations
- `uv run pytest src/tests/ -v` — 1422 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)