### PR TITLE
feat: enable include_hook_events and fix hook event replay/display

### DIFF
--- a/src/claude_sdk.py
+++ b/src/claude_sdk.py
@@ -962,6 +962,10 @@ class ClaudeSDK:
         # (e.g., Chrome DevTools screenshots/snapshots). SDK default is 1MB which is too small.
         options_kwargs["max_buffer_size"] = 10 * 1024 * 1024
 
+        # Issue #1299: Emit hook lifecycle events (hook_started/hook_response) into the message
+        # stream as HookEventMessage objects. Without this flag, hook events are silently dropped.
+        options_kwargs["include_hook_events"] = True
+
         options_kwargs["env"] = self._resolve_env_vars()
 
         # Add stderr handler to capture SDK CLI errors (issue #517)

--- a/src/message_parser.py
+++ b/src/message_parser.py
@@ -339,9 +339,12 @@ class SystemMessageHandler(MessageHandler):
                 if subtype == "hook_started":
                     extracted["content"] = f"Hook: {hook_name} ({hook_event})" if hook_event else f"Hook: {hook_name}"
                 else:
-                    outcome = hook_data.get("outcome", hook_data.get("output", "done"))
                     exit_code = hook_data.get("exit_code", hook_data.get("exitCode"))
-                    extracted["content"] = f"Hook: {hook_name} \u2192 {outcome}"
+                    if exit_code == 0:
+                        display = hook_data.get("stdout") or hook_data.get("outcome", "success")
+                    else:
+                        display = hook_data.get("stderr") or hook_data.get("outcome", "failed")
+                    extracted["content"] = f"Hook: {hook_name} \u2192 {display}"
                     if exit_code is not None:
                         extracted["metadata"]["exit_code"] = exit_code
 
@@ -395,9 +398,12 @@ class SystemMessageHandler(MessageHandler):
                 if subtype == "hook_started":
                     extracted["content"] = f"Hook: {hook_name} ({hook_event})" if hook_event else f"Hook: {hook_name}"
                 else:
-                    outcome = init_data.get("outcome", init_data.get("output", "done"))
                     exit_code = init_data.get("exit_code", init_data.get("exitCode"))
-                    extracted["content"] = f"Hook: {hook_name} \u2192 {outcome}"
+                    if exit_code == 0:
+                        display = init_data.get("stdout") or init_data.get("outcome", "success")
+                    else:
+                        display = init_data.get("stderr") or init_data.get("outcome", "failed")
+                    extracted["content"] = f"Hook: {hook_name} \u2192 {display}"
                     if exit_code is not None:
                         extracted["metadata"]["exit_code"] = exit_code
 

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -2708,7 +2708,7 @@ class SessionCoordinator:
                 )
 
             # Handle SystemMessage subtypes (including Task* subclasses)
-            if _type in ("SystemMessage", "TaskStartedMessage", "TaskProgressMessage", "TaskNotificationMessage"):
+            if _type in ("SystemMessage", "HookEventMessage", "TaskStartedMessage", "TaskProgressMessage", "TaskNotificationMessage"):
                 subtype = data.get("subtype")
                 if subtype:
                     metadata["subtype"] = subtype
@@ -2763,9 +2763,12 @@ class SessionCoordinator:
                     if subtype == "hook_started":
                         content = f"Hook: {hook_name} ({hook_event})" if hook_event else f"Hook: {hook_name}"
                     else:
-                        outcome = hook_data.get("outcome", hook_data.get("output", "done"))
                         exit_code = hook_data.get("exit_code", hook_data.get("exitCode"))
-                        content = f"Hook: {hook_name} \u2192 {outcome}"
+                        if exit_code == 0:
+                            display = hook_data.get("stdout") or hook_data.get("outcome", "success")
+                        else:
+                            display = hook_data.get("stderr") or hook_data.get("outcome", "failed")
+                        content = f"Hook: {hook_name} \u2192 {display}"
                         if exit_code is not None:
                             metadata["exit_code"] = exit_code
 

--- a/src/tests/test_message_parser.py
+++ b/src/tests/test_message_parser.py
@@ -628,6 +628,54 @@ class TestHookMessageHandling:
         assert "my-hook" in parsed.content
         assert "Stop" in parsed.content
 
+    def test_hook_response_uses_stdout_on_success(self):
+        """Test hook_response prefers stdout over outcome string when exit_code == 0."""
+        handler = SystemMessageHandler()
+        message_data = {
+            "type": "system",
+            "content": "",
+            "metadata": {
+                "subtype": "hook_response",
+                "init_data": {
+                    "hook_name": "my-hook",
+                    "hook_event": "PreToolUse",
+                    "hook_id": "hook-003",
+                    "outcome": "success",
+                    "exit_code": 0,
+                    "stdout": "hook ran OK",
+                },
+            },
+            "session_id": "test-hooks",
+            "timestamp": time.time(),
+        }
+        parsed = handler.parse(message_data)
+        assert "hook ran OK" in parsed.content
+        assert "success" not in parsed.content
+
+    def test_hook_response_uses_stderr_on_failure(self):
+        """Test hook_response prefers stderr over outcome string when exit_code != 0."""
+        handler = SystemMessageHandler()
+        message_data = {
+            "type": "system",
+            "content": "",
+            "metadata": {
+                "subtype": "hook_response",
+                "init_data": {
+                    "hook_name": "my-hook",
+                    "hook_event": "PostToolUse",
+                    "hook_id": "hook-004",
+                    "outcome": "failed",
+                    "exit_code": 2,
+                    "stderr": "permission denied",
+                },
+            },
+            "session_id": "test-hooks",
+            "timestamp": time.time(),
+        }
+        parsed = handler.parse(message_data)
+        assert "permission denied" in parsed.content
+        assert "failed" not in parsed.content
+
     def test_hook_parser_integration(self):
         """Test hook messages through the full MessageParser pipeline."""
         parser = MessageParser()


### PR DESCRIPTION
## Summary
Resolves #1299

Enable SDK hook event emission and fix how hook events are replayed and displayed in the UI.

## Changes Made
- Set `include_hook_events=True` in `ClaudeAgentOptions` so the SDK emits `HookEventMessage` objects instead of silently dropping them
- Add `HookEventMessage` to the type tuple in `_convert_stored_message_to_websocket` so hook events replay correctly on session reload
- Fix `hook_response` content synthesis to prefer `stdout` (success) or `stderr` (failure) over the literal outcome string (e.g. "success") — applied to all three synthesis sites
- Add two unit tests covering the `stdout`/`stderr` priority behaviour

## Testing
- `uv run ruff check src/` — zero violations
- `uv run pytest src/tests/ -v` — 1426 passed (1 pre-existing unrelated failure)
- Frontend build succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)