### PR TITLE
fix: chown socks5.log to uid 9999 after entrypoint truncation

### DIFF
--- a/src/docker/proxy/entrypoint.sh
+++ b/src/docker/proxy/entrypoint.sh
@@ -239,6 +239,7 @@ iptables -A OUTPUT -p udp -j DROP
 # Issue #1214: Truncate SOCKS5 log at sidecar start so each session begins clean.
 if [ -d "$LOG_DIR" ]; then
     : > "$LOG_DIR/socks5.log"
+    chown 9999:9999 "$LOG_DIR/socks5.log"
 fi
 
 echo "Starting mitmdump (transparent + SOCKS5) on :8080 / 127.0.0.1:1080..."


### PR DESCRIPTION
## Summary

- The `entrypoint.sh` truncation block (introduced in #1214) creates `socks5.log` as root when the file doesn't exist
- `mitmdump` runs as uid 9999 and cannot open a root-owned file, causing it to fail to write logs
- Added `chown 9999:9999` immediately after the truncate line
- Verified: `access.log`, `dns.log`, `dropped.log`, and `mitm.flows` have no similar pre-creation blocks and are unaffected

## Test plan
- [ ] `uv run pytest src/tests/ -v` passes (1461 tests, pre-existing unrelated failure in test_template_manager)
- [ ] `uv run ruff check src/` passes with zero violations
- [ ] In a running proxy container: `LOG_DIR` mounted, `socks5.log` is owned by 9999:9999 after container start

Resolves #1336

🤖 Generated with [Claude Code](https://claude.com/claude-code)