### PR TITLE
chore: bump claude-agent-sdk to 0.1.76

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -85,7 +85,7 @@ RUN curl -fsSL https://astral.sh/uv/install.sh | bash
 
 # ---------- Layer 7: Claude Code CLI ----------
 # Bump in lockstep with claude-agent-sdk in pyproject.toml/uv.lock.
-ARG CLAUDE_CODE_VERSION=2.1.131
+ARG CLAUDE_CODE_VERSION=2.1.132
 RUN curl -fsSL https://claude.ai/install.sh | bash -s ${CLAUDE_CODE_VERSION}
 
 # ---------- Layer 8: PATH and entrypoint ----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "uvicorn>=0.24.0",
     "websockets>=12.0",
     "pydantic>=2.5.0",
-    "claude-agent-sdk==0.1.75",
+    "claude-agent-sdk>=0.1.76",
     "croniter>=6.0.0",
     "keyring>=24.3.0",
     "keyrings.cryptfile>=1.3.9",

--- a/src/claude_sdk.py
+++ b/src/claude_sdk.py
@@ -1376,7 +1376,7 @@ class ClaudeSDK:
                     message_dict["content"] = " ".join(text_parts) if text_parts else ""
 
             # Copy other common attributes from SDK message
-            for attr in ['message', 'data', 'subtype', 'error', 'usage', 'model_usage', 'model', 'duration_ms', 'total_cost_usd', 'parent_tool_use_id', 'stop_reason', 'errors', 'permission_denials', 'is_error', 'num_turns', 'duration_api_ms']:
+            for attr in ['message', 'data', 'subtype', 'error', 'usage', 'model_usage', 'model', 'duration_ms', 'total_cost_usd', 'parent_tool_use_id', 'stop_reason', 'errors', 'permission_denials', 'is_error', 'num_turns', 'duration_api_ms', 'api_error_status']:
                 if hasattr(sdk_message, attr):
                     value = getattr(sdk_message, attr)
                     # Only add serializable values

--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -26,7 +26,7 @@ USER claude
 # Install Claude Code using the official native installer
 # This downloads the correct platform binary, verifies checksum, and installs it
 # Bump in lockstep with claude-agent-sdk in pyproject.toml/uv.lock.
-ARG CLAUDE_CODE_VERSION=2.1.131
+ARG CLAUDE_CODE_VERSION=2.1.132
 RUN curl -fsSL https://claude.ai/install.sh | bash -s ${CLAUDE_CODE_VERSION}
 
 # Ensure the binary is on PATH

--- a/src/message_parser.py
+++ b/src/message_parser.py
@@ -1041,6 +1041,7 @@ class ResultMessageHandler(MessageHandler):
                 "has_permission_requests": False,
                 "has_permission_responses": False,
                 "deferred_tool_use": message_data.get("deferred_tool_use"),
+                "api_error_status": message_data.get("api_error_status"),
             }
         }
 

--- a/uv.lock
+++ b/uv.lock
@@ -171,20 +171,20 @@ wheels = [
 
 [[package]]
 name = "claude-agent-sdk"
-version = "0.1.75"
+version = "0.1.76"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "mcp" },
     { name = "sniffio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/3f/f7f5931c9df6f8185b45bed15546c6e3f6ce773db97c064c65f388e4fa27/claude_agent_sdk-0.1.75.tar.gz", hash = "sha256:ab28c69391675dcffd5c0e622b350ce5c9a811b2715a81c847477c1dfcedf361", size = 246971, upload-time = "2026-05-06T07:59:30.754Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/df/1ec1b9489c90342eb00078ab482871440baefae0707006d6cf4bf3e67e02/claude_agent_sdk-0.1.76.tar.gz", hash = "sha256:9a36f7629cc00dc1c5959b68d3bef8f8810b3616f9012df92a60144d6b0f0a84", size = 248264, upload-time = "2026-05-06T22:22:00.601Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/9e/2d5eae0f1ee7273fe60e27efbe066a74c8329cd86c25ad908953d5fc0474/claude_agent_sdk-0.1.75-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a4343a4fe1f4d2bf74aeed84ff177ad7c296c82532d4acc73a670ffaa105a0a4", size = 64001809, upload-time = "2026-05-06T07:59:33.867Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/ae/f4727ec93a457f09820b26ff87a639cf2734b461792c5e0ee8016872b542/claude_agent_sdk-0.1.75-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:bb7db09e6825db8f6bdbd51fb208870efabe66321281136ddcbac948e019a67c", size = 65849171, upload-time = "2026-05-06T07:59:38.167Z" },
-    { url = "https://files.pythonhosted.org/packages/32/c4/ede5c3231cfff481eda49c6425274c47f48e9922ebf171565472051d8c50/claude_agent_sdk-0.1.75-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:c724c5dd0986774f2c9f9fffc47991d3cca1c2342822602702b98003a985e67f", size = 77181298, upload-time = "2026-05-06T07:59:41.745Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/b0/9351431cd9984bc057ed219f615cc8d0a33348f4088658d1479896ebdc3d/claude_agent_sdk-0.1.75-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:6903ec35c8b74233574615a47535ff2f8db58c4eec2f4307f94a932baa64c517", size = 77328964, upload-time = "2026-05-06T07:59:45.327Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/cc/3a7c95d40c98995d9c8aa0193b0f1c841ab9f691c3f98feda98e2872ace9/claude_agent_sdk-0.1.75-py3-none-win_amd64.whl", hash = "sha256:bceae9ccab5903660ad940823db67e0e317ed6d6fe4ec9e3c6104c6ea828fac2", size = 78730050, upload-time = "2026-05-06T07:59:48.904Z" },
+    { url = "https://files.pythonhosted.org/packages/48/fa/f87ed968ddfdd1f99c9d5b6c690f4589c0e3f91bc50d964c331d40c9c0b5/claude_agent_sdk-0.1.76-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4c06607b60fd0704a55d61675da179aa16107f6c656c70cc296c3a845b898bc3", size = 64186601, upload-time = "2026-05-06T22:22:04.107Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/92/be2a0c3b397aa1056fa39e5457d55c3b37699adab90a855d2b5252f03171/claude_agent_sdk-0.1.76-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:bbaeb4bccfabe71b0a9041352fae06f0ea9ac1192537d845ac89bd67f9c7fa08", size = 66026957, upload-time = "2026-05-06T22:22:07.749Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d0/091d31cb46d0a7d3e4dc61b33fe831169d99aac06485eac5bfb3e4035115/claude_agent_sdk-0.1.76-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:90134c8b1e48c84fb544683b004d8acbe1ee6e91e39dd03f3937bea2f101b5dc", size = 77350162, upload-time = "2026-05-06T22:22:11.687Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/cb/680c52c9235e16f50cbb5b0427b695663d480bbefe90e5ad237835c4e27e/claude_agent_sdk-0.1.76-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:0b323ee8c5fad84f1fa1acdaa4578a0ea027d158ee5bc3f4df7fd792d269a0e0", size = 77495303, upload-time = "2026-05-06T22:22:16.147Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/4e/1e5cdb5c5c8cd330c53aabbf99e4ea23bbda4700c0d27d00200eff119d75/claude_agent_sdk-0.1.76-py3-none-win_amd64.whl", hash = "sha256:68a879d642982c4d451b4bed0d323f8c3897103393a2b8c936123f868afba6a7", size = 78913643, upload-time = "2026-05-06T22:22:20.779Z" },
 ]
 
 [[package]]
@@ -221,7 +221,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
-    { name = "claude-agent-sdk", specifier = "==0.1.75" },
+    { name = "claude-agent-sdk", specifier = ">=0.1.76" },
     { name = "croniter", specifier = ">=6.0.0" },
     { name = "fastapi", specifier = ">=0.104.0" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12.0" },


### PR DESCRIPTION
## Summary
Resolves #1339

Bumps `claude-agent-sdk` from 0.1.75 to 0.1.76 and wires through the new `api_error_status` field.

## Changes Made
- `pyproject.toml`: `claude-agent-sdk==0.1.75` → `>=0.1.76`
- `uv.lock`: resolves `claude-agent-sdk==0.1.76`
- `src/claude_sdk.py`: add `api_error_status` to the SDK attr copy list so it is propagated from `ResultMessage` into the message dict
- `src/message_parser.py`: expose `api_error_status` in `ResultMessageHandler` metadata (alongside `deferred_tool_use`)
- `src/docker/Dockerfile`, `docker/Dockerfile.dev`: bump bundled CLI `2.1.131` → `2.1.132`
- No changes needed in `src/permission_service.py`: the existing `_get_field()` helper in `pretooluse_handler.py` handles `PermissionUpdate` objects and raw dicts transparently, so the 0.1.76 deserialization fix is a no-op for our code

## Testing
- `uv run pytest src/tests/ -v`: 1461 passed, 1 pre-existing failure unrelated to this change (`test_update_accepts_all_template_fields`)
- `uv run ruff check src/`: zero violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)