### PR TITLE
fix: treat empty prompt as no-op on script-type schedule updates

### DIFF
--- a/src/legion/mcp/legion_mcp_tools.py
+++ b/src/legion/mcp/legion_mcp_tools.py
@@ -2433,11 +2433,14 @@ class LegionMCPTools:
 
         if prompt is not None:
             if schedule.schedule_type == "script":
-                return {
-                    "content": [{"type": "text", "text": "Error: This schedule is script-type; prompt cannot be set"}],
-                    "is_error": True,
-                }
-            if not prompt.strip():
+                if prompt.strip():
+                    return {
+                        "content": [{"type": "text", "text": "Error: This schedule is script-type; prompt cannot be set"}],
+                        "is_error": True,
+                    }
+                else:
+                    prompt = None  # empty/whitespace prompt is a no-op for script-type schedules
+            elif not prompt.strip():
                 return {
                     "content": [{"type": "text", "text": "Error: Prompt cannot be empty"}],
                     "is_error": True,
@@ -2450,6 +2453,12 @@ class LegionMCPTools:
             fields["prompt"] = prompt
         if cron_expression is not None:
             fields["cron_expression"] = cron_expression
+
+        if not fields:
+            return {
+                "content": [{"type": "text", "text": "Error: Must provide at least one of: name, prompt, cron_expression"}],
+                "is_error": True,
+            }
 
         try:
             updated = await self.system.scheduler_service.update_schedule(schedule_id, **fields)

--- a/src/tests/test_legion_mcp_tools.py
+++ b/src/tests/test_legion_mcp_tools.py
@@ -954,3 +954,123 @@ async def test_issue_1370_update_schedule_handler_returns_full_schedule_on_succe
         name="Renamed Schedule",
         cron_expression="0 9 * * 1-5",
     )
+
+
+# ── update_schedule handler tests (Issue #1419) ──
+
+
+def _make_script_schedule():
+    from unittest.mock import MagicMock
+
+    from src.models.schedule_models import ScheduleStatus
+
+    schedule = MagicMock()
+    schedule.schedule_id = "sched-script"
+    schedule.minion_id = "minion-123"
+    schedule.schedule_type = "script"
+    schedule.name = "Script Schedule"
+    schedule.cron_expression = "0 * * * *"
+    schedule.next_run = None
+    schedule.status = ScheduleStatus.ACTIVE
+    return schedule
+
+
+@pytest.mark.asyncio
+async def test_issue_1419_update_schedule_handler_script_type_ignores_empty_prompt():
+    """Issue #1419: script-type + name + prompt='' + cron_expression → success; prompt not passed to service."""
+    from unittest.mock import MagicMock
+
+    from src.models.schedule_models import ScheduleStatus
+
+    script_schedule = _make_script_schedule()
+    updated = MagicMock()
+    updated.schedule_id = "sched-script"
+    updated.name = "Renamed Script"
+    updated.cron_expression = "*/5 * * * *"
+    updated.next_run = None
+    updated.status = ScheduleStatus.ACTIVE
+
+    tools, svc, _ = _make_update_schedule_tools(schedule=script_schedule, update_return=updated)
+
+    result = await tools._handle_update_schedule({
+        "_from_minion_id": "minion-123",
+        "schedule_id": "sched-script",
+        "name": "Renamed Script",
+        "prompt": "",
+        "cron_expression": "*/5 * * * *",
+    })
+
+    assert result.get("is_error") is False
+    svc.update_schedule.assert_awaited_once_with(
+        "sched-script",
+        name="Renamed Script",
+        cron_expression="*/5 * * * *",
+    )
+
+
+@pytest.mark.asyncio
+async def test_issue_1419_update_schedule_handler_script_type_ignores_whitespace_prompt():
+    """Issue #1419: script-type + name + prompt='   ' + cron_expression → success; prompt not passed to service."""
+    from unittest.mock import MagicMock
+
+    from src.models.schedule_models import ScheduleStatus
+
+    script_schedule = _make_script_schedule()
+    updated = MagicMock()
+    updated.schedule_id = "sched-script"
+    updated.name = "Renamed Script"
+    updated.cron_expression = "*/5 * * * *"
+    updated.next_run = None
+    updated.status = ScheduleStatus.ACTIVE
+
+    tools, svc, _ = _make_update_schedule_tools(schedule=script_schedule, update_return=updated)
+
+    result = await tools._handle_update_schedule({
+        "_from_minion_id": "minion-123",
+        "schedule_id": "sched-script",
+        "name": "Renamed Script",
+        "prompt": "   ",
+        "cron_expression": "*/5 * * * *",
+    })
+
+    assert result.get("is_error") is False
+    svc.update_schedule.assert_awaited_once_with(
+        "sched-script",
+        name="Renamed Script",
+        cron_expression="*/5 * * * *",
+    )
+
+
+@pytest.mark.asyncio
+async def test_issue_1419_update_schedule_handler_script_type_only_empty_prompt():
+    """Issue #1419: script-type + only prompt='' (no other fields) → is_error=True; service not called."""
+    script_schedule = _make_script_schedule()
+    tools, svc, _ = _make_update_schedule_tools(schedule=script_schedule)
+
+    result = await tools._handle_update_schedule({
+        "_from_minion_id": "minion-123",
+        "schedule_id": "sched-script",
+        "prompt": "",
+    })
+
+    assert result.get("is_error") is True
+    assert "at least one" in result["content"][0]["text"].lower()
+    svc.update_schedule.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_issue_1419_update_schedule_handler_rejects_non_empty_prompt_on_script_type():
+    """Issue #1419: script-type + non-empty prompt → is_error=True; service not called."""
+    script_schedule = _make_script_schedule()
+    tools, svc, _ = _make_update_schedule_tools(schedule=script_schedule)
+
+    result = await tools._handle_update_schedule({
+        "_from_minion_id": "minion-123",
+        "schedule_id": "sched-script",
+        "name": "Renamed Script",
+        "prompt": "do something",
+    })
+
+    assert result.get("is_error") is True
+    assert "script-type" in result["content"][0]["text"].lower()
+    svc.update_schedule.assert_not_called()


### PR DESCRIPTION
## Summary
Resolves #1419

`_handle_update_schedule` previously rejected any call that included `prompt` (even `prompt=""`) on a script-type schedule. This blocked legitimate updates to `name` and/or `cron_expression` when callers incidentally passed `prompt=""`. The fix normalizes empty/whitespace prompt to `None` (no-op) for script-type schedules while preserving all other validation behaviour.

## Changes Made
- `src/legion/mcp/legion_mcp_tools.py`: Restructure prompt validation branch in `_handle_update_schedule`:
  - Script-type + non-empty prompt → error (preserved)
  - Script-type + empty/whitespace prompt → normalize to `None` (no-op, new behaviour)
  - Prompt-type + empty prompt → error (preserved)
  - Add post-normalization guard: if all supplied fields reduce to nothing, return "must provide at least one" error
- `src/tests/test_legion_mcp_tools.py`: Add 4 new tests for issue #1419:
  - Script-type + empty prompt + other fields → success, prompt stripped from service call
  - Script-type + whitespace prompt + other fields → success, prompt stripped
  - Script-type + only `prompt=""` → "nothing to update" error
  - Script-type + non-empty prompt → error (existing contract verified)

## Testing
- All 12 `update_schedule` unit tests pass (`uv run pytest src/tests/test_legion_mcp_tools.py -v -k update_schedule`)
- Ruff linting passes with zero violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)