### PR TITLE
fix: restore analytics token recording for SDK 0.1.72+ (#1287)

### DIFF
--- a/src/claude_sdk.py
+++ b/src/claude_sdk.py
@@ -1371,7 +1371,7 @@ class ClaudeSDK:
                     message_dict["content"] = " ".join(text_parts) if text_parts else ""
 
             # Copy other common attributes from SDK message
-            for attr in ['message', 'data', 'subtype', 'error', 'usage', 'model', 'duration_ms', 'total_cost_usd', 'parent_tool_use_id', 'stop_reason', 'errors', 'permission_denials', 'is_error', 'num_turns', 'duration_api_ms']:
+            for attr in ['message', 'data', 'subtype', 'error', 'usage', 'model_usage', 'model', 'duration_ms', 'total_cost_usd', 'parent_tool_use_id', 'stop_reason', 'errors', 'permission_denials', 'is_error', 'num_turns', 'duration_api_ms']:
                 if hasattr(sdk_message, attr):
                     value = getattr(sdk_message, attr)
                     # Only add serializable values

--- a/src/message_parser.py
+++ b/src/message_parser.py
@@ -1025,6 +1025,7 @@ class ResultMessageHandler(MessageHandler):
                 "num_turns": message_data.get("num_turns"),
                 "total_cost_usd": message_data.get("total_cost_usd"),
                 "usage": message_data.get("usage", {}),
+                "model_usage": message_data.get("model_usage"),
                 "stop_reason": message_data.get("stop_reason"),
                 "permission_denials": message_data.get("permission_denials", []),
                 "errors": message_data.get("errors"),

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -106,6 +106,46 @@ def _apply_resource_filters(
     return result
 
 
+def _normalize_result_usage(
+    usage: dict | None,
+    model_usage: dict | None,
+) -> tuple[dict, float | None]:
+    """Return (snake_case usage dict, aggregate cost from model_usage or None).
+
+    Prefers SDK 'usage' when it carries non-zero token counts. Otherwise
+    aggregates per-model 'model_usage' entries (camelCase keys, keyed by
+    model name) into the snake_case shape that AnalyticsStore.record_turn
+    already understands.
+    """
+    snake_keys = (
+        "input_tokens",
+        "output_tokens",
+        "cache_creation_input_tokens",
+        "cache_read_input_tokens",
+    )
+    if isinstance(usage, dict) and any(int(usage.get(k) or 0) for k in snake_keys):
+        return dict(usage), None
+
+    if not isinstance(model_usage, dict) or not model_usage:
+        return (dict(usage) if isinstance(usage, dict) else {}), None
+
+    agg = {k: 0 for k in snake_keys}
+    cost = 0.0
+    has_cost = False
+    for entry in model_usage.values():
+        if not isinstance(entry, dict):
+            continue
+        agg["input_tokens"] += int(entry.get("inputTokens") or 0)
+        agg["output_tokens"] += int(entry.get("outputTokens") or 0)
+        agg["cache_creation_input_tokens"] += int(entry.get("cacheCreationInputTokens") or 0)
+        agg["cache_read_input_tokens"] += int(entry.get("cacheReadInputTokens") or 0)
+        c = entry.get("costUSD")
+        if c is not None:
+            cost += float(c)
+            has_cost = True
+    return agg, (cost if has_cost else None)
+
+
 def _tail_read_lines(path: "Path", limit: int) -> list[str]:
     """Read the last `limit` lines from a file efficiently using a deque."""
     from collections import deque
@@ -2735,7 +2775,7 @@ class SessionCoordinator:
                 if subtype:
                     metadata["subtype"] = subtype
                 # Copy usage data
-                for key in ["usage", "duration_ms", "duration_api_ms", "total_cost_usd", "num_turns"]:
+                for key in ["usage", "model_usage", "duration_ms", "duration_api_ms", "total_cost_usd", "num_turns"]:
                     if key in data:
                         metadata[key] = data[key]
                 # Copy stop_reason for truncation detection
@@ -3957,8 +3997,12 @@ class SessionCoordinator:
                     if self.analytics_store:
                         try:
                             meta = parsed_message.metadata or {}
-                            usage = meta.get("usage") or {}
+                            usage, model_usage_cost = _normalize_result_usage(
+                                meta.get("usage"), meta.get("model_usage")
+                            )
                             sdk_cost = meta.get("total_cost_usd")
+                            if sdk_cost is None:
+                                sdk_cost = model_usage_cost
                             # Resolve model from session info
                             _sinfo = await self.session_manager.get_session_info(session_id)
                             _model = _sinfo.model if _sinfo else None

--- a/src/tests/test_session_coordinator_usage.py
+++ b/src/tests/test_session_coordinator_usage.py
@@ -1,0 +1,71 @@
+"""Unit tests for usage normalisation against SDK 0.1.72+ (issue #1287)."""
+from src.session_coordinator import _normalize_result_usage
+
+
+def test_prefers_usage_when_populated():
+    usage = {"input_tokens": 100, "output_tokens": 50,
+             "cache_creation_input_tokens": 10, "cache_read_input_tokens": 5}
+    out, cost = _normalize_result_usage(usage, None)
+    assert out == usage
+    assert cost is None
+
+
+def test_falls_back_to_model_usage_when_usage_none():
+    model_usage = {
+        "claude-sonnet-4-6": {
+            "inputTokens": 200, "outputTokens": 80,
+            "cacheCreationInputTokens": 20, "cacheReadInputTokens": 4,
+            "costUSD": 0.0123,
+        }
+    }
+    out, cost = _normalize_result_usage(None, model_usage)
+    assert out == {
+        "input_tokens": 200, "output_tokens": 80,
+        "cache_creation_input_tokens": 20, "cache_read_input_tokens": 4,
+    }
+    assert abs(cost - 0.0123) < 1e-9
+
+
+def test_falls_back_when_usage_is_all_zeros():
+    usage = {"input_tokens": 0, "output_tokens": 0}
+    model_usage = {
+        "claude-sonnet-4-6": {
+            "inputTokens": 50, "outputTokens": 25,
+            "cacheCreationInputTokens": 0, "cacheReadInputTokens": 0,
+            "costUSD": 0.001,
+        }
+    }
+    out, cost = _normalize_result_usage(usage, model_usage)
+    assert out["input_tokens"] == 50
+    assert out["output_tokens"] == 25
+    assert cost is not None
+
+
+def test_aggregates_across_multiple_models():
+    model_usage = {
+        "claude-sonnet-4-6": {
+            "inputTokens": 100, "outputTokens": 40,
+            "cacheCreationInputTokens": 5, "cacheReadInputTokens": 1,
+            "costUSD": 0.002,
+        },
+        "claude-haiku-4-5": {
+            "inputTokens": 50, "outputTokens": 20,
+            "cacheCreationInputTokens": 2, "cacheReadInputTokens": 1,
+            "costUSD": 0.0005,
+        },
+    }
+    out, cost = _normalize_result_usage(None, model_usage)
+    assert out == {
+        "input_tokens": 150, "output_tokens": 60,
+        "cache_creation_input_tokens": 7, "cache_read_input_tokens": 2,
+    }
+    assert abs(cost - 0.0025) < 1e-9
+
+
+def test_empty_inputs_return_empty_dict():
+    out, cost = _normalize_result_usage(None, None)
+    assert out == {}
+    assert cost is None
+    out, cost = _normalize_result_usage({}, {})
+    assert out == {}
+    assert cost is None


### PR DESCRIPTION
## Summary

- Add `_normalize_result_usage()` helper in `session_coordinator.py` that prefers `usage` (snake_case) when non-zero, otherwise aggregates per-model `modelUsage` (camelCase) entries and sums `costUSD` as a cost fallback
- Wire helper into the result-message analytics block with `total_cost_usd` → `costUSD` fallback chain
- Propagate `model_usage` through the SDK attr-copy loop (`claude_sdk.py`), `ResultMessageHandler` metadata (`message_parser.py`), and stored-message replay conversion (`session_coordinator.py`)
- Add 5 unit tests covering all `_normalize_result_usage` branches

## Test plan

- [x] `uv run ruff check src/` — zero violations
- [x] `uv run pytest src/tests/test_session_coordinator_usage.py src/tests/test_analytics_store.py -v` — 15 passed
- [x] `uv run pytest src/tests/ -v` — 1424 passed, 1 pre-existing failure in `test_template_manager.py` (unrelated to this change)

Resolves #1287

🤖 Generated with [Claude Code](https://claude.com/claude-code)