### PR TITLE
fix(proxy): move header substitution + OAuth refresh to requestheaders()

### DIFF
--- a/src/docker/proxy/addon.py
+++ b/src/docker/proxy/addon.py
@@ -4,9 +4,12 @@ Proxy addon for Claude WebUI (issue #1134).
 Replaces the static credentials.json model with a REST-fetch approach:
   - load(): reads session_token + session_id from mounted files, fetches secrets
             from the WebUI resolve endpoint via httpx.
-  - request(): blocks non-allowlisted hosts; refreshes expiring OAuth2 tokens
-               (per-placeholder asyncio.Lock prevents parallel refresh);
-               injects placeholder → real-value via type-specific handler.
+  - requestheaders(): fires after client headers arrive, before upstream forwarding.
+                      Enforces allowlist, refreshes expiring OAuth2 tokens, and
+                      injects placeholder → real-value for all header/query locations.
+  - request(): body-only injection (when flow.request.content is buffered). Under
+               mitmproxy stream_large_bodies, content may be None — body injection
+               no-ops in that case (companion issue tracks streamed-body scrub).
   - response(): scrubs raw values from inbound responses (defense-in-depth,
                 all types); writes back captured tokens via session-scoped PATCH.
 
@@ -50,8 +53,8 @@ _BINARY_CONTENT_TYPES = frozenset({
 # Injection helpers — one function per secret type
 # ---------------------------------------------------------------------------
 
-def _inject_generic(flow: http.HTTPFlow, record: dict, placeholder: str) -> bool:
-    """Replace placeholder anywhere in headers, query string, and body."""
+def _inject_generic_headers(flow: http.HTTPFlow, record: dict, placeholder: str) -> bool:
+    """Replace placeholder in headers and query string (header phase only)."""
     value = record.get("value", "")
     if not value:
         return False
@@ -64,11 +67,28 @@ def _inject_generic(flow: http.HTTPFlow, record: dict, placeholder: str) -> bool
         if placeholder in v:
             flow.request.query[k] = v.replace(placeholder, value)
             modified = True
+    return modified
+
+
+def _inject_generic_body(flow: http.HTTPFlow, record: dict, placeholder: str) -> bool:
+    """Replace placeholder in request body bytes (body phase only)."""
+    value = record.get("value", "")
+    if not value:
+        return False
     if flow.request.content and placeholder.encode() in flow.request.content:
         flow.request.content = flow.request.content.replace(
             placeholder.encode(), value.encode()
         )
-        modified = True
+        return True
+    return False
+
+
+# Keep the original name as an alias so existing unit tests that import
+# _inject_generic directly continue to work without modification.
+def _inject_generic(flow: http.HTTPFlow, record: dict, placeholder: str) -> bool:
+    """Replace placeholder anywhere in headers, query string, and body."""
+    modified = _inject_generic_headers(flow, record, placeholder)
+    modified |= _inject_generic_body(flow, record, placeholder)
     return modified
 
 
@@ -101,7 +121,7 @@ def _inject_basic_auth(flow: http.HTTPFlow, record: dict, placeholder: str) -> b
     return modified
 
 
-def _inject_api_key(flow: http.HTTPFlow, record: dict, placeholder: str) -> bool:
+def _inject_api_key_headers(flow: http.HTTPFlow, record: dict, placeholder: str) -> bool:
     """Inject at the configured location (header or query_param) per InjectionSpec."""
     value = record.get("value", "")
     if not value:
@@ -125,13 +145,31 @@ def _inject_api_key(flow: http.HTTPFlow, record: dict, placeholder: str) -> bool
     return modified
 
 
-_INJECT_DISPATCH: dict = {
-    "generic": _inject_generic,
-    "api_key": _inject_api_key,
-    "bearer": _inject_bearer,
+# Keep original name as alias for tests that import _inject_api_key directly.
+_inject_api_key = _inject_api_key_headers
+
+_INJECT_HEADERS_DISPATCH: dict = {
+    "generic":    _inject_generic_headers,
+    "api_key":    _inject_api_key_headers,
+    "bearer":     _inject_bearer,
     "basic_auth": _inject_basic_auth,
-    "oauth2": _inject_bearer,   # OAuth2 access token injects same as bearer
-    "ssh": lambda _f, _r, _p: False,
+    "oauth2":     _inject_bearer,   # OAuth2 access token injects same as bearer
+    "ssh":        lambda _f, _r, _p: False,
+}
+
+_INJECT_BODY_DISPATCH: dict = {
+    "generic": _inject_generic_body,
+    # other types are header-only; absent here is intentional
+}
+
+# Legacy alias — keeps _inject_credentials shim and any external callers working.
+_INJECT_DISPATCH: dict = {
+    "generic":    _inject_generic,
+    "api_key":    _inject_api_key_headers,
+    "bearer":     _inject_bearer,
+    "basic_auth": _inject_basic_auth,
+    "oauth2":     _inject_bearer,
+    "ssh":        lambda _f, _r, _p: False,
 }
 
 
@@ -359,7 +397,13 @@ class ProxyAddon:
         except Exception as exc:
             ctx.log.error(f"[proxy] Failed to fetch secrets for session {self._session_id}: {exc}")
 
-    async def request(self, flow: http.HTTPFlow) -> None:
+    async def requestheaders(self, flow: http.HTTPFlow) -> None:
+        """Fires after client headers arrive, before upstream forwarding.
+
+        Performs allowlist enforcement, OAuth2 refresh, and all header/query
+        injection. Body injection is deferred to request() where content is
+        available (or no-ops when streaming).
+        """
         host = flow.request.pretty_host
         client_ip = (
             flow.client_conn.peername[0] if flow.client_conn.peername else "unknown"
@@ -411,7 +455,7 @@ class ProxyAddon:
                                     "error": str(exc),
                                 })
 
-            inject_fn = _INJECT_DISPATCH.get(secret_type, _inject_generic)
+            inject_fn = _INJECT_HEADERS_DISPATCH.get(secret_type, _inject_generic_headers)
             if inject_fn(flow, record, ph):
                 credential_used = record.get("name")
 
@@ -422,6 +466,19 @@ class ProxyAddon:
             )
         else:
             ctx.log.info(f"[proxy] ALLOW {client_ip} -> {host}{flow.request.path}")
+
+    async def request(self, flow: http.HTTPFlow) -> None:
+        """Body-only injection phase. Allowlist and OAuth refresh already handled in requestheaders()."""
+        if flow.metadata.get("denied"):
+            return
+        host = flow.request.pretty_host
+        for ph, record in self._records.items():
+            if not _host_matches_targets(host, record.get("target_hosts") or []):
+                continue
+            inject_fn = _INJECT_BODY_DISPATCH.get(record.get("type", "generic"))
+            if inject_fn is None:
+                continue
+            inject_fn(flow, record, ph)
 
     async def response(self, flow: http.HTTPFlow) -> None:
         if flow.metadata.get("denied"):
@@ -560,11 +617,15 @@ class ProxyAddon:
         )
 
     def _inject_credentials(self, flow: http.HTTPFlow) -> str | None:
-        """Compatibility shim for tests — dispatches to typed inject handler."""
+        """Compatibility shim for tests — dispatches through both header and body maps."""
         for ph, record in self._records.items():
             secret_type = record.get("type", "generic")
-            inject_fn = _INJECT_DISPATCH.get(secret_type, _inject_generic)
-            if inject_fn(flow, record, ph):
+            header_fn = _INJECT_HEADERS_DISPATCH.get(secret_type, _inject_generic_headers)
+            body_fn = _INJECT_BODY_DISPATCH.get(secret_type)
+            modified = header_fn(flow, record, ph)
+            if body_fn:
+                modified |= body_fn(flow, record, ph)
+            if modified:
                 return record.get("name")
         return None
 

--- a/src/tests/test_proxy_addon_1216.py
+++ b/src/tests/test_proxy_addon_1216.py
@@ -1,14 +1,14 @@
 """
-Tests for issue #1216 — enforce target_hosts scoping in ProxyAddon.request().
+Tests for issue #1216 — enforce target_hosts scoping in ProxyAddon.requestheaders().
 
-Verifies that the per-record host gate added to request() correctly:
+Verifies that the per-record host gate added to requestheaders() correctly:
 - Injects only when the request host matches target_hosts.
 - Skips injection (and OAuth refresh) for non-matching hosts.
 - Retains match-all semantics when target_hosts is empty or absent.
 - Uses subdomain-aware matching (same as _is_allowed()).
 - Handles multiple records with independent scopes simultaneously.
 
-Tests call request() directly via the mitmproxy stub fixture pattern from
+Tests call requestheaders() directly via the mitmproxy stub fixture pattern from
 test_proxy_credentials_1051.py. No live proxy or Docker is required.
 """
 
@@ -126,9 +126,12 @@ async def test_issue_1216_request_injects_when_host_matches_target():
         "target_hosts": ["api.anthropic.com"],
     }])
     flow = _flow("api.anthropic.com", {"Authorization": f"Bearer {ph}"})
-    await addon.request(flow)
+    await addon.requestheaders(flow)
     assert flow.request.headers["Authorization"] == "Bearer sk-ant-real"
     assert flow.metadata["credential_used"] == "anthropic_key"
+    # request() after requestheaders() must not re-mutate the header (no-op guard)
+    await addon.request(flow)
+    assert flow.request.headers["Authorization"] == "Bearer sk-ant-real"
 
 
 @pytest.mark.asyncio
@@ -143,7 +146,7 @@ async def test_issue_1216_request_skips_injection_when_host_does_not_match():
         "target_hosts": ["api.anthropic.com"],
     }])
     flow = _flow("api.github.com", {"Authorization": f"Bearer {ph}"})
-    await addon.request(flow)
+    await addon.requestheaders(flow)
     assert flow.request.headers["Authorization"] == f"Bearer {ph}"
     assert flow.metadata["credential_used"] is None
 
@@ -160,7 +163,7 @@ async def test_issue_1216_request_injects_when_target_hosts_empty():
         "target_hosts": [],
     }])
     flow = _flow("api.github.com", {"Authorization": f"Bearer {ph}"})
-    await addon.request(flow)
+    await addon.requestheaders(flow)
     assert flow.request.headers["Authorization"] == "Bearer real-value"
     assert flow.metadata["credential_used"] == "generic_secret"
 
@@ -189,7 +192,7 @@ async def test_issue_1216_request_injects_when_target_hosts_missing():
     f.logger = MagicMock()
 
     flow = _flow("api.github.com", {"Authorization": f"Bearer {ph}"})
-    await f.request(flow)
+    await f.requestheaders(flow)
     assert flow.request.headers["Authorization"] == "Bearer real-value"
     assert flow.metadata["credential_used"] == "old_record"
 
@@ -206,7 +209,7 @@ async def test_issue_1216_request_subdomain_match():
         "target_hosts": ["github.com"],
     }])
     flow = _flow("api.github.com", {"Authorization": f"Bearer {ph}"})
-    await addon.request(flow)
+    await addon.requestheaders(flow)
     assert flow.request.headers["Authorization"] == "Bearer ghp-real"
     assert flow.metadata["credential_used"] == "github_token"
 
@@ -223,7 +226,7 @@ async def test_issue_1216_request_subdomain_non_match_substring():
         "target_hosts": ["github.com"],
     }])
     flow = _flow("notgithub.com", {"Authorization": f"Bearer {ph}"})
-    await addon.request(flow)
+    await addon.requestheaders(flow)
     assert flow.request.headers["Authorization"] == f"Bearer {ph}"
     assert flow.metadata["credential_used"] is None
 
@@ -255,7 +258,7 @@ async def test_issue_1216_request_multiple_records_independent_scoping():
         "Authorization": f"Bearer {ph_a}",
         "X-GitHub-Token": f"Bearer {ph_b}",
     })
-    await addon.request(flow_a)
+    await addon.requestheaders(flow_a)
     assert flow_a.request.headers["Authorization"] == "Bearer sk-ant-real"
     assert flow_a.request.headers["X-GitHub-Token"] == f"Bearer {ph_b}"
     assert flow_a.metadata["credential_used"] == "anthropic_key"
@@ -265,7 +268,7 @@ async def test_issue_1216_request_multiple_records_independent_scoping():
         "Authorization": f"Bearer {ph_b}",
         "X-Anthropic-Key": f"Bearer {ph_a}",
     })
-    await addon.request(flow_b)
+    await addon.requestheaders(flow_b)
     assert flow_b.request.headers["Authorization"] == "Bearer ghp-real"
     assert flow_b.request.headers["X-Anthropic-Key"] == f"Bearer {ph_a}"
     assert flow_b.metadata["credential_used"] == "github_token"

--- a/src/tests/test_proxy_addon_1245.py
+++ b/src/tests/test_proxy_addon_1245.py
@@ -264,7 +264,7 @@ def test_1245_inject_api_key_header_location_default():
 
 @pytest.mark.asyncio
 async def test_1245_request_end_to_end_sets_credential_used():
-    """Full ProxyAddon.request() with generic secret + placeholder in Authorization.
+    """Full ProxyAddon.requestheaders() with generic secret + placeholder in Authorization.
 
     Pre-fix: _inject_generic raised AttributeError on query_string, the exception
     propagated to request(), and credential_used was never set (remained None).
@@ -282,10 +282,36 @@ async def test_1245_request_end_to_end_sets_credential_used():
         host="api.anthropic.com",
         headers={"Authorization": f"Bearer {ph}"},
     )
-    await addon.request(flow)
+    await addon.requestheaders(flow)
 
     assert flow.request.headers["Authorization"] == f"Bearer {VALUE}"
     assert flow.metadata["credential_used"] == "oauth_token"
+
+
+@pytest.mark.asyncio
+async def test_1245_request_body_substitution_via_request_hook():
+    """Body placeholder is replaced by request() (body phase) after requestheaders() sets metadata."""
+    ph = "CC_SECRET_oauth_abcd1234"
+    addon = _make_addon([{
+        "placeholder": ph,
+        "name": "oauth_token",
+        "type": "generic",
+        "value": VALUE,
+        "target_hosts": [],
+    }])
+    body = f'{{"token": "{ph}"}}'.encode()
+    flow = _flow(
+        host="api.anthropic.com",
+        headers={"Authorization": "Bearer already-replaced"},
+        content=body,
+    )
+    # Simulate requestheaders() already having run (sets metadata)
+    await addon.requestheaders(flow)
+    # request() should replace the body placeholder
+    await addon.request(flow)
+
+    assert ph.encode() not in flow.request.content
+    assert VALUE.encode() in flow.request.content
 
 
 def test_1245_inject_generic_empty_query_no_crash():

--- a/src/tests/test_proxy_addon_1399.py
+++ b/src/tests/test_proxy_addon_1399.py
@@ -1,0 +1,340 @@
+"""
+Regression tests for issue #1399 — move header substitution + OAuth refresh
+to requestheaders() so streamed requests get the substituted Authorization header.
+
+Five invariants established by the fix:
+
+1. OAuth refresh fires in requestheaders(), not request().
+2. request() does NOT retrigger OAuth refresh.
+3. Streamed-body simulation: requestheaders() injects headers; request() no-ops cleanly.
+4. Buffered-body case: both header and body placeholders are replaced across the two hooks.
+5. Denied host short-circuits in requestheaders() before any injection runs.
+"""
+
+import asyncio
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Minimal MultiDictView-compatible query stub (reused from test_1245 pattern)
+# ---------------------------------------------------------------------------
+
+class _FakeQuery:
+    def __init__(self, pairs=None):
+        self._pairs = list(pairs or [])
+
+    def items(self):
+        return list(self._pairs)
+
+    def __setitem__(self, key, value):
+        for i, (k, _) in enumerate(self._pairs):
+            if k == key:
+                self._pairs[i] = (key, value)
+                return
+        self._pairs.append((key, value))
+
+    def __getitem__(self, key):
+        for k, v in self._pairs:
+            if k == key:
+                return v
+        raise KeyError(key)
+
+    def __contains__(self, key):
+        return any(k == key for k, _ in self._pairs)
+
+
+class _FakeRequest:
+    __slots__ = (
+        "pretty_host", "path", "method", "scheme", "port",
+        "headers", "query", "url", "content",
+    )
+
+    def __init__(self, host="api.anthropic.com", headers=None, content=None):
+        self.pretty_host = host
+        self.path = "/v1/messages"
+        self.method = "POST"
+        self.scheme = "https"
+        self.port = 443
+        self.url = f"https://{host}/v1/messages"
+        self.headers = dict(headers or {})
+        self.query = _FakeQuery()
+        self.content = content
+
+
+# ---------------------------------------------------------------------------
+# mitmproxy stubs + addon loader
+# ---------------------------------------------------------------------------
+
+def _install_mitmproxy_stubs():
+    """Install minimal mitmproxy stubs if not already present, then (re)load addon.
+
+    Installs a concrete _Response class (not a MagicMock) so status_code assertions
+    work even when running after test_proxy_addon_1175.py which installs a MagicMock
+    Response. We force-set mitmproxy.http.Response so any module loaded afterward
+    gets the real stub.
+    """
+    class _Response:
+        status_code = 200
+        content = b""
+
+        @staticmethod
+        def make(status, body, headers):
+            r = _Response()
+            r.status_code = status
+            r.content = body.encode() if isinstance(body, str) else body
+            return r
+
+    class _HTTPFlow:
+        def __init__(self, host):
+            self.request = _FakeRequest(host=host)
+            self.response = None
+            self.client_conn = MagicMock()
+            self.client_conn.peername = ("127.0.0.1", 12345)
+            self.metadata = {}
+
+    if "mitmproxy" not in sys.modules:
+        mitmproxy_pkg = types.ModuleType("mitmproxy")
+        mitmproxy_http = types.ModuleType("mitmproxy.http")
+        mitmproxy_ctx = types.ModuleType("mitmproxy.ctx")
+        mitmproxy_tcp = types.ModuleType("mitmproxy.tcp")
+
+        mitmproxy_http.HTTPFlow = _HTTPFlow
+        mitmproxy_http.Response = _Response
+        mitmproxy_ctx.log = MagicMock()
+        mitmproxy_tcp.TCPFlow = MagicMock
+
+        sys.modules["mitmproxy"] = mitmproxy_pkg
+        sys.modules["mitmproxy.http"] = mitmproxy_http
+        sys.modules["mitmproxy.ctx"] = mitmproxy_ctx
+        sys.modules["mitmproxy.tcp"] = mitmproxy_tcp
+    else:
+        # mitmproxy already installed — ensure HTTPFlow and Response are our stubs
+        # (test_proxy_addon_1175.py installs Response = MagicMock(); override it).
+        sys.modules["mitmproxy.http"].HTTPFlow = _HTTPFlow
+        sys.modules["mitmproxy.http"].Response = _Response
+        if not hasattr(sys.modules["mitmproxy.ctx"], "log"):
+            sys.modules["mitmproxy.ctx"].log = MagicMock()
+
+    # Always reload the addon module so it picks up the updated stubs.
+    if "src.docker.proxy.addon" in sys.modules:
+        del sys.modules["src.docker.proxy.addon"]
+
+
+def _make_addon(records, allowed=None):
+    """Build a ProxyAddon with pre-populated _records. Returns (addon, addon_mod)."""
+    _install_mitmproxy_stubs()
+    from src.docker.proxy import addon as addon_mod  # noqa: PLC0415
+
+    f = addon_mod.ProxyAddon.__new__(addon_mod.ProxyAddon)
+    if allowed is None:
+        allowed = {"api.anthropic.com"}
+    f.allowed_domains = allowed
+    f._records = {
+        r["placeholder"]: {
+            "name": r["name"],
+            "type": r.get("type", "bearer"),
+            "value": r["value"],
+            "target_hosts": r.get("target_hosts", []),
+            "refresh": r.get("refresh", {}),
+        }
+        for r in records
+    }
+    f._refresh_locks = {ph: asyncio.Lock() for ph in f._records}
+    f._session_id = "test-1399"
+    f._session_token = "test-token"
+    f._log_file = None
+    f.logger = MagicMock()
+    return f, addon_mod
+
+
+def _flow(host="api.anthropic.com", headers=None, content=None):
+    """Build a flow WITHOUT calling _install_mitmproxy_stubs (avoids module invalidation)."""
+    flow_cls = sys.modules["mitmproxy.http"].HTTPFlow
+    flow = flow_cls(host)
+    flow.request.headers = dict(headers or {})
+    flow.request.content = content
+    return flow
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — OAuth refresh fires in requestheaders(), not request()
+# ---------------------------------------------------------------------------
+
+PH = "CC_SECRET_oauth_1399_abcd1234"
+EXPIRED_REFRESH = {
+    "token_url": "https://auth.example.com/token",
+    "expires_at": "2000-01-01T00:00:00Z",   # always in the past
+    "client_id": "client-id",
+    "refresh_token_secret_name": "refresh_tok",
+    "buffer_seconds": 60,
+}
+
+
+@pytest.mark.asyncio
+async def test_issue_1399_oauth_refresh_fires_in_requestheaders():
+    """OAuth refresh must occur in requestheaders(), before any upstream forwarding."""
+    addon, addon_mod = _make_addon([{
+        "placeholder": PH,
+        "name": "oauth_secret",
+        "type": "oauth2",
+        "value": "old-access-token",
+        "refresh": EXPIRED_REFRESH,
+    }])
+    # Inject refresh_tok partner record
+    addon._records["CC_SECRET_refresh_tok"] = {
+        "name": "refresh_tok", "type": "bearer", "value": "my-refresh-token",
+    }
+    addon._refresh_locks["CC_SECRET_refresh_tok"] = asyncio.Lock()
+
+    flow = _flow("api.anthropic.com", {"Authorization": f"Bearer {PH}"})
+
+    new_token = "new-access-token-from-refresh"
+    fake_updates = {"value": new_token}
+
+    with patch.object(addon_mod, "_do_refresh", new=AsyncMock(return_value=fake_updates)) as mock_refresh:
+        with patch.object(addon, "_patch_secret", new=AsyncMock()):
+            await addon.requestheaders(flow)
+
+    mock_refresh.assert_called_once()
+    assert flow.request.headers["Authorization"] == f"Bearer {new_token}"
+    assert flow.metadata.get("credential_used") == "oauth_secret"
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — request() does NOT retrigger OAuth refresh
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_issue_1399_request_does_not_retrigger_oauth_refresh():
+    """After requestheaders(), calling request() must not call _do_refresh again."""
+    addon, addon_mod = _make_addon([{
+        "placeholder": PH,
+        "name": "oauth_secret",
+        "type": "oauth2",
+        "value": "old-access-token",
+        "refresh": EXPIRED_REFRESH,
+    }])
+    addon._records["CC_SECRET_refresh_tok"] = {
+        "name": "refresh_tok", "type": "bearer", "value": "my-refresh-token",
+    }
+    addon._refresh_locks["CC_SECRET_refresh_tok"] = asyncio.Lock()
+
+    flow = _flow("api.anthropic.com", {"Authorization": f"Bearer {PH}"})
+
+    fake_updates = {"value": "new-access-token"}
+
+    with patch.object(addon_mod, "_do_refresh", new=AsyncMock(return_value=fake_updates)) as mock_refresh:
+        with patch.object(addon, "_patch_secret", new=AsyncMock()):
+            await addon.requestheaders(flow)
+            await addon.request(flow)
+
+    assert mock_refresh.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — Streamed-body simulation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_issue_1399_streamed_body_header_injected_request_noop():
+    """Simulates mitmproxy stream_large_bodies: content is None.
+
+    requestheaders() must inject the Authorization header.
+    request() must not raise and must not re-mutate the header.
+    """
+    ph = "CC_SECRET_bearer_1399_abcd1234"
+    addon, _ = _make_addon([{
+        "placeholder": ph,
+        "name": "anthropic_key",
+        "type": "bearer",
+        "value": "sk-ant-real",
+        "target_hosts": ["api.anthropic.com"],
+    }])
+
+    # content=None simulates streaming (mitmproxy hasn't buffered the body yet)
+    flow = _flow("api.anthropic.com", headers={"Authorization": f"Bearer {ph}"}, content=None)
+
+    await addon.requestheaders(flow)
+
+    assert flow.request.headers["Authorization"] == "Bearer sk-ant-real"
+    assert flow.metadata.get("credential_used") == "anthropic_key"
+
+    # request() should complete without error even with content=None
+    await addon.request(flow)
+
+    # Header must not have been re-mutated
+    assert flow.request.headers["Authorization"] == "Bearer sk-ant-real"
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — Buffered-body case: both header and body placeholders replaced
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_issue_1399_buffered_body_header_and_body_both_replaced():
+    """Both header and body placeholders are replaced across the two hooks."""
+    ph = "CC_SECRET_generic_1399_abcd1234"
+    value = "real-generic-value"
+    addon, _ = _make_addon([{
+        "placeholder": ph,
+        "name": "generic_secret",
+        "type": "generic",
+        "value": value,
+        "target_hosts": [],
+    }])
+
+    body = f'{{"key": "{ph}"}}'.encode()
+    flow = _flow(
+        "api.anthropic.com",
+        headers={"Authorization": f"Bearer {ph}"},
+        content=body,
+    )
+
+    await addon.requestheaders(flow)
+    # Header replaced in requestheaders()
+    assert flow.request.headers["Authorization"] == f"Bearer {value}"
+
+    await addon.request(flow)
+    # Body replaced in request()
+    assert ph.encode() not in flow.request.content
+    assert value.encode() in flow.request.content
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — Denied host short-circuits in requestheaders() before injection
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_issue_1399_denied_host_short_circuits_in_requestheaders():
+    """Non-allowlisted host must be blocked in requestheaders(); injection must not run."""
+    ph = "CC_SECRET_bearer_1399_abcd1234"
+    addon, addon_mod = _make_addon(
+        records=[{
+            "placeholder": ph,
+            "name": "anthropic_key",
+            "type": "bearer",
+            "value": "sk-ant-real",
+            "target_hosts": [],
+        }],
+        allowed={"api.anthropic.com"},   # evil.example.com is NOT in allowlist
+    )
+
+    flow = _flow("evil.example.com", headers={"Authorization": f"Bearer {ph}"})
+
+    header_dispatch_mock = {k: MagicMock(return_value=False) for k in addon_mod._INJECT_HEADERS_DISPATCH}
+
+    with patch.object(addon_mod, "_INJECT_HEADERS_DISPATCH", header_dispatch_mock):
+        await addon.requestheaders(flow)
+
+    assert flow.metadata.get("denied") is True
+    # flow.response is synthesised as a 403 by the addon
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    # No injection helpers should have been called
+    for mock_fn in header_dispatch_mock.values():
+        mock_fn.assert_not_called()
+    # Header must remain as the raw placeholder
+    assert flow.request.headers["Authorization"] == f"Bearer {ph}"


### PR DESCRIPTION
## Summary

Resolves #1399

Under mitmproxy's `stream_large_bodies` (64 MB threshold), large requests have their headers forwarded upstream **before** `request()` fires. Any header mutation or OAuth refresh done in `request()` had no effect — Anthropic received the raw `CC_SECRET_…` placeholder and returned 401.

The fix moves all header-side work to `requestheaders()`, which fires immediately after headers arrive from the client and before any upstream forwarding.

## Changes Made

**`src/docker/proxy/addon.py`**
- Add `requestheaders()` hook: enforces allowlist, runs OAuth refresh, dispatches all header/query injection via `_INJECT_HEADERS_DISPATCH`
- Slim `request()` to body-only injection via `_INJECT_BODY_DISPATCH`; no allowlist re-check, no OAuth refresh, no `credential_used` mutation
- Split `_inject_generic` → `_inject_generic_headers` (headers + query) + `_inject_generic_body` (body bytes only)
- Rename `_inject_api_key` → `_inject_api_key_headers` (both branches are header/query-side)
- Keep `_inject_generic`, `_inject_api_key`, and `_inject_credentials` as backward-compat aliases
- Use `flow.metadata["denied"]` to short-circuit `request()` (same pattern already used by `response()`)

**`src/tests/test_proxy_addon_1216.py`**
- Retarget 7 `await addon.request(flow)` calls → `await addon.requestheaders(flow)`
- Add no-op assertion verifying `request()` doesn't re-mutate headers after `requestheaders()` runs

**`src/tests/test_proxy_addon_1245.py`**
- Retarget end-to-end `credential_used` test to `requestheaders()`
- Add body-substitution end-to-end test via `request()`

**`src/tests/test_proxy_addon_1399.py`** *(new)*
- 5-case regression suite:
  1. OAuth refresh fires in `requestheaders()`
  2. `request()` does not retrigger OAuth refresh
  3. Streamed-body simulation (`content=None`): header injected, `request()` no-ops cleanly
  4. Buffered-body: both header and body placeholders replaced across the two hooks
  5. Denied host short-circuits in `requestheaders()` before any injection runs

## Testing

- 92 proxy tests pass: `uv run pytest src/tests/test_proxy_addon_*.py src/tests/test_proxy_credentials_1051.py src/tests/test_proxy_lifecycle_1050.py src/tests/test_proxy_log_parsing.py src/tests/test_socks5_addon.py -v`
- Zero ruff violations: `uv run ruff check src/`
- No frontend, schema, or API changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)