### PR TITLE
fix: restore traceback output for logger.exception calls

### DIFF
--- a/src/logging_config.py
+++ b/src/logging_config.py
@@ -108,7 +108,18 @@ class StandardizedFormatter(logging.Formatter):
         category = getattr(record, 'category', record.name.upper())
 
         # Format: YYYY-MM-DDTHH:mm:ss.mmm LEVEL - [CATEGORY] Message
-        return f"{timestamp}.{ms} {record.levelname} - [{category}] {record.getMessage()}"
+        formatted = f"{timestamp}.{ms} {record.levelname} - [{category}] {record.getMessage()}"
+
+        # Append exception traceback when present (preserves logger.exception() behavior)
+        if record.exc_info:
+            if not record.exc_text:
+                record.exc_text = self.formatException(record.exc_info)
+        if record.exc_text:
+            formatted = formatted + "\n" + record.exc_text
+        if record.stack_info:
+            formatted = formatted + "\n" + self.formatStack(record.stack_info)
+
+        return formatted
 
 
 class CategoryAdapter(logging.LoggerAdapter):

--- a/src/tests/test_issue_1332_logger_exception.py
+++ b/src/tests/test_issue_1332_logger_exception.py
@@ -1,0 +1,119 @@
+"""Regression test for issue #1332.
+
+Verifies that logger.exception() produces traceback output via StandardizedFormatter.
+"""
+
+import logging
+from io import StringIO
+
+from ..logging_config import StandardizedFormatter, configure_logging
+
+
+class TestLoggerExceptionTraceback:
+    """StandardizedFormatter must preserve exc_info so tracebacks appear in output."""
+
+    def test_formatter_includes_traceback_in_output(self):
+        """StandardizedFormatter.format() appends traceback when exc_info is set."""
+        formatter = StandardizedFormatter()
+        try:
+            raise ValueError("something went wrong")
+        except ValueError:
+            import sys
+            exc_info = sys.exc_info()
+
+        record = logging.LogRecord(
+            name="test_logger",
+            level=logging.ERROR,
+            pathname="test.py",
+            lineno=1,
+            msg="operation failed",
+            args=(),
+            exc_info=exc_info,
+        )
+
+        formatted = formatter.format(record)
+
+        assert "operation failed" in formatted
+        assert "ValueError" in formatted
+        assert "something went wrong" in formatted
+        assert "Traceback (most recent call last)" in formatted
+
+    def test_logger_exception_writes_traceback_to_error_log(self, tmp_path):
+        """logger.exception() call produces traceback lines in error.log."""
+        configure_logging(log_dir=str(tmp_path))
+
+        stream = StringIO()
+        handler = logging.StreamHandler(stream)
+        handler.setLevel(logging.ERROR)
+        handler.setFormatter(StandardizedFormatter())
+
+        test_logger = logging.getLogger("test_1332_exception")
+        test_logger.handlers.clear()
+        test_logger.propagate = False
+        test_logger.setLevel(logging.ERROR)
+        test_logger.addHandler(handler)
+
+        try:
+            raise RuntimeError("disk full")
+        except RuntimeError:
+            test_logger.exception("backup failed")
+
+        output = stream.getvalue()
+        assert "backup failed" in output
+        assert "RuntimeError" in output
+        assert "disk full" in output
+        assert "Traceback (most recent call last)" in output
+
+    def test_logger_exception_written_to_error_log_file(self, tmp_path):
+        """Error log file contains both message and traceback when logger.exception is used."""
+        configure_logging(log_dir=str(tmp_path))
+
+        root_logger = logging.getLogger()
+
+        try:
+            raise AttributeError("'SessionInfo' object has no attribute 'model'")
+        except AttributeError:
+            root_logger.exception("Failed to record analytics for session %s", "abc-123")
+
+        error_log = tmp_path / "error.log"
+        assert error_log.exists()
+        content = error_log.read_text()
+
+        assert "Failed to record analytics for session abc-123" in content
+        assert "AttributeError" in content
+        assert "'SessionInfo' object has no attribute 'model'" in content
+
+    def test_format_without_exc_info_unchanged(self):
+        """Normal log records without exc_info are unaffected."""
+        formatter = StandardizedFormatter()
+        record = logging.LogRecord(
+            name="test_logger",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="normal message",
+            args=(),
+            exc_info=None,
+        )
+
+        formatted = formatter.format(record)
+
+        assert "normal message" in formatted
+        assert "Traceback" not in formatted
+
+    def test_exception_outside_except_block_does_not_crash(self):
+        """logger.exception() outside an except block logs NoneType: None, does not raise."""
+        formatter = StandardizedFormatter()
+
+        record = logging.LogRecord(
+            name="test_logger",
+            level=logging.ERROR,
+            pathname="test.py",
+            lineno=1,
+            msg="unexpected call site",
+            args=(),
+            exc_info=(None, None, None),
+        )
+
+        formatted = formatter.format(record)
+        assert "unexpected call site" in formatted


### PR DESCRIPTION
## Summary

- `StandardizedFormatter.format()` was building output from `record.getMessage()` and returning early, silently discarding `record.exc_info`
- `logger.exception()` sets `exc_info` on the record, but the formatter never called `formatException()`, so every call produced a single-line message with no traceback
- Fix appends `exc_info` and `stack_info` after the message line, matching stdlib `Formatter` behavior

## Test plan

- [ ] `uv run pytest src/tests/test_issue_1332_logger_exception.py -v` — 5 new tests, all pass
- [ ] `uv run ruff check src/` — zero violations
- [ ] `uv run pytest src/tests/ -v` — pre-existing `test_template_manager` failure only; no regressions introduced

Resolves #1332

🤖 Generated with [Claude Code](https://claude.com/claude-code)