### PR TITLE
chore: retire ~/.config/gh mount in favour of vault-injected GH_TOKEN + extra_env passthrough

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -19,8 +19,8 @@
 # Port forwarding example:
 #   docker run -p 8001:8001 -p 5173:5173 -v $(pwd):/workspace -w /workspace ...
 #
-# GitHub CLI auth (mount host config):
-#   -v ~/.config/gh:/home/claude/.config/gh:ro
+# GitHub CLI auth: assign a vault secret with inject_env="GH_TOKEN" to the session.
+# The proxy pipeline delivers it as GH_TOKEN inside the container (issue #1396).
 #
 # SSH agent forwarding (default — keys stay on host):
 #   -v $SSH_AUTH_SOCK:/ssh-agent -e SSH_AUTH_SOCK=/ssh-agent

--- a/frontend/src/components/configuration/SecretsTab.vue
+++ b/frontend/src/components/configuration/SecretsTab.vue
@@ -407,7 +407,7 @@
               v-model="form.inject_file_path"
               type="text"
               class="form-control form-control-sm font-monospace"
-              placeholder="/root/.config/gh/hosts.yml"
+              placeholder="/etc/credentials/example.yml"
             />
           </div>
 

--- a/src/config_resolution.py
+++ b/src/config_resolution.py
@@ -41,7 +41,7 @@ PROFILE_AREAS: dict[str, set[str]] = {
         "docker_home_directory", "docker_proxy_enabled", "docker_proxy_image",
         "docker_proxy_allowlist_domains",
         "bare_mode", "env_scrub_enabled",
-        "assigned_secrets",
+        "assigned_secrets", "extra_env",
     },
     "features": {
         "history_distillation_enabled", "auto_memory_mode", "auto_memory_directory",

--- a/src/docker/claude-docker
+++ b/src/docker/claude-docker
@@ -29,6 +29,9 @@ set -euo pipefail
 #                                   Default when set: claude-proxy:local
 #   CLAUDE_DOCKER_DELIVERY_ENVS   - JSON string mapping env var names to placeholder values;
 #                                   forwarded as -e flags to the agent container (issue #1134)
+#   CLAUDE_DOCKER_EXTRA_ENV       - JSON string mapping env var names to literal values;
+#                                   non-secret direct passthrough, no proxy substitution (issue #1396).
+#                                   Placed before DELIVERY_ENV_FLAGS so vault secrets win on conflicts.
 #   CLAUDE_DOCKER_SSH_DIR         - Host dir with SSH key/config for SOCKS5-tunnelled SSH
 #                                   (issue #1052); mounted at /run/ssh:ro, sets GIT_SSH_COMMAND
 #
@@ -328,6 +331,20 @@ if [ -n "$PROXY_IMAGE" ]; then
     PROXY_FLAGS="$PROXY_FLAGS -e GIT_SSL_CAINFO=/run/proxy-ca/ca.crt"
 fi
 
+# Issue #1396: Build extra env flags — non-secret literal env vars from session template.
+# No proxy substitution. Placed BEFORE DELIVERY_ENV_FLAGS so vault secrets win on conflicts.
+EXTRA_ENV_FLAGS=""
+if [ -n "${CLAUDE_DOCKER_EXTRA_ENV:-}" ]; then
+    while IFS=$'\t' read -r key value; do
+        [ -n "$key" ] && EXTRA_ENV_FLAGS="$EXTRA_ENV_FLAGS -e ${key}=${value}"
+    done < <(python3 -c "
+import json, sys
+d = json.loads(sys.argv[1])
+for k, v in d.items():
+    print(k + '\t' + v)
+" "$CLAUDE_DOCKER_EXTRA_ENV" 2>/dev/null || true)
+fi
+
 # Issue #1134: Build delivery env flags — env vars carrying placeholder values for
 # credential injection. The agent container receives placeholder values (not real secrets);
 # the proxy sidecar replaces placeholders with real values on matching outgoing requests.
@@ -375,6 +392,7 @@ docker run \
     $SSH_DIR_FLAGS \
     $RESOURCE_FLAGS \
     $PROXY_FLAGS \
+    $EXTRA_ENV_FLAGS \
     $DELIVERY_ENV_FLAGS \
     "$IMAGE_NAME" \
     "$@"

--- a/src/docker/claude-docker
+++ b/src/docker/claude-docker
@@ -333,10 +333,15 @@ fi
 
 # Issue #1396: Build extra env flags — non-secret literal env vars from session template.
 # No proxy substitution. Placed BEFORE DELIVERY_ENV_FLAGS so vault secrets win on conflicts.
+# Values are exported into the wrapper's environment and passed via --env KEY (no =VALUE)
+# so that word-splitting on $EXTRA_ENV_FLAGS cannot break values that contain spaces.
 EXTRA_ENV_FLAGS=""
 if [ -n "${CLAUDE_DOCKER_EXTRA_ENV:-}" ]; then
     while IFS=$'\t' read -r key value; do
-        [ -n "$key" ] && EXTRA_ENV_FLAGS="$EXTRA_ENV_FLAGS -e ${key}=${value}"
+        if [ -n "$key" ]; then
+            export "${key}=${value}"
+            EXTRA_ENV_FLAGS="$EXTRA_ENV_FLAGS --env ${key}"
+        fi
     done < <(python3 -c "
 import json, sys
 d = json.loads(sys.argv[1])

--- a/src/docker_utils.py
+++ b/src/docker_utils.py
@@ -88,6 +88,8 @@ def resolve_docker_cli_path(
     proxy_image: str | None = None,
     # Issue #1134: delivery env vars passed inline (replaces file-based approach)
     delivery_envs: dict[str, str] | None = None,
+    # Issue #1396: non-secret direct env passthrough (no proxy substitution)
+    extra_env: dict[str, str] | None = None,
     # Issue #1053: Dynamic allowlist override
     proxy_allowlist_file: str | None = None,
     # Issue #1179: Proxy-sidecar-only mounts (session_token, session_id, etc.)
@@ -112,7 +114,13 @@ def resolve_docker_cli_path(
                      the agent into its network namespace automatically.
         delivery_envs: Dict of env_var_name → placeholder string. Passed inline to
                        claude-docker via CLAUDE_DOCKER_DELIVERY_ENVS (JSON). The wrapper
-                       forwards these as -e flags to the agent container.
+                       forwards these as -e flags to the agent container. Vault secrets
+                       win over extra_env when the same key appears in both (delivery_envs
+                       is placed after EXTRA_ENV_FLAGS in the docker run argv).
+        extra_env: Dict of env_var_name → literal value. Non-secret direct passthrough;
+                   no proxy substitution. Serialised into CLAUDE_DOCKER_EXTRA_ENV (JSON).
+                   Placed before DELIVERY_ENV_FLAGS in docker run so vault secrets win
+                   on key conflicts. Do not put secrets here — use assigned_secrets.
         docker_proxy_extra_mounts: Additional volume mount specs applied exclusively to the
                                    proxy sidecar container (never the agent container).
         session_id: Session UUID; when set, emits CLAUDE_DOCKER_SESSION_ID so that
@@ -143,6 +151,9 @@ def resolve_docker_cli_path(
 
     if proxy_image:
         env_vars["CLAUDE_DOCKER_PROXY_IMAGE"] = proxy_image
+
+    if extra_env:
+        env_vars["CLAUDE_DOCKER_EXTRA_ENV"] = _json.dumps(extra_env)
 
     if delivery_envs:
         env_vars["CLAUDE_DOCKER_DELIVERY_ENVS"] = _json.dumps(delivery_envs)

--- a/src/routers/_models.py
+++ b/src/routers/_models.py
@@ -241,6 +241,8 @@ class TemplateUpdateRequest(BaseModel):
     setting_sources: list[str] | None = None
     bare_mode: bool | None = None
     env_scrub_enabled: bool | None = None
+    # Non-secret direct env passthrough (issue #1396)
+    extra_env: dict[str, str] | None = None
     # Composable profiles (issue #1062)
     profile_ids: dict[str, str] | None = None
     # Issue #1230: full config dict (preferred over flat fields above)

--- a/src/routers/templates.py
+++ b/src/routers/templates.py
@@ -93,6 +93,8 @@ def build_router(webui) -> APIRouter:
             setting_sources=request.setting_sources,
             bare_mode=request.bare_mode,
             env_scrub_enabled=request.env_scrub_enabled,
+            # Non-secret direct env passthrough (issue #1396)
+            extra_env=request.extra_env,
             profile_ids=request.profile_ids,
         )
 

--- a/src/session_config.py
+++ b/src/session_config.py
@@ -73,6 +73,12 @@ class SessionConfig(BaseModel):
     bare_mode: bool = False  # Pass --bare to skip hooks, LSP, plugin sync, skill walks
     env_scrub_enabled: bool = False  # Issue #957: Strip credentials from subprocess envs
 
+    # Non-secret direct env passthrough (issue #1396)
+    # Plain key=value pairs emitted as -e flags by claude-docker BEFORE delivery_envs,
+    # so vault secrets win on key conflicts. No proxy substitution — keep secrets
+    # in assigned_secrets / vault instead.
+    extra_env: dict[str, str] | None = None
+
     # Template linkage (issue #1059)
     template_id: str | None = None
 
@@ -93,7 +99,7 @@ CONFIG_FIELDS: set[str] = {
     "history_distillation_enabled", "auto_memory_mode", "auto_memory_directory",
     "skill_creating_enabled",
     "mcp_server_ids", "enable_claudeai_mcp_servers", "strict_mcp_config",
-    "bare_mode", "env_scrub_enabled",
+    "bare_mode", "env_scrub_enabled", "extra_env",
 }
 
 # Default values for all CONFIG_FIELDS — derived from a fresh SessionConfig instance.

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -1330,10 +1330,6 @@ class SessionCoordinator:
                     extra_mounts.append(
                         f"{NEW_GLOBAL_SKILLS_DIR}:{docker_home}/.claude/skills:ro"
                     )
-                # Issue #789: Mount host gh CLI config for GitHub auth passthrough
-                gh_config = Path.home() / ".config" / "gh"
-                if gh_config.exists():
-                    extra_mounts.append(f"{gh_config}:{docker_home}/.config/gh:ro")
                 # Issue #820: Mount session-specific /tmp dir so container /tmp is host-accessible
                 # IMPORTANT: mkdir must happen BEFORE adding to extra_mounts — Docker bind-mount
                 # fails at container start if the host source path does not already exist.
@@ -1471,6 +1467,8 @@ class SessionCoordinator:
                     ),
                     # Issue #1134: pass delivery env vars inline (no file); keep allowlist path
                     delivery_envs=delivery_envs or None,
+                    # Issue #1396: non-secret direct env passthrough
+                    extra_env=effective_config.extra_env or None,
                     proxy_allowlist_file=proxy_allowlist_file,
                     # Issue #1179: Proxy-sidecar-only mounts
                     docker_proxy_extra_mounts=proxy_extra_mounts or None,

--- a/src/template_manager.py
+++ b/src/template_manager.py
@@ -344,6 +344,8 @@ class TemplateManager:
         setting_sources: list[str] | None = None,
         bare_mode: bool | None = None,
         env_scrub_enabled: bool | None = None,
+        # Non-secret direct env passthrough (issue #1396)
+        extra_env: dict[str, str] | None = None,
         # Deprecated: template_overrides absorbed into config
         template_overrides: dict[str, Any] | None = None,
     ) -> MinionTemplate:
@@ -414,6 +416,7 @@ class TemplateManager:
             "setting_sources": setting_sources,
             "bare_mode": bare_mode,
             "env_scrub_enabled": env_scrub_enabled,
+            "extra_env": extra_env,
         }
         for field_name, value in local_vars.items():
             if value is not None and field_name in CONFIG_FIELDS:

--- a/src/tests/test_config_resolution.py
+++ b/src/tests/test_config_resolution.py
@@ -882,3 +882,44 @@ class TestIssue1170AssignedSecretsInIsolation:
         result = await resolve_effective_config(session, tm, pm)
 
         assert result.assigned_secrets == ["my-secret"]
+
+
+class TestIssue1396ExtraEnvResolution:
+    """Tests for extra_env config resolution (issue #1396)."""
+
+    @pytest.mark.asyncio
+    async def test_template_extra_env_merges_to_config(self):
+        """Template extra_env is reflected in the resolved SessionConfig."""
+        template_env = {"GIT_AUTHOR_NAME": "Alice", "GIT_AUTHOR_EMAIL": "alice@example.test"}
+        template = _make_template(extra_env=template_env)
+        session = _make_session(template_id="tmpl-001")
+        tm = _make_template_manager(template)
+
+        result = await resolve_effective_config(session, tm)
+
+        assert result.extra_env == template_env
+
+    @pytest.mark.asyncio
+    async def test_session_extra_env_overrides_template(self):
+        """Session-level extra_env overrides (not merges with) the template's value."""
+        template_env = {"GIT_AUTHOR_NAME": "Template"}
+        session_env = {"GIT_AUTHOR_NAME": "Session", "CUSTOM_VAR": "value"}
+
+        template = _make_template(extra_env=template_env)
+        session = _make_session(template_id="tmpl-001", extra_env=session_env)
+        tm = _make_template_manager(template)
+
+        result = await resolve_effective_config(session, tm)
+
+        assert result.extra_env == session_env
+
+    @pytest.mark.asyncio
+    async def test_template_missing_extra_env_defaults_none(self):
+        """Template without extra_env produces None on the resolved config."""
+        template = _make_template()  # no extra_env set
+        session = _make_session(template_id="tmpl-001")
+        tm = _make_template_manager(template)
+
+        result = await resolve_effective_config(session, tm)
+
+        assert result.extra_env is None

--- a/src/tests/test_proxy_credentials_1051.py
+++ b/src/tests/test_proxy_credentials_1051.py
@@ -146,6 +146,41 @@ def test_resolve_docker_cli_path_delivery_envs_none_omitted():
 
 
 # ---------------------------------------------------------------------------
+# 7-8. docker_utils extra_env logic (issue #1396: non-secret direct passthrough)
+# ---------------------------------------------------------------------------
+
+def test_resolve_docker_cli_path_extra_env_dict_set():
+    """extra_env dict serialises to CLAUDE_DOCKER_EXTRA_ENV as JSON string."""
+    extra = {"GIT_AUTHOR_NAME": "Alice", "GIT_AUTHOR_EMAIL": "alice@example.test"}
+    _, env = resolve_docker_cli_path(extra_env=extra)
+    assert "CLAUDE_DOCKER_EXTRA_ENV" in env
+    assert json.loads(env["CLAUDE_DOCKER_EXTRA_ENV"]) == extra
+
+
+def test_resolve_docker_cli_path_extra_env_none_omitted():
+    """extra_env=None omits CLAUDE_DOCKER_EXTRA_ENV."""
+    _, env = resolve_docker_cli_path(extra_env=None)
+    assert "CLAUDE_DOCKER_EXTRA_ENV" not in env
+
+
+def test_resolve_docker_cli_path_extra_env_empty_dict_omitted():
+    """extra_env={} (empty) omits CLAUDE_DOCKER_EXTRA_ENV."""
+    _, env = resolve_docker_cli_path(extra_env={})
+    assert "CLAUDE_DOCKER_EXTRA_ENV" not in env
+
+
+def test_resolve_docker_cli_path_extra_env_and_delivery_both_set():
+    """extra_env and delivery_envs can both be set simultaneously."""
+    extra = {"GIT_AUTHOR_NAME": "Bob"}
+    delivery = {"GH_TOKEN": "CC_SECRET_gh_abc123"}
+    _, env = resolve_docker_cli_path(extra_env=extra, delivery_envs=delivery)
+    assert "CLAUDE_DOCKER_EXTRA_ENV" in env
+    assert "CLAUDE_DOCKER_DELIVERY_ENVS" in env
+    assert json.loads(env["CLAUDE_DOCKER_EXTRA_ENV"]) == extra
+    assert json.loads(env["CLAUDE_DOCKER_DELIVERY_ENVS"]) == delivery
+
+
+# ---------------------------------------------------------------------------
 # Addon test helpers — minimal mitmproxy stubs
 # ---------------------------------------------------------------------------
 

--- a/src/tests/test_session_config.py
+++ b/src/tests/test_session_config.py
@@ -1,0 +1,41 @@
+"""
+Unit tests for SessionConfig — issue #1396 extra_env field.
+"""
+
+from src.session_config import CONFIG_FIELDS, DEFAULTS, SessionConfig
+
+
+def test_extra_env_default_none():
+    """extra_env defaults to None when not supplied."""
+    config = SessionConfig()
+    assert config.extra_env is None
+
+
+def test_extra_env_round_trip_populated():
+    """extra_env survives Pydantic validation and serialisation."""
+    data = {"GIT_AUTHOR_NAME": "Alice", "GIT_AUTHOR_EMAIL": "alice@example.test"}
+    config = SessionConfig(extra_env=data)
+    assert config.extra_env == data
+
+    dumped = config.model_dump()
+    restored = SessionConfig(**dumped)
+    assert restored.extra_env == data
+
+
+def test_extra_env_round_trip_none():
+    """extra_env=None survives serialisation."""
+    config = SessionConfig(extra_env=None)
+    dumped = config.model_dump()
+    restored = SessionConfig(**dumped)
+    assert restored.extra_env is None
+
+
+def test_extra_env_in_config_fields():
+    """extra_env must be listed in CONFIG_FIELDS so templates can declare it."""
+    assert "extra_env" in CONFIG_FIELDS
+
+
+def test_extra_env_in_defaults():
+    """extra_env must appear in DEFAULTS with value None."""
+    assert "extra_env" in DEFAULTS
+    assert DEFAULTS["extra_env"] is None

--- a/src/tests/test_session_coordinator.py
+++ b/src/tests/test_session_coordinator.py
@@ -1257,3 +1257,46 @@ class TestIssue1115SessionConfigStorage:
             )
 
             await coordinator.cleanup()
+
+
+class TestIssue1396GhMountRemoved:
+    """Regression test for issue #1396 — ~/.config/gh must not be bind-mounted."""
+
+    @pytest.mark.asyncio
+    async def test_no_gh_config_mount_in_docker_session(self, temp_coordinator):
+        """start_session() must not include any ~/.config/gh mount for Docker sessions."""
+        import uuid
+
+        coordinator = temp_coordinator
+
+        project = await coordinator.project_manager.create_project(
+            name="Test Project", working_directory="/tmp/test_gh"
+        )
+        session_id = str(uuid.uuid4())
+        await coordinator.create_session(
+            session_id=session_id,
+            project_id=project.project_id,
+            config=SessionConfig(docker_enabled=True, docker_image="claude-code:local"),
+        )
+
+        captured_mounts = []
+
+        def fake_resolve(docker_image, docker_extra_mounts, workspace, session_data_dir, docker_home_directory, **kwargs):
+            captured_mounts.extend(docker_extra_mounts or [])
+            return "/usr/bin/docker", {}
+
+        mock_sdk = AsyncMock()
+        mock_sdk.start.return_value = True
+        mock_sdk.is_running.return_value = False
+        coordinator.set_sdk_factory(Mock(return_value=mock_sdk))
+
+        with patch("src.docker_utils.resolve_docker_cli_path", fake_resolve):
+            with patch("src.skill_manager.NEW_GLOBAL_SKILLS_DIR") as mock_skills_dir:
+                mock_skills_dir.exists.return_value = False
+                await coordinator.start_session(session_id)
+
+        gh_mounts = [m for m in captured_mounts if ".config/gh" in m]
+        assert not gh_mounts, (
+            f"~/.config/gh must not be bind-mounted in Docker sessions (issue #1396). "
+            f"Found: {gh_mounts}"
+        )


### PR DESCRIPTION
## Summary

Resolves #1396

Remove the `~/.config/gh` host bind-mount from Docker sessions and replace it with vault-injected `GH_TOKEN` delivery via the existing proxy pipeline. Add a new `extra_env` non-secret passthrough field on `SessionConfig` so templates can declare plain env vars (e.g. git identity) without vault involvement.

## Changes Made

- **Remove `~/.config/gh` mount** (`session_coordinator.py`): delete the 4-line bind-mount block (issue #789). GitHub auth now arrives as `GH_TOKEN` via a vault secret with `inject_env="GH_TOKEN"`.
- **Add `SessionConfig.extra_env`** (`session_config.py`): `dict[str, str] | None = None` field; added to `CONFIG_FIELDS`, `PROFILE_AREAS["isolation"]` (`config_resolution.py`), `TemplateUpdateRequest` (`routers/_models.py`), and `TemplateManager.update_template()` (`template_manager.py`).
- **Thread through `docker_utils`** (`docker_utils.py`): new `extra_env` kwarg on `resolve_docker_cli_path()` serialised to `CLAUDE_DOCKER_EXTRA_ENV` (JSON).
- **Parse in wrapper** (`src/docker/claude-docker`): `EXTRA_ENV_FLAGS` block mirroring `DELIVERY_ENV_FLAGS`; placed **before** `$DELIVERY_ENV_FLAGS` in `docker run` argv so vault secrets win on key conflicts.
- **Dockerfile.dev comment** (`docker/Dockerfile.dev`): replace `~/.config/gh` mount example with a note to use a vault secret.
- **SecretsTab.vue placeholder** (`SecretsTab.vue`): change from `/root/.config/gh/hosts.yml` to `/etc/credentials/example.yml`.

## Testing

- 1560 tests passing, 1 pre-existing failure (`is_default` field in `TestSignatureParity` — present on `main` before this branch).
- New tests added:
  - `test_session_coordinator.py::TestIssue1396GhMountRemoved` — regression: no `.config/gh` mount in Docker sessions
  - `test_session_config.py` — `extra_env` round-trip, `CONFIG_FIELDS`/`DEFAULTS` presence
  - `test_proxy_credentials_1051.py` — `extra_env` JSON serialisation in `resolve_docker_cli_path()`
  - `test_config_resolution.py::TestIssue1396ExtraEnvResolution` — template → config merge

## Migration Notes

Users relying on `~/.config/gh` being bind-mounted into Docker sessions must migrate to a vault secret:
1. Create a vault secret with `inject_env="GH_TOKEN"` and `target_hosts=["api.github.com"]`.
2. Assign the secret to the session/template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)