### PR TITLE
fix: resolve post-config-refactor AttributeErrors in list_templates, spawn_minion, whoami

### DIFF
--- a/src/legion/mcp/legion_mcp_tools.py
+++ b/src/legion/mcp/legion_mcp_tools.py
@@ -998,7 +998,7 @@ class LegionMCPTools:
                     'history_distillation_enabled',
                     _pc.get('history_distillation_enabled', _SESSION_DEFAULTS['history_distillation_enabled']),
                 )
-                auto_memory_mode = resolved.get('auto_memory_mode') or _pc.get('auto_memory_mode')
+                auto_memory_mode = resolved.get('auto_memory_mode') or _pc.get('auto_memory_mode') or _SESSION_DEFAULTS['auto_memory_mode']
                 skill_creating_enabled = resolved.get(
                     'skill_creating_enabled',
                     _pc.get('skill_creating_enabled', _SESSION_DEFAULTS['skill_creating_enabled']),
@@ -1042,7 +1042,7 @@ class LegionMCPTools:
             sandbox_config = _pc.get('sandbox_config')
             docker_home_directory = _pc.get('docker_home_directory')
             history_distillation_enabled = _pc.get('history_distillation_enabled', _SESSION_DEFAULTS['history_distillation_enabled'])
-            auto_memory_mode = _pc.get('auto_memory_mode')
+            auto_memory_mode = _pc.get('auto_memory_mode') or _SESSION_DEFAULTS['auto_memory_mode']
             skill_creating_enabled = _pc.get('skill_creating_enabled', _SESSION_DEFAULTS['skill_creating_enabled'])
             mcp_server_ids = _pc.get('mcp_server_ids')
             enable_claudeai_mcp_servers = _pc.get('enable_claudeai_mcp_servers', _SESSION_DEFAULTS['enable_claudeai_mcp_servers'])
@@ -1753,7 +1753,8 @@ class LegionMCPTools:
 
             for template in templates:
                 # Format allowed tools
-                tools_str = ", ".join(template.allowed_tools) if template.allowed_tools else "None"
+                _allowed = template.config.get("allowed_tools", [])
+                tools_str = ", ".join(_allowed) if _allowed else "None"
                 if len(tools_str) > 60:  # Truncate if too long
                     tools_str = tools_str[:60] + "..."
 
@@ -1761,7 +1762,7 @@ class LegionMCPTools:
                 result_lines.append(
                     f"• **{template.name}**\n"
                     f"  - Description: {template.description or 'No description'}\n"
-                    f"  - Permission Mode: {template.permission_mode}\n"
+                    f"  - Permission Mode: {template.config.get('permission_mode', 'default')}\n"
                     f"  - Allowed Tools: {tools_str}\n"
                     f"  - Role: {template.role or 'Not specified'}\n"
                 )
@@ -1995,7 +1996,7 @@ class LegionMCPTools:
             "session_id": session.session_id,
             # Configuration
             "permission_mode": session.current_permission_mode,
-            "model": session.model,
+            "model": session.config.get('model'),
             "can_spawn_minions": session.can_spawn_minions,
         }
 


### PR DESCRIPTION
## Summary

Three MCP tool handlers were broken by the #1230 config dict refactor — fields moved into `session.config`/`template.config` but the handlers weren't updated. All fixes are in `src/legion/mcp/legion_mcp_tools.py`.

- **#1285** `list_templates`: `template.allowed_tools` / `template.permission_mode` → `template.config.get(...)`
- **#1286** `spawn_minion`: `auto_memory_mode` bare `.get()` → falls back to `_SESSION_DEFAULTS['auto_memory_mode']` when key absent (same pattern as other fields in the same block)
- **#1292** `whoami`: `session.model` → `session.config.get('model')`

`session.current_permission_mode` (also in `whoami`) confirmed still a valid top-level attribute on `SessionInfo` — no change needed.

## Test plan

- [ ] `list_templates` returns template catalog without error
- [ ] `spawn_minion` succeeds with default config (no explicit `auto_memory_mode`)
- [ ] `spawn_minion` respects explicit `auto_memory_mode` when set in template/parent config
- [ ] `whoami` returns identity dict including correct `model` field
- [ ] `uv run pytest src/tests/ -v` — 1419 passed, 0 new failures

Closes #1285
Closes #1286
Closes #1292

🤖 Generated with [Claude Code](https://claude.com/claude-code)