### PR TITLE
fix: prevent glob expansion on $DOMAINS in proxy entrypoint for-loop

### DIFF
--- a/src/docker/proxy/entrypoint.sh
+++ b/src/docker/proxy/entrypoint.sh
@@ -15,6 +15,10 @@ cat > "$COREFILE" <<'HEADER'
 # Auto-generated from allowlist.json
 HEADER
 
+# Disable glob expansion: $DOMAINS is intentionally unquoted for word-splitting,
+# but an unquoted "*" would otherwise expand to filenames in the cwd before the
+# sentinel guard below can detect it (issue #1380).
+set -f
 for domain in $DOMAINS; do
     if [ "$domain" = "*" ]; then
         continue
@@ -32,6 +36,7 @@ ${domain} {
 }
 EOF
 done
+set +f
 
 # Catch-all: forwarding when sentinel present, NXDOMAIN otherwise.
 if echo "$DOMAINS" | grep -qx '\*'; then


### PR DESCRIPTION
## Summary
Resolves #1380

When `$DOMAINS` contains the wildcard sentinel `*`, bash performs pathname expansion against cwd (`/`) before the for-loop body runs, so the guard `if [ "$domain" = "*" ]` never sees a literal `*`. This pollutes the Corefile with one DNS zone per top-level filesystem entry (`bin`, `boot`, `dev`, `etc`, …).

## Changes Made
- `src/docker/proxy/entrypoint.sh`: wrap the affected `for domain in $DOMAINS` loop with `set -f` / `set +f` to disable glob expansion during word-splitting
- Added a brief comment explaining the intent (references issue #1380)

## Testing
- Bash-only change; no Python files modified (Ruff not applicable)
- Manual verification: build proxy image with `{"domains": ["*"]}`, inspect `/etc/coredns/Corefile` — expected: header + single `.` catch-all zone, no filesystem-path zones
- Existing `src/docker/proxy/test-proxy.sh` suite covers no-wildcard regression path

🤖 Generated with [Claude Code](https://claude.com/claude-code)