### PR TITLE
chore: migrate strict_mcp_config from extra_args to ClaudeAgentOptions

### DIFF
--- a/src/claude_sdk.py
+++ b/src/claude_sdk.py
@@ -856,12 +856,6 @@ class ClaudeSDK:
             }
             sdk_logger.info("Using DEFAULT mode - Claude Code preset only")
 
-        # Issue #676: Pass --strict-mcp-config to disable local .mcp.json configs
-        # Use None (not True) so the SDK transport emits a bare flag without a value.
-        # True would produce "--strict-mcp-config True" which the CLI misinterprets.
-        if self.strict_mcp_config:
-            extra_args["strict-mcp-config"] = None
-
         # Issue #902: Bare mode skips hooks, LSP, plugin sync, skill walks
         if self.bare_mode:
             extra_args["bare"] = None
@@ -878,6 +872,11 @@ class ClaudeSDK:
             # Issue #36: Use configurable setting_sources (default: load from user, project, and local)
             "setting_sources": self.setting_sources if self.setting_sources else ["user", "project", "local"]
         }
+
+        # Issue #676 / #1301: strict_mcp_config is a typed ClaudeAgentOptions field
+        # in claude-agent-sdk >= 0.1.74; pass as kwarg instead of CLI extra_args.
+        if self.strict_mcp_config:
+            options_kwargs["strict_mcp_config"] = True
 
         # Issue #461: Add disallowed_tools if any are configured
         if self.disallowed_tools:

--- a/src/tests/test_claude_sdk.py
+++ b/src/tests/test_claude_sdk.py
@@ -191,6 +191,27 @@ class TestClaudeSDK:
         assert "timestamp" in converted
         # No conversion_error since this is handled gracefully, not as an exception
 
+    def test_get_sdk_options_strict_mcp_config_enabled(self, temp_dir, session_id):
+        """Issue #1301: strict_mcp_config flows through as a typed kwarg, not extra_args."""
+        sdk = ClaudeSDK(
+            session_id=session_id,
+            working_directory=temp_dir,
+            config=SessionConfig(strict_mcp_config=True),
+        )
+        opts = sdk._get_sdk_options()
+        assert opts.strict_mcp_config is True
+        assert "strict-mcp-config" not in (opts.extra_args or {})
+
+    def test_get_sdk_options_strict_mcp_config_disabled(self, temp_dir, session_id):
+        """Issue #1301: default strict_mcp_config=False leaves the typed kwarg unset and extra_args clean."""
+        sdk = ClaudeSDK(
+            session_id=session_id,
+            working_directory=temp_dir,
+            config=SessionConfig(strict_mcp_config=False),
+        )
+        opts = sdk._get_sdk_options()
+        assert opts.strict_mcp_config is False
+        assert "strict-mcp-config" not in (opts.extra_args or {})
 
 
 class TestSessionInfo:


### PR DESCRIPTION
## Summary
Resolves #1301

Migrate `strict_mcp_config` from the brittle `extra_args` CLI passthrough to the first-class `strict_mcp_config: bool` field on `ClaudeAgentOptions`, available since `claude-agent-sdk 0.1.74` (project is on 0.1.75).

## Changes Made
- `src/claude_sdk.py`: Remove `extra_args["strict-mcp-config"] = None`; add `options_kwargs["strict_mcp_config"] = True` when flag is set
- `src/tests/test_claude_sdk.py`: Two new unit tests asserting typed kwarg is set and CLI flag is absent from `extra_args` for both enabled and disabled cases

## Testing
- `uv run ruff check src/` — zero violations
- `uv run pytest src/tests/test_claude_sdk.py -v` — 16/16 passed (includes 2 new tests)
- `uv run pytest src/tests/ -v` — 1426 passed, 1 pre-existing failure in `test_template_manager` unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)