### PR TITLE
feat: extend create_schedule MCP tool to support scripted cron schedules

### DIFF
--- a/src/legion/mcp/legion_mcp_tools.py
+++ b/src/legion/mcp/legion_mcp_tools.py
@@ -281,15 +281,19 @@ class LegionMCPTools:
 
         @tool(
             "create_schedule",
-            "Create a recurring cron schedule for yourself. The system will automatically "
-            "deliver the specified prompt to you at the scheduled times. If you are terminated "
-            "when a schedule fires, the system will auto-start you."
+            "Create a recurring cron schedule for yourself. Provide exactly one of 'prompt' or 'script'."
+            "\n\nPrompt mode: The specified prompt text is delivered to you when the schedule fires."
+            "\nScript mode: A shell script is run at each tick; stdout becomes the delivered message."
+            " Silent exits (no stdout) are discarded and no message is delivered."
+            " If you are terminated when a schedule fires, the system will auto-start you."
             "\n\nParameters:"
             "\n- name: Human-readable name (e.g., 'Daily status report')"
             "\n- cron_expression: Standard 5-field cron (min hour dom mon dow). "
             "Examples: '0 8 * * 1-5' (weekdays 8am), '0 */2 * * *' (every 2 hours), "
             "'30 9 1 * *' (1st of month at 9:30am)"
-            "\n- prompt: The prompt text delivered to you when the schedule fires"
+            "\n- prompt (optional): Prompt mode — text delivered to you when the schedule fires. XOR with script."
+            "\n- script (optional): Script mode — shell command/script run at each tick. XOR with prompt."
+            "\n- script_timeout_seconds (optional, default 60): Script mode only — max seconds before script is killed."
             "\n- reset_session (optional, default false): Reset session before each execution for clean context"
             "\n- max_retries (optional, default 3): Max delivery retries on failure"
             "\n- timeout_seconds (optional, default 3600): Delivery timeout",
@@ -297,6 +301,8 @@ class LegionMCPTools:
                 "name": str,
                 "cron_expression": str,
                 "prompt": str,
+                "script": str,
+                "script_timeout_seconds": int,
                 "reset_session": bool,
                 "max_retries": int,
                 "timeout_seconds": int,
@@ -2023,12 +2029,38 @@ class LegionMCPTools:
         name = args.get("name", "").strip()
         cron_expression = args.get("cron_expression", "").strip()
         prompt = args.get("prompt", "").strip()
+        script = args.get("script", "").strip()
 
-        if not name or not cron_expression or not prompt:
+        if not name or not cron_expression:
             return {
-                "content": [{"type": "text", "text": "Error: name, cron_expression, and prompt are all required"}],
+                "content": [{"type": "text", "text": "Error: name and cron_expression are required"}],
                 "is_error": True,
             }
+
+        if prompt and script:
+            return {
+                "content": [{"type": "text", "text": "Error: Provide exactly one of 'prompt' or 'script', not both"}],
+                "is_error": True,
+            }
+        if not prompt and not script:
+            return {
+                "content": [{"type": "text", "text": "Error: Either 'prompt' or 'script' is required"}],
+                "is_error": True,
+            }
+
+        if script:
+            schedule_type = "script"
+            script_command = script
+            script_timeout_seconds = args.get("script_timeout_seconds", 60)
+            if isinstance(script_timeout_seconds, str):
+                try:
+                    script_timeout_seconds = int(script_timeout_seconds)
+                except ValueError:
+                    script_timeout_seconds = 60
+        else:
+            schedule_type = "prompt"
+            script_command = None
+            script_timeout_seconds = 60
 
         # Get minion info for legion_id and name
         session = await self.system.session_coordinator.session_manager.get_session_info(from_minion_id)
@@ -2074,6 +2106,9 @@ class LegionMCPTools:
                 reset_session=reset_session,
                 max_retries=max_retries,
                 timeout_seconds=timeout_seconds,
+                schedule_type=schedule_type,
+                script_command=script_command,
+                script_timeout_seconds=script_timeout_seconds,
             )
 
             from datetime import datetime
@@ -2083,18 +2118,28 @@ class LegionMCPTools:
                     "%Y-%m-%d %H:%M %Z"
                 )
 
+            if schedule_type == "script":
+                msg = (
+                    f"Schedule created successfully.\n\n"
+                    f"- **ID**: {schedule.schedule_id}\n"
+                    f"- **Name**: {schedule.name}\n"
+                    f"- **Type**: script\n"
+                    f"- **Cron**: {schedule.cron_expression}\n"
+                    f"- **Next run**: {next_run_str}\n"
+                    f"- **Status**: {schedule.status.value}"
+                )
+            else:
+                msg = (
+                    f"Schedule created successfully.\n\n"
+                    f"- **ID**: {schedule.schedule_id}\n"
+                    f"- **Name**: {schedule.name}\n"
+                    f"- **Cron**: {schedule.cron_expression}\n"
+                    f"- **Next run**: {next_run_str}\n"
+                    f"- **Status**: {schedule.status.value}"
+                )
+
             return {
-                "content": [{
-                    "type": "text",
-                    "text": (
-                        f"Schedule created successfully.\n\n"
-                        f"- **ID**: {schedule.schedule_id}\n"
-                        f"- **Name**: {schedule.name}\n"
-                        f"- **Cron**: {schedule.cron_expression}\n"
-                        f"- **Next run**: {next_run_str}\n"
-                        f"- **Status**: {schedule.status.value}"
-                    ),
-                }],
+                "content": [{"type": "text", "text": msg}],
                 "is_error": False,
             }
         except ValueError as e:

--- a/src/tests/test_legion_mcp_tools.py
+++ b/src/tests/test_legion_mcp_tools.py
@@ -588,3 +588,167 @@ async def test_issue_1114_queue_task_handler_passes_reset_session():
         content="reset and do",
         reset_session=True,
     )
+
+
+# ── create_schedule handler tests (Issue #1371) ──
+
+
+def _make_create_schedule_tools(create_schedule_side_effect=None, create_schedule_return=None):
+    """Build LegionMCPTools with mocked scheduler_service.create_schedule."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from src.legion.mcp.legion_mcp_tools import LegionMCPTools
+    from src.session_manager import SessionState
+
+    session_info = MagicMock()
+    session_info.project_id = "legion-abc"
+    session_info.name = "TestMinion"
+    session_info.state = SessionState.ACTIVE
+
+    session_manager = MagicMock()
+    session_manager.get_session_info = AsyncMock(return_value=session_info)
+
+    session_coordinator = MagicMock()
+    session_coordinator.session_manager = session_manager
+
+    schedule_mock = MagicMock()
+    schedule_mock.schedule_id = "sched-001"
+    schedule_mock.name = "Test Schedule"
+    schedule_mock.cron_expression = "0 * * * *"
+    schedule_mock.next_run = None
+    schedule_mock.status = MagicMock()
+    schedule_mock.status.value = "active"
+
+    scheduler_service = MagicMock()
+    if create_schedule_side_effect is not None:
+        scheduler_service.create_schedule = AsyncMock(side_effect=create_schedule_side_effect)
+    else:
+        scheduler_service.create_schedule = AsyncMock(
+            return_value=create_schedule_return or schedule_mock
+        )
+
+    mock_system = MagicMock()
+    mock_system.session_coordinator = session_coordinator
+    mock_system.scheduler_service = scheduler_service
+
+    return LegionMCPTools(mock_system), scheduler_service
+
+
+_CREATE_SCHEDULE_BASE_ARGS = {
+    "_from_minion_id": "minion-xyz",
+    "name": "Test Schedule",
+    "cron_expression": "0 * * * *",
+}
+
+
+@pytest.mark.asyncio
+async def test_issue_1371_create_schedule_script_mode_passes_through():
+    """Issue #1371: script param invokes service with schedule_type='script', script_command set."""
+    tools, svc = _make_create_schedule_tools()
+
+    result = await tools._handle_create_schedule({
+        **_CREATE_SCHEDULE_BASE_ARGS,
+        "script": "echo hello",
+    })
+
+    assert result.get("is_error") is False
+    svc.create_schedule.assert_awaited_once()
+    call_kwargs = svc.create_schedule.call_args.kwargs
+    assert call_kwargs["schedule_type"] == "script"
+    assert call_kwargs["script_command"] == "echo hello"
+    assert call_kwargs.get("prompt", "") == ""
+    assert "Type**: script" in result["content"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_issue_1371_create_schedule_rejects_both_prompt_and_script():
+    """Issue #1371: supplying both prompt and script returns descriptive error, service not called."""
+    tools, svc = _make_create_schedule_tools()
+
+    result = await tools._handle_create_schedule({
+        **_CREATE_SCHEDULE_BASE_ARGS,
+        "prompt": "do the thing",
+        "script": "echo hello",
+    })
+
+    assert result.get("is_error") is True
+    assert "exactly one" in result["content"][0]["text"].lower()
+    svc.create_schedule.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_issue_1371_create_schedule_rejects_neither_prompt_nor_script():
+    """Issue #1371: omitting both prompt and script returns descriptive error, service not called."""
+    tools, svc = _make_create_schedule_tools()
+
+    result = await tools._handle_create_schedule({**_CREATE_SCHEDULE_BASE_ARGS})
+
+    assert result.get("is_error") is True
+    assert "required" in result["content"][0]["text"].lower()
+    svc.create_schedule.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_issue_1371_create_schedule_rejects_empty_script():
+    """Issue #1371: whitespace-only script treated as missing — 'neither provided' error."""
+    tools, svc = _make_create_schedule_tools()
+
+    result = await tools._handle_create_schedule({
+        **_CREATE_SCHEDULE_BASE_ARGS,
+        "script": "   ",
+    })
+
+    assert result.get("is_error") is True
+    assert "required" in result["content"][0]["text"].lower()
+    svc.create_schedule.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_issue_1371_create_schedule_prompt_mode_unchanged():
+    """Issue #1371: prompt-only call still passes schedule_type='prompt' and script_command=None."""
+    tools, svc = _make_create_schedule_tools()
+
+    result = await tools._handle_create_schedule({
+        **_CREATE_SCHEDULE_BASE_ARGS,
+        "prompt": "summarize today",
+    })
+
+    assert result.get("is_error") is False
+    call_kwargs = svc.create_schedule.call_args.kwargs
+    assert call_kwargs["schedule_type"] == "prompt"
+    assert call_kwargs["script_command"] is None
+    assert call_kwargs["prompt"] == "summarize today"
+    assert "Type**: script" not in result["content"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_issue_1371_create_schedule_script_timeout_seconds_propagated():
+    """Issue #1371: script_timeout_seconds flows through; default=60 when omitted; string coercion works."""
+    tools, svc = _make_create_schedule_tools()
+
+    # Explicit integer value
+    await tools._handle_create_schedule({
+        **_CREATE_SCHEDULE_BASE_ARGS,
+        "script": "check.sh",
+        "script_timeout_seconds": 120,
+    })
+    assert svc.create_schedule.call_args.kwargs["script_timeout_seconds"] == 120
+
+    svc.create_schedule.reset_mock()
+
+    # String form (MCP may pass as string)
+    await tools._handle_create_schedule({
+        **_CREATE_SCHEDULE_BASE_ARGS,
+        "script": "check.sh",
+        "script_timeout_seconds": "90",
+    })
+    assert svc.create_schedule.call_args.kwargs["script_timeout_seconds"] == 90
+
+    svc.create_schedule.reset_mock()
+
+    # Omitted — default 60
+    await tools._handle_create_schedule({
+        **_CREATE_SCHEDULE_BASE_ARGS,
+        "script": "check.sh",
+    })
+    assert svc.create_schedule.call_args.kwargs["script_timeout_seconds"] == 60


### PR DESCRIPTION
## Summary
Resolves #1371

Extends the `create_schedule` MCP tool to accept a `script` parameter as an alternative to `prompt`, enabling minions to register self-filtering monitoring schedules that only deliver a message when script stdout is non-empty.

## Changes Made
- **Tool schema** (`src/legion/mcp/legion_mcp_tools.py`): Added `script` (str, optional) and `script_timeout_seconds` (int, optional, default 60) to the decorator schema. Rewrote description with distinct Prompt mode / Script mode sections explaining XOR semantics and stdout-as-message behavior.
- **Handler validation**: Replaced single `not prompt` check with XOR logic — both or neither provided returns a descriptive error; service is not called.
- **Mode dispatch**: When `script` is provided, sets `schedule_type="script"`, `script_command=script`, coerces `script_timeout_seconds` from string if needed. Prompt mode sets `schedule_type="prompt"`, `script_command=None` — unchanged behavior.
- **Service call**: Passes `schedule_type`, `script_command`, `script_timeout_seconds` to `scheduler_service.create_schedule()`.
- **Success message**: Includes `Type: script` line for scripted schedules.
- **Unit tests** (`src/tests/test_legion_mcp_tools.py`): 6 new tests covering script pass-through, both-rejected, neither-rejected, empty-script-rejected, prompt-mode-unchanged, and timeout default/coercion.

## Testing
- All 50 tests pass: `uv run pytest src/tests/test_legion_mcp_tools.py src/tests/test_scheduler_script_schedule.py -v`
- Zero ruff violations: `uv run ruff check --fix src/legion/mcp/legion_mcp_tools.py src/tests/test_legion_mcp_tools.py`
- Backward compatible: prompt-only callers unaffected (covered by `test_issue_1371_create_schedule_prompt_mode_unchanged`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)