### PR TITLE
fix(sdk): clear CLAUDE_CODE_DISABLE_AUTO_MEMORY for session memory mode

### DIFF
--- a/src/claude_sdk.py
+++ b/src/claude_sdk.py
@@ -1017,7 +1017,7 @@ class ClaudeSDK:
 
         # Per-session opt-back-in: remove suppression keys when session expresses preference
         # Issues #709, #906: auto-memory
-        if self.auto_memory_mode == "claude":
+        if self.auto_memory_mode in ("claude", "session"):
             env_vars.pop("CLAUDE_CODE_DISABLE_AUTO_MEMORY", None)
         elif self.auto_memory_mode == "disabled":
             env_vars["CLAUDE_CODE_DISABLE_AUTO_MEMORY"] = "1"

--- a/src/tests/test_claude_sdk_env.py
+++ b/src/tests/test_claude_sdk_env.py
@@ -74,10 +74,12 @@ class TestResolveEnvVars:
         assert "CLAUDE_CODE_DISABLE_AUTO_MEMORY" not in env
 
     def test_auto_memory_session_mode_does_not_set_disable_var(self):
-        # Issue #1401: session mode uses built-in memory scoped to session dir; disable flag must be unset.
+        # Issue #1408: session mode must clear CLAUDE_CODE_DISABLE_AUTO_MEMORY even when global
+        # suppression (disable_auto_memory=True) has already set it. Using _suppression_off_config()
+        # was vacuous — the var was never set in the first place.
         config = SessionConfig(auto_memory_mode="session")
         sdk = _make_sdk(config=config)
-        with patch("src.config_manager.load_config", return_value=_suppression_off_config()):
+        with patch("src.config_manager.load_config", return_value=_all_suppressed_config()):
             env = sdk._resolve_env_vars()
         assert "CLAUDE_CODE_DISABLE_AUTO_MEMORY" not in env
 


### PR DESCRIPTION
## Summary
Resolves #1408

When `auto_memory_mode="session"`, the env-var resolution in `_resolve_env_vars()` only popped `CLAUDE_CODE_DISABLE_AUTO_MEMORY` for the `"claude"` branch. The global suppression default (`disable_auto_memory=True`) set the var unconditionally, and `"session"` mode never cleared it — silently disabling built-in memory despite the user opting in.

## Changes Made
- `src/claude_sdk.py`: Extend the pop to `("claude", "session")` — both modes require the disable var absent; only the memory directory differs.
- `src/tests/test_claude_sdk_env.py`: Strengthen `test_auto_memory_session_mode_does_not_set_disable_var` to patch `load_config` with `_all_suppressed_config()` instead of `_suppression_off_config()`. The old config never set the var in the first place, making the test vacuous and unable to catch this exact bug.

## Testing
- Targeted: `uv run pytest src/tests/test_claude_sdk_env.py -v` — 9/9 passed
- Full suite: `uv run pytest src/tests/ -v` — 1598 passed, 1 pre-existing unrelated failure (`test_update_accepts_all_template_fields`)
- Lint: `uv run ruff check src/claude_sdk.py src/tests/test_claude_sdk_env.py` — zero violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)