### PR TITLE
feat: add update_schedule MCP tool for minion self-management of schedules

### DIFF
--- a/src/legion/mcp/legion_mcp_tools.py
+++ b/src/legion/mcp/legion_mcp_tools.py
@@ -371,6 +371,31 @@ class LegionMCPTools:
             args["_from_minion_id"] = session_id
             return await self._handle_cancel_schedule(args)
 
+        @tool(
+            "update_schedule",
+            "Update one or more attributes of your own schedule. You can change "
+            "the schedule's name, its prompt (for prompt-type schedules), and/or "
+            "its cron expression. You cannot change a schedule's type, the minion "
+            "it is bound to, or its session configuration via this tool. You can "
+            "only update schedules that belong to you."
+            "\n\nParameters:"
+            "\n- schedule_id: The ID of the schedule to update"
+            "\n- name (optional): New display name for the schedule"
+            "\n- prompt (optional): New prompt text. Only valid for prompt-type schedules. Must be non-empty"
+            "\n- cron_expression (optional): New cron expression (5-field standard cron). "
+            "Examples: '0 8 * * 1-5' (weekdays 8am), '*/30 * * * *' (every 30 min)",
+            {
+                "schedule_id": str,
+                "name": str,
+                "prompt": str,
+                "cron_expression": str,
+            }
+        )
+        async def update_schedule_tool(args: dict[str, Any]) -> dict[str, Any]:
+            """Update a schedule owned by the calling minion."""
+            args["_from_minion_id"] = session_id
+            return await self._handle_update_schedule(args)
+
         # ── Session lifecycle tools (Issue #680) ──
 
         @tool(
@@ -437,6 +462,7 @@ class LegionMCPTools:
                 pause_schedule_tool,
                 resume_schedule_tool,
                 cancel_schedule_tool,
+                update_schedule_tool,
                 restart_session_tool,
                 queue_task_tool,
             ]
@@ -2366,6 +2392,96 @@ class LegionMCPTools:
                 "content": [{"type": "text", "text": f"Unexpected error cancelling schedule: {e}"}],
                 "is_error": True,
             }
+
+    async def _handle_update_schedule(self, args: dict[str, Any]) -> dict[str, Any]:
+        """Handle update_schedule tool call."""
+        from_minion_id = args.get("_from_minion_id")
+        schedule_id = args.get("schedule_id", "").strip()
+
+        if not from_minion_id:
+            return {
+                "content": [{"type": "text", "text": "Error: Unable to determine minion ID"}],
+                "is_error": True,
+            }
+        if not schedule_id:
+            return {
+                "content": [{"type": "text", "text": "Error: schedule_id is required"}],
+                "is_error": True,
+            }
+
+        schedule = await self.system.scheduler_service.get_schedule(schedule_id)
+        if not schedule:
+            return {
+                "content": [{"type": "text", "text": f"Error: Schedule {schedule_id} not found"}],
+                "is_error": True,
+            }
+        if schedule.minion_id != from_minion_id:
+            return {
+                "content": [{"type": "text", "text": "Error: You can only update your own schedules"}],
+                "is_error": True,
+            }
+
+        name = args.get("name")
+        prompt = args.get("prompt")
+        cron_expression = args.get("cron_expression")
+
+        if name is None and prompt is None and cron_expression is None:
+            return {
+                "content": [{"type": "text", "text": "Error: Must provide at least one of: name, prompt, cron_expression"}],
+                "is_error": True,
+            }
+
+        if prompt is not None:
+            if schedule.schedule_type == "script":
+                return {
+                    "content": [{"type": "text", "text": "Error: This schedule is script-type; prompt cannot be set"}],
+                    "is_error": True,
+                }
+            if not prompt.strip():
+                return {
+                    "content": [{"type": "text", "text": "Error: Prompt cannot be empty"}],
+                    "is_error": True,
+                }
+
+        fields: dict = {}
+        if name is not None:
+            fields["name"] = name
+        if prompt is not None:
+            fields["prompt"] = prompt
+        if cron_expression is not None:
+            fields["cron_expression"] = cron_expression
+
+        try:
+            updated = await self.system.scheduler_service.update_schedule(schedule_id, **fields)
+        except ValueError as e:
+            return {
+                "content": [{"type": "text", "text": f"Error: {e}"}],
+                "is_error": True,
+            }
+
+        from datetime import datetime
+        next_run_str = "N/A"
+        if updated.next_run:
+            next_run_str = datetime.fromtimestamp(updated.next_run).astimezone().strftime(
+                "%Y-%m-%d %H:%M %Z"
+            )
+
+        updated_fields = ", ".join(fields.keys())
+        return {
+            "content": [{
+                "type": "text",
+                "text": (
+                    f"Schedule '{updated.name}' updated successfully.\n\n"
+                    f"Updated fields: {updated_fields}\n"
+                    f"- **ID**: {updated.schedule_id}\n"
+                    f"- **Name**: {updated.name}\n"
+                    f"- **Cron**: {updated.cron_expression}\n"
+                    f"- **Next run**: {next_run_str}\n"
+                    f"- **Status**: {updated.status.value}"
+                ),
+            }],
+            "is_error": False,
+        }
 
     # ── Session Lifecycle Handlers (Issue #680) ──
 

--- a/src/tests/test_legion_mcp_tools.py
+++ b/src/tests/test_legion_mcp_tools.py
@@ -752,3 +752,205 @@ async def test_issue_1371_create_schedule_script_timeout_seconds_propagated():
         "script": "check.sh",
     })
     assert svc.create_schedule.call_args.kwargs["script_timeout_seconds"] == 60
+
+
+# ── update_schedule handler tests (Issue #1370) ──
+
+
+_SENTINEL = object()
+
+
+def _make_update_schedule_tools(
+    schedule=None,
+    get_schedule_return=_SENTINEL,
+    update_side_effect=None,
+    update_return=None,
+):
+    """Build LegionMCPTools with mocked scheduler_service for update_schedule tests."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from src.legion.mcp.legion_mcp_tools import LegionMCPTools
+    from src.models.schedule_models import ScheduleStatus
+
+    if schedule is None:
+        schedule = MagicMock()
+        schedule.schedule_id = "sched-abc"
+        schedule.minion_id = "minion-123"
+        schedule.schedule_type = "prompt"
+        schedule.name = "My Schedule"
+        schedule.cron_expression = "0 8 * * *"
+        schedule.next_run = None
+        schedule.status = ScheduleStatus.ACTIVE
+
+    mock_svc = MagicMock()
+    resolved_get = schedule if get_schedule_return is _SENTINEL else get_schedule_return
+    mock_svc.get_schedule = AsyncMock(return_value=resolved_get)
+
+    if update_side_effect is not None:
+        mock_svc.update_schedule = AsyncMock(side_effect=update_side_effect)
+    else:
+        returned = update_return if update_return is not None else schedule
+        mock_svc.update_schedule = AsyncMock(return_value=returned)
+
+    mock_system = MagicMock()
+    mock_system.scheduler_service = mock_svc
+    return LegionMCPTools(mock_system), mock_svc, schedule
+
+
+@pytest.mark.asyncio
+async def test_issue_1370_update_schedule_handler_requires_minion_id():
+    """Issue #1370: missing from_minion_id returns is_error=True."""
+    tools, svc, _ = _make_update_schedule_tools()
+
+    result = await tools._handle_update_schedule({
+        "schedule_id": "sched-abc",
+        "name": "New Name",
+    })
+
+    assert result.get("is_error") is True
+    assert "minion id" in result["content"][0]["text"].lower()
+    svc.update_schedule.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_issue_1370_update_schedule_handler_rejects_missing_schedule():
+    """Issue #1370: get_schedule returns None → is_error=True."""
+    tools, svc, _ = _make_update_schedule_tools(get_schedule_return=None)
+
+    result = await tools._handle_update_schedule({
+        "_from_minion_id": "minion-123",
+        "schedule_id": "no-such-id",
+        "name": "New Name",
+    })
+
+    assert result.get("is_error") is True
+    assert "not found" in result["content"][0]["text"].lower()
+    svc.update_schedule.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_issue_1370_update_schedule_handler_rejects_foreign_schedule():
+    """Issue #1370: schedule.minion_id != from_minion_id → is_error=True; service not called."""
+    tools, svc, _ = _make_update_schedule_tools()
+
+    result = await tools._handle_update_schedule({
+        "_from_minion_id": "minion-OTHER",
+        "schedule_id": "sched-abc",
+        "name": "Steal Name",
+    })
+
+    assert result.get("is_error") is True
+    assert "own schedules" in result["content"][0]["text"].lower()
+    svc.update_schedule.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_issue_1370_update_schedule_handler_requires_at_least_one_field():
+    """Issue #1370: all three optional fields absent → is_error=True."""
+    tools, svc, _ = _make_update_schedule_tools()
+
+    result = await tools._handle_update_schedule({
+        "_from_minion_id": "minion-123",
+        "schedule_id": "sched-abc",
+    })
+
+    assert result.get("is_error") is True
+    assert "at least one" in result["content"][0]["text"].lower()
+    svc.update_schedule.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_issue_1370_update_schedule_handler_rejects_prompt_on_script_type():
+    """Issue #1370: prompt arg on script-type schedule → is_error=True; service not called."""
+    from unittest.mock import MagicMock
+
+    from src.models.schedule_models import ScheduleStatus
+
+    script_schedule = MagicMock()
+    script_schedule.schedule_id = "sched-script"
+    script_schedule.minion_id = "minion-123"
+    script_schedule.schedule_type = "script"
+    script_schedule.name = "Script Schedule"
+    script_schedule.cron_expression = "0 * * * *"
+    script_schedule.next_run = None
+    script_schedule.status = ScheduleStatus.ACTIVE
+
+    tools, svc, _ = _make_update_schedule_tools(schedule=script_schedule)
+
+    result = await tools._handle_update_schedule({
+        "_from_minion_id": "minion-123",
+        "schedule_id": "sched-script",
+        "prompt": "new prompt text",
+    })
+
+    assert result.get("is_error") is True
+    assert "script-type" in result["content"][0]["text"].lower()
+    svc.update_schedule.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_issue_1370_update_schedule_handler_rejects_empty_prompt():
+    """Issue #1370: prompt='   ' (whitespace-only) → is_error=True."""
+    tools, svc, _ = _make_update_schedule_tools()
+
+    result = await tools._handle_update_schedule({
+        "_from_minion_id": "minion-123",
+        "schedule_id": "sched-abc",
+        "prompt": "   ",
+    })
+
+    assert result.get("is_error") is True
+    assert "prompt cannot be empty" in result["content"][0]["text"].lower()
+    svc.update_schedule.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_issue_1370_update_schedule_handler_propagates_invalid_cron():
+    """Issue #1370: service raises ValueError('Invalid cron') → handler returns error envelope."""
+    tools, svc, _ = _make_update_schedule_tools(
+        update_side_effect=ValueError("Invalid cron expression: bad-cron")
+    )
+
+    result = await tools._handle_update_schedule({
+        "_from_minion_id": "minion-123",
+        "schedule_id": "sched-abc",
+        "cron_expression": "bad-cron",
+    })
+
+    assert result.get("is_error") is True
+    assert "Invalid cron expression" in result["content"][0]["text"]
+    svc.update_schedule.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_issue_1370_update_schedule_handler_returns_full_schedule_on_success():
+    """Issue #1370: success path returns is_error=False and updated schedule info."""
+    from unittest.mock import MagicMock
+
+    from src.models.schedule_models import ScheduleStatus
+
+    updated = MagicMock()
+    updated.schedule_id = "sched-abc"
+    updated.name = "Renamed Schedule"
+    updated.cron_expression = "0 9 * * 1-5"
+    updated.next_run = None
+    updated.status = ScheduleStatus.ACTIVE
+
+    tools, svc, _ = _make_update_schedule_tools(update_return=updated)
+
+    result = await tools._handle_update_schedule({
+        "_from_minion_id": "minion-123",
+        "schedule_id": "sched-abc",
+        "name": "Renamed Schedule",
+        "cron_expression": "0 9 * * 1-5",
+    })
+
+    assert result.get("is_error") is False
+    text = result["content"][0]["text"]
+    assert "Renamed Schedule" in text
+    assert "0 9 * * 1-5" in text
+    svc.update_schedule.assert_awaited_once_with(
+        "sched-abc",
+        name="Renamed Schedule",
+        cron_expression="0 9 * * 1-5",
+    )


### PR DESCRIPTION
## Summary
Resolves #1370

Add `update_schedule` MCP tool that lets a minion modify its own schedule's `name`, `prompt`, and/or `cron_expression`. Ownership is enforced — a minion can only update schedules where `schedule.minion_id == from_minion_id`. Structural attributes (type, binding, session config) are excluded from the schema and cannot be changed.

## Changes Made
- `src/legion/mcp/legion_mcp_tools.py`: Register `update_schedule` tool and add `_handle_update_schedule` handler
  - Validates ownership before any mutation
  - Rejects `prompt` on script-type schedules
  - Rejects empty/whitespace-only `prompt`
  - Requires at least one of `name`, `prompt`, `cron_expression`
  - Delegates to existing `SchedulerService.update_schedule()` (no service changes)
  - Wraps `ValueError` from cron validation into the error envelope
- `src/tests/test_legion_mcp_tools.py`: 8 unit tests covering all validation branches and success path

## Testing
- `uv run pytest src/tests/test_legion_mcp_tools.py -v` — 32 passed (includes 8 new #1370 tests)
- `uv run ruff check src/legion/mcp/legion_mcp_tools.py src/tests/test_legion_mcp_tools.py` — zero violations
- Full suite: 1524 passed, 1 pre-existing failure in unrelated template_manager test

🤖 Generated with [Claude Code](https://claude.com/claude-code)