### PR TITLE
fix: proxy credential scrubbing bypassed for OAuth MCP, scheduled scripts, and SSE

### DIFF
--- a/src/docker/proxy/addon.py
+++ b/src/docker/proxy/addon.py
@@ -191,6 +191,13 @@ def _is_binary_response(flow: http.HTTPFlow) -> bool:
     return any(ct.startswith(bt) for bt in _BINARY_CONTENT_TYPES)
 
 
+def _is_sse_response(flow: http.HTTPFlow) -> bool:
+    if not flow.response:
+        return False
+    ct = flow.response.headers.get("content-type", "")
+    return ct.startswith("text/event-stream")
+
+
 def _scrub_response_headers(flow: http.HTTPFlow, value: str, placeholder: str) -> bool:
     if not flow.response:
         return False
@@ -319,6 +326,30 @@ def _make_chunk_filter(pairs: list[tuple[bytes, bytes]]):
             return buf[:split_at]
         carry[:] = buf
         return b""
+
+    return _filter_chunk
+
+
+def _make_unbuffered_chunk_filter(pairs: list[tuple[bytes, bytes]]):
+    """Per-chunk replacement with NO carry buffer — for SSE/streamed responses.
+
+    Cross-chunk-boundary needle detection is sacrificed for liveness;
+    per-chunk single-shot scrubbing still applies as a defense-in-depth.
+    Accepted residual risk: a secret that straddles two SSE chunk boundaries
+    will not be redacted. SSE chunks are typically full text lines, so this
+    boundary is bounded by the mitmproxy emit size, not arbitrary splits.
+    """
+    if not pairs:
+        raise ValueError("pairs must be non-empty")
+    pairs = sorted(pairs, key=lambda p: len(p[0]), reverse=True)
+
+    def _filter_chunk(chunk: bytes) -> bytes:
+        if chunk == b"":
+            return b""
+        buf = chunk
+        for needle, replacement in pairs:
+            buf = buf.replace(needle, replacement)
+        return buf
 
     return _filter_chunk
 
@@ -592,7 +623,11 @@ class ProxyAddon:
         )
         if not response_pairs:
             return
-        flow.response.stream = _make_chunk_filter(response_pairs)
+        # Issue #1425: SSE responses must not buffer carry bytes — use unbuffered filter.
+        if _is_sse_response(flow):
+            flow.response.stream = _make_unbuffered_chunk_filter(response_pairs)
+        else:
+            flow.response.stream = _make_chunk_filter(response_pairs)
 
     async def response(self, flow: http.HTTPFlow) -> None:
         if flow.metadata.get("denied"):

--- a/src/legion/scheduler_service.py
+++ b/src/legion/scheduler_service.py
@@ -885,7 +885,13 @@ class SchedulerService:
                 self._inflight_scripts_by_session.pop(target_id, None)
 
     async def _fire_script_schedule(self, schedule: "Schedule", now: float, trigger: str = "cron"):
-        """Fire a script schedule: auto-start session, run command, route outcome."""
+        """Fire a script schedule: auto-start session, run command, route outcome.
+
+        **Security:** For Docker sessions, vault secrets are passed as proxy placeholders
+        (CC_SECRET_*) so the sidecar substitutes them on outbound HTTP. For host sessions
+        (docker_enabled=False), the proxy is unavailable; vault secrets are resolved to
+        plaintext and visible via process listing. Use Docker sessions for sensitive scripts.
+        """
         target_id = schedule.minion_id or schedule.ephemeral_agent_id
         started_clock = time.monotonic()
 
@@ -943,19 +949,35 @@ class SchedulerService:
                         f"Container did not appear after session start for {target_id}"
                     )
 
-                # Build env dict: extra_env first, then vault secrets (secrets win on conflict)
+                # Build env dict: extra_env first, then vault secrets as placeholders (secrets win)
                 script_env: dict[str, str] = {}
                 if effective_config.extra_env:
                     script_env.update(effective_config.extra_env)
+                # Issue #1425: invert placeholder→name map to get name→placeholder.
+                placeholders_by_name = {
+                    name: ph for ph, name in (session_info.secret_placeholders or {}).items()
+                }
                 if effective_config.assigned_secrets:
                     resolved = await sc.credential_vault.resolve_secrets_for_assignment(
                         effective_config.assigned_secrets
                     )
+                    missing: list[str] = []
                     for secret in resolved:
                         inject_env = secret.get("inject_env")
-                        value = secret.get("value")
-                        if inject_env and value is not None:
-                            script_env[inject_env] = value
+                        name = secret.get("name")
+                        if not inject_env:
+                            continue
+                        placeholder = placeholders_by_name.get(name)
+                        if placeholder is None:
+                            missing.append(name)
+                            continue
+                        script_env[inject_env] = placeholder
+                    if missing:
+                        raise RuntimeError(
+                            f"Scheduled script for session {target_id}: secrets {missing} "
+                            "are assigned but no proxy placeholder exists. Restart the session "
+                            "to regenerate placeholders, or remove the assignment."
+                        )
                     legion_logger.debug(
                         f"Script env for {target_id}: {len(script_env)} vars "
                         f"(keys: {sorted(script_env)})"

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -396,59 +396,68 @@ class SessionCoordinator:
         import time as _time
 
         config = mcp_cfg.to_sdk_config()
+        # Issue #1425: detect ${secret:...} placeholder in Authorization header before OAuth injection.
+        orig_headers = config.get("headers") or {}
+        orig_auth = orig_headers.get("Authorization", "")
+        auth_has_placeholder = bool(_SECRET_REF_RE.search(orig_auth))
         if mcp_cfg.oauth_enabled and mcp_cfg.type in (McpServerType.SSE, McpServerType.HTTP):
-            try:
-                token = await self.oauth_manager.get_stored_token(mcp_cfg.id)
-                if token:
-                    store = self.oauth_manager.get_token_store(mcp_cfg.id)
-                    expiry = await store.get_token_expiry()
-                    now = _time.time()
-
-                    # Issue #976: Attempt refresh if token is expired or expiring soon
-                    if expiry is not None and expiry < (now + OAuthRefreshManager.REFRESH_BUFFER_SECONDS):
-                        seconds_until_expiry = expiry - now
-                        if seconds_until_expiry < 0:
-                            logger.warning(
-                                "OAuth token for MCP server %s expired %.0f s ago — attempting refresh.",
-                                mcp_cfg.id,
-                                -seconds_until_expiry,
-                            )
-                        else:
-                            logger.info(
-                                "OAuth token for MCP server %s expires in %.0f s — refreshing proactively.",
-                                mcp_cfg.id,
-                                seconds_until_expiry,
-                            )
-                        new_token = await self.oauth_refresh_manager.refresh_token(mcp_cfg.id)
-                        if new_token:
-                            token = new_token
-                        else:
-                            logger.warning(
-                                "OAuth token refresh failed for MCP server %s. "
-                                "Injecting best available token — re-authenticate via the UI if calls fail.",
-                                mcp_cfg.id,
-                            )
-
-                    headers = dict(config.get("headers") or {})
-                    headers["Authorization"] = f"Bearer {token.access_token}"
-                    config["headers"] = headers
-                    coord_logger.debug(
-                        "[MCP config] server=%s oauth=True token=%s expiry=%s config=%s",
-                        mcp_cfg.id,
-                        token.access_token,
-                        expiry,
-                        config,
-                    )
-                else:
-                    coord_logger.debug(
-                        "[MCP config] server=%s oauth=True token=None (not authenticated) config=%s",
-                        mcp_cfg.id,
-                        config,
-                    )
-            except Exception as exc:
-                logger.warning(
-                    "Failed to inject OAuth token for MCP server %s: %s", mcp_cfg.id, exc
+            if auth_has_placeholder:
+                coord_logger.info(
+                    "[MCP config] server=%s oauth_enabled=True but Authorization header "
+                    "contains ${secret:...} — preserving placeholder, proxy will inject from vault.",
+                    mcp_cfg.id,
                 )
+            else:
+                try:
+                    token = await self.oauth_manager.get_stored_token(mcp_cfg.id)
+                    if token:
+                        store = self.oauth_manager.get_token_store(mcp_cfg.id)
+                        expiry = await store.get_token_expiry()
+                        now = _time.time()
+
+                        # Issue #976: Attempt refresh if token is expired or expiring soon
+                        if expiry is not None and expiry < (now + OAuthRefreshManager.REFRESH_BUFFER_SECONDS):
+                            seconds_until_expiry = expiry - now
+                            if seconds_until_expiry < 0:
+                                logger.warning(
+                                    "OAuth token for MCP server %s expired %.0f s ago — attempting refresh.",
+                                    mcp_cfg.id,
+                                    -seconds_until_expiry,
+                                )
+                            else:
+                                logger.info(
+                                    "OAuth token for MCP server %s expires in %.0f s — refreshing proactively.",
+                                    mcp_cfg.id,
+                                    seconds_until_expiry,
+                                )
+                            new_token = await self.oauth_refresh_manager.refresh_token(mcp_cfg.id)
+                            if new_token:
+                                token = new_token
+                            else:
+                                logger.warning(
+                                    "OAuth token refresh failed for MCP server %s. "
+                                    "Injecting best available token — re-authenticate via the UI if calls fail.",
+                                    mcp_cfg.id,
+                                )
+
+                        headers = dict(config.get("headers") or {})
+                        headers["Authorization"] = f"Bearer {token.access_token}"
+                        config["headers"] = headers
+                        coord_logger.debug(
+                            "[MCP config] server=%s oauth=True token_present=True expiry=%s",
+                            mcp_cfg.id,
+                            int(expiry) if expiry is not None else None,
+                        )
+                    else:
+                        coord_logger.debug(
+                            "[MCP config] server=%s oauth=True token=None (not authenticated) config=%s",
+                            mcp_cfg.id,
+                            config,
+                        )
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to inject OAuth token for MCP server %s: %s", mcp_cfg.id, exc
+                    )
         else:
             coord_logger.debug(
                 "[MCP config] server=%s oauth=False config=%s", mcp_cfg.id, config

--- a/src/tests/test_proxy_addon_1400.py
+++ b/src/tests/test_proxy_addon_1400.py
@@ -553,3 +553,150 @@ class TestCaptureBackAfterStreamedResponse:
         # Token should be captured and PATCHed
         assert addon._records[ph]["value"] == new_value
         mock_patch.assert_called_once_with("oauth_tok", {"value": new_value})
+
+
+# ---------------------------------------------------------------------------
+# Issue #1425 — Problem C: SSE connection timeout (5 scenarios)
+# ---------------------------------------------------------------------------
+
+
+class TestIssue1425SSEUnbufferedFilter:
+    """Tests for fix #1425 Problem C: _is_sse_response + _make_unbuffered_chunk_filter."""
+
+    def setup_method(self):
+        _install_mitmproxy_stubs()
+
+    def test_issue_1425_c1_sse_chunks_forwarded_immediately_no_holdback(self):
+        """C1: SSE response with 3 chunks — each forwarded immediately; secret within chunk redacted."""
+        from src.docker.proxy.addon import _make_unbuffered_chunk_filter
+
+        secret = b"CC_SECRET_tok_aabbccdd"
+        replacement = b"real-token-xyz"
+        f = _make_unbuffered_chunk_filter([(replacement, secret)])
+
+        chunk1 = b"data: hello world\n\n"
+        chunk2 = b"data: real-token-xyz is here\n\n"
+        chunk3 = b"data: done\n\n"
+
+        out1 = f(chunk1)
+        out2 = f(chunk2)
+        out3 = f(chunk3)
+        eos = f(b"")
+
+        # Each chunk forwarded immediately (no carry buffer holdback)
+        assert out1 == chunk1
+        # Secret within chunk is scrubbed
+        assert replacement not in out2
+        assert secret in out2
+        assert out3 == chunk3
+        assert eos == b""
+
+    def test_issue_1425_c2_cross_chunk_boundary_not_redacted(self):
+        """C2: SSE with needle split across two chunks → not redacted (documented residual risk)."""
+        from src.docker.proxy.addon import _make_unbuffered_chunk_filter
+
+        needle = b"real-token-xyz"
+        replacement = b"CC_SECRET_tok_11223344"
+        f = _make_unbuffered_chunk_filter([(needle, replacement)])
+
+        # Split needle across two chunks
+        half = len(needle) // 2
+        chunk1 = b"data: prefix-" + needle[:half]
+        chunk2 = needle[half:] + b"-suffix\n\n"
+
+        out1 = f(chunk1)
+        out2 = f(chunk2)
+
+        # Needle straddles boundary — accepted residual risk.
+        combined = out1 + out2
+        # The full needle IS present when the two chunks are concatenated (not redacted).
+        assert needle in combined
+        # The replacement CC_SECRET_* is NOT present (scrubbing did not fire cross-boundary).
+        assert replacement not in combined
+
+    def test_issue_1425_c3_non_sse_response_uses_carry_buffer(self):
+        """C3: application/json response → buffered _make_chunk_filter installed (regression guard)."""
+        from src.docker.proxy.addon import _make_chunk_filter, _make_unbuffered_chunk_filter
+
+        ph = PH
+        value = VALUE
+        records = [{
+            "placeholder": ph,
+            "name": "test_tok",
+            "type": "generic",
+            "value": value,
+            "target_hosts": [],
+        }]
+        addon = _make_addon(records)
+
+        f = _flow(
+            host="api.anthropic.com",
+            response_headers={"content-type": "application/json"},
+            response_content=b"",
+        )
+
+        addon.responseheaders(f)
+
+        # stream must be a function (the chunk filter)
+        assert callable(f.response.stream)
+        # Verify it IS the carry-buffer variant by checking that it holds back bytes:
+        # Send a chunk exactly equal to the needle — carry-buffer filter returns b"" (held back).
+        needle_bytes = value.encode()
+        f.response.stream(needle_bytes)
+        # Carry buffer filter: short chunks are held; unbuffered filter would return them immediately.
+        # The carry-buffer filter returns empty for a chunk that fits entirely in the overlap window.
+        # We can't inspect internals, but we can check _make_chunk_filter separately.
+        buffered = _make_chunk_filter([(needle_bytes, b"REPLACED")])
+        unbuffered = _make_unbuffered_chunk_filter([(needle_bytes, b"REPLACED")])
+        buf_result = buffered(needle_bytes)
+        ub_result = unbuffered(needle_bytes)
+        # Carry-buffer: short needle-sized chunk held back (returns b"" or partial)
+        assert len(buf_result) < len(needle_bytes)
+        # Unbuffered: passes through immediately (with scrubbing)
+        assert ub_result == b"REPLACED"
+
+    def test_issue_1425_c4_sse_with_no_records_no_filter_installed(self):
+        """C4: SSE response but no records targeting this host → responseheaders returns early,
+        no filter installed (existing short-circuit unchanged)."""
+        addon = _make_addon([])  # no records
+
+        f = _flow(
+            host="api.anthropic.com",
+            response_headers={"content-type": "text/event-stream"},
+            response_content=b"",
+        )
+
+        addon.responseheaders(f)
+
+        assert f.response.stream is None
+
+    def test_issue_1425_c5_sse_responseheaders_installs_unbuffered_filter(self):
+        """C5: SSE response with matching records → responseheaders installs unbuffered filter;
+        chunks pass through immediately without holdback."""
+        ph = PH
+        value = VALUE
+        records = [{
+            "placeholder": ph,
+            "name": "sse_tok",
+            "type": "generic",
+            "value": value,
+            "target_hosts": [],
+        }]
+        addon = _make_addon(records)
+
+        f = _flow(
+            host="api.anthropic.com",
+            response_headers={"content-type": "text/event-stream"},
+            response_content=b"",
+        )
+
+        addon.responseheaders(f)
+
+        assert callable(f.response.stream), "SSE filter must be installed"
+
+        # The installed filter must NOT hold back a chunk smaller than the needle length.
+        # Feed a small SSE heartbeat that does NOT contain the needle.
+        heartbeat = b": heartbeat\n\n"
+        result = f.response.stream(heartbeat)
+        # Unbuffered: chunk passes through immediately (no carry buffer holdback).
+        assert result == heartbeat

--- a/src/tests/test_scheduler_script_schedule.py
+++ b/src/tests/test_scheduler_script_schedule.py
@@ -32,6 +32,7 @@ def _make_session_info(
     is_processing: bool = False,
     docker_enabled: bool = False,
     working_directory: str = "/work",
+    secret_placeholders: dict | None = None,
 ):
     info = MagicMock()
     info.session_id = session_id
@@ -41,6 +42,8 @@ def _make_session_info(
     info.config = {"docker_enabled": docker_enabled}
     info.working_directory = working_directory
     info.template_id = None  # no template by default; prevents template lookup in resolve_effective_config
+    # Issue #1425: explicit dict so placeholder lookup doesn't see a MagicMock.
+    info.secret_placeholders = secret_placeholders if secret_placeholders is not None else {}
     return info
 
 
@@ -880,8 +883,13 @@ async def test_non_containerized_session_runs_on_host(tmp_session_dir):
 
 @pytest.mark.asyncio
 async def test_secrets_injected_into_docker_exec_env(tmp_session_dir):
-    """Vault secrets are resolved and passed as env to run_command_in_container."""
-    session_info = _make_session_info(docker_enabled=True)
+    """Vault secrets are passed as CC_SECRET_* placeholders to run_command_in_container (#1425 B1)."""
+    # Placeholders are stored as placeholder→name in session_info.secret_placeholders.
+    secret_placeholders = {
+        "CC_SECRET_my_token_aabb0011": "my_token",
+        "CC_SECRET_other_key_ccdd0022": "other_key",
+    }
+    session_info = _make_session_info(docker_enabled=True, secret_placeholders=secret_placeholders)
     vault_secrets = [
         {"name": "my_token", "inject_env": "MY_TOKEN", "value": "secret_abc"},
         {"name": "other_key", "inject_env": "OTHER_KEY", "value": "val_xyz"},
@@ -913,8 +921,11 @@ async def test_secrets_injected_into_docker_exec_env(tmp_session_dir):
     mock_exec.assert_awaited_once()
     passed_env = mock_exec.call_args.kwargs.get("env")
     assert passed_env is not None
-    assert passed_env["MY_TOKEN"] == "secret_abc"
-    assert passed_env["OTHER_KEY"] == "val_xyz"
+    # Issue #1425: placeholders, not plaintext values, must be passed.
+    assert passed_env["MY_TOKEN"] == "CC_SECRET_my_token_aabb0011"
+    assert passed_env["OTHER_KEY"] == "CC_SECRET_other_key_ccdd0022"
+    assert "secret_abc" not in str(passed_env)
+    assert "val_xyz" not in str(passed_env)
 
 
 # ---------------------------------------------------------------------------
@@ -924,9 +935,13 @@ async def test_secrets_injected_into_docker_exec_env(tmp_session_dir):
 
 @pytest.mark.asyncio
 async def test_post_rotation_vault_value_reflected_at_fire_time(tmp_session_dir):
-    """Each fire reads the vault fresh; post-rotation values are picked up."""
-    session_info = _make_session_info(docker_enabled=True)
-    # Vault returns current (rotated) value
+    """Each fire reads the vault fresh; env receives the placeholder (not the rotated plaintext).
+
+    The placeholder itself is stable across rotations; the vault replaces the value behind it.
+    Vault is still called fresh each fire so metadata is current (#1425 B1 / regression guard).
+    """
+    secret_placeholders = {"CC_SECRET_api_key_eeff0033": "api_key"}
+    session_info = _make_session_info(docker_enabled=True, secret_placeholders=secret_placeholders)
     vault_secrets = [{"name": "api_key", "inject_env": "API_KEY", "value": "rotated_value_999"}]
     system = _make_system_with_vault(
         session_info=session_info,
@@ -951,7 +966,9 @@ async def test_post_rotation_vault_value_reflected_at_fire_time(tmp_session_dir)
 
     passed_env = mock_exec.call_args.kwargs.get("env")
     assert passed_env is not None
-    assert passed_env["API_KEY"] == "rotated_value_999"
+    # Issue #1425: placeholder, not plaintext rotated value.
+    assert passed_env["API_KEY"] == "CC_SECRET_api_key_eeff0033"
+    assert "rotated_value_999" not in str(passed_env)
     system.session_coordinator.credential_vault.resolve_secrets_for_assignment.assert_awaited_once()
 
 
@@ -962,10 +979,11 @@ async def test_post_rotation_vault_value_reflected_at_fire_time(tmp_session_dir)
 
 @pytest.mark.asyncio
 async def test_no_secret_values_appear_in_logs(tmp_session_dir, caplog):
-    """Plaintext secret values must never appear in log output."""
+    """Plaintext secret values must never appear in log output (#1425: now using placeholders)."""
     import logging
 
-    session_info = _make_session_info(docker_enabled=True)
+    secret_placeholders = {"CC_SECRET_tok_ff001122": "tok"}
+    session_info = _make_session_info(docker_enabled=True, secret_placeholders=secret_placeholders)
     plaintext = "SUPERSECRET_PLAINTEXT_12345"
     vault_secrets = [{"name": "tok", "inject_env": "TOKEN", "value": plaintext}]
     system = _make_system_with_vault(
@@ -1062,3 +1080,173 @@ async def test_container_exited_surfaces_error_no_host_fallback(tmp_session_dir)
     assert "exited" in execution.error_message.lower()
     mock_exec.assert_not_called()
     mock_host.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Issue #1425 — Problem B: scheduler script credential bypass (5 scenarios)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_issue_1425_b1_docker_env_uses_placeholder_not_plaintext(tmp_session_dir):
+    """B1: docker schedule fires with vault secret → run_command_in_container receives CC_SECRET_*,
+    NOT the plaintext value."""
+    secret_placeholders = {"CC_SECRET_vault_tok_11223344": "vault_tok"}
+    session_info = _make_session_info(docker_enabled=True, secret_placeholders=secret_placeholders)
+    vault_secrets = [{"name": "vault_tok", "inject_env": "VAULT_TOKEN", "value": "plaintext-real-value"}]
+    system = _make_system_with_vault(
+        session_info=session_info,
+        data_dir=tmp_session_dir,
+        vault_resolved=vault_secrets,
+    )
+    svc = SchedulerService(system)
+    svc._persist_schedules = AsyncMock()
+    svc._append_execution = AsyncMock()
+    svc._broadcast_execution_event = AsyncMock()
+    svc._broadcast_schedule_event = AsyncMock()
+
+    schedule = _make_schedule()
+    effective = _make_effective_config(docker_enabled=True, assigned_secrets=["vault_tok"])
+
+    with (
+        patch("src.legion.scheduler_service.resolve_effective_config", new=AsyncMock(return_value=effective)),
+        patch("src.legion.scheduler_service.find_session_container", new=AsyncMock(return_value="ctr-b1")),
+        patch("src.legion.scheduler_service.run_command_in_container", new=AsyncMock(return_value=(0, "ok\n", "", False))) as mock_exec,
+    ):
+        await svc._fire_script_schedule(schedule, 1000.0)
+
+    passed_env = mock_exec.call_args.kwargs.get("env")
+    assert passed_env["VAULT_TOKEN"] == "CC_SECRET_vault_tok_11223344"
+    assert "plaintext-real-value" not in str(passed_env)
+
+
+@pytest.mark.asyncio
+async def test_issue_1425_b2_host_schedule_uses_plaintext(tmp_session_dir):
+    """B2: host-only schedule (docker_enabled=False) → run_command_on_host does NOT receive env
+    (proxy unavailable; documented limitation — host path uses resolved values at OS level)."""
+    session_info = _make_session_info(docker_enabled=False)
+    system = _make_system_with_vault(session_info=session_info, data_dir=tmp_session_dir)
+    svc = SchedulerService(system)
+    svc._persist_schedules = AsyncMock()
+    svc._append_execution = AsyncMock()
+    svc._broadcast_execution_event = AsyncMock()
+    svc._broadcast_schedule_event = AsyncMock()
+
+    schedule = _make_schedule()
+    effective = _make_effective_config(docker_enabled=False)
+
+    with (
+        patch("src.legion.scheduler_service.resolve_effective_config", new=AsyncMock(return_value=effective)),
+        patch("src.legion.scheduler_service.run_command_on_host", new=AsyncMock(return_value=(0, "host-out\n", "", False))) as mock_host,
+        patch("src.legion.scheduler_service.run_command_in_container") as mock_exec,
+    ):
+        await svc._fire_script_schedule(schedule, 1000.0)
+
+    mock_host.assert_awaited_once()
+    mock_exec.assert_not_called()
+    assert schedule.last_status == "delivered"
+
+
+@pytest.mark.asyncio
+async def test_issue_1425_b3_missing_placeholder_raises_runtime_error(tmp_session_dir):
+    """B3: docker schedule with assigned_secrets whose placeholder is absent from
+    session_info.secret_placeholders → raises RuntimeError, docker exec not invoked."""
+    # No placeholder registered for "missing_secret"
+    session_info = _make_session_info(docker_enabled=True, secret_placeholders={})
+    vault_secrets = [{"name": "missing_secret", "inject_env": "MISSING", "value": "plaintext"}]
+    system = _make_system_with_vault(
+        session_info=session_info,
+        data_dir=tmp_session_dir,
+        vault_resolved=vault_secrets,
+    )
+    svc = SchedulerService(system)
+    svc._persist_schedules = AsyncMock()
+    svc._append_execution = AsyncMock()
+    svc._broadcast_execution_event = AsyncMock()
+    svc._broadcast_schedule_event = AsyncMock()
+
+    schedule = _make_schedule()
+    effective = _make_effective_config(docker_enabled=True, assigned_secrets=["missing_secret"])
+
+    with (
+        patch("src.legion.scheduler_service.resolve_effective_config", new=AsyncMock(return_value=effective)),
+        patch("src.legion.scheduler_service.find_session_container", new=AsyncMock(return_value="ctr-b3")),
+        patch("src.legion.scheduler_service.run_command_in_container") as mock_exec,
+    ):
+        await svc._fire_script_schedule(schedule, 1000.0)
+
+    assert schedule.last_status == "error"
+    mock_exec.assert_not_called()
+    execution = svc._append_execution.call_args.args[1]
+    assert "missing_secret" in (execution.error_message or "")
+
+
+@pytest.mark.asyncio
+async def test_issue_1425_b4_extra_env_merges_correctly_with_placeholder(tmp_session_dir):
+    """B4: extra_env values merge with placeholder-replaced secrets; secret wins on key collision."""
+    secret_placeholders = {"CC_SECRET_my_key_aabbccdd": "my_key"}
+    session_info = _make_session_info(docker_enabled=True, secret_placeholders=secret_placeholders)
+    vault_secrets = [{"name": "my_key", "inject_env": "SHARED_KEY", "value": "plaintext-val"}]
+    system = _make_system_with_vault(
+        session_info=session_info,
+        data_dir=tmp_session_dir,
+        vault_resolved=vault_secrets,
+    )
+    svc = SchedulerService(system)
+    svc._persist_schedules = AsyncMock()
+    svc._append_execution = AsyncMock()
+    svc._broadcast_execution_event = AsyncMock()
+    svc._broadcast_schedule_event = AsyncMock()
+
+    schedule = _make_schedule()
+    # extra_env has SHARED_KEY set; secret should win (overwrite it with placeholder)
+    effective = _make_effective_config(
+        docker_enabled=True,
+        assigned_secrets=["my_key"],
+        extra_env={"SHARED_KEY": "extra-env-value", "EXTRA_ONLY": "only-from-extra"},
+    )
+
+    with (
+        patch("src.legion.scheduler_service.resolve_effective_config", new=AsyncMock(return_value=effective)),
+        patch("src.legion.scheduler_service.find_session_container", new=AsyncMock(return_value="ctr-b4")),
+        patch("src.legion.scheduler_service.run_command_in_container", new=AsyncMock(return_value=(0, "ok\n", "", False))) as mock_exec,
+    ):
+        await svc._fire_script_schedule(schedule, 1000.0)
+
+    passed_env = mock_exec.call_args.kwargs.get("env")
+    # Secret placeholder wins over extra_env on collision
+    assert passed_env["SHARED_KEY"] == "CC_SECRET_my_key_aabbccdd"
+    # Non-conflicting extra_env key is preserved
+    assert passed_env["EXTRA_ONLY"] == "only-from-extra"
+    assert "plaintext-val" not in str(passed_env)
+
+
+@pytest.mark.asyncio
+async def test_issue_1425_b5_no_assigned_secrets_no_placeholder_lookup(tmp_session_dir):
+    """B5: docker schedule with no assigned_secrets → placeholder lookup skipped, env is empty
+    or only extra_env, no RuntimeError raised."""
+    session_info = _make_session_info(docker_enabled=True, secret_placeholders={})
+    system = _make_system_with_vault(
+        session_info=session_info,
+        data_dir=tmp_session_dir,
+        vault_resolved=[],
+    )
+    svc = SchedulerService(system)
+    svc._persist_schedules = AsyncMock()
+    svc._append_execution = AsyncMock()
+    svc._broadcast_execution_event = AsyncMock()
+    svc._broadcast_schedule_event = AsyncMock()
+
+    schedule = _make_schedule()
+    effective = _make_effective_config(docker_enabled=True, assigned_secrets=None)
+
+    with (
+        patch("src.legion.scheduler_service.resolve_effective_config", new=AsyncMock(return_value=effective)),
+        patch("src.legion.scheduler_service.find_session_container", new=AsyncMock(return_value="ctr-b5")),
+        patch("src.legion.scheduler_service.run_command_in_container", new=AsyncMock(return_value=(0, "fine\n", "", False))) as mock_exec,
+    ):
+        await svc._fire_script_schedule(schedule, 1000.0)
+
+    mock_exec.assert_awaited_once()
+    assert schedule.last_status == "delivered"
+    system.session_coordinator.credential_vault.resolve_secrets_for_assignment.assert_not_awaited()

--- a/src/tests/test_session_coordinator.py
+++ b/src/tests/test_session_coordinator.py
@@ -801,7 +801,12 @@ class TestIssue1375SecretRefs:
 
     @pytest.mark.asyncio
     async def test_issue_1375_oauth_and_secret_ref_interaction(self, temp_coordinator):
-        """OAuth-enabled server: Authorization set by OAuth; other headers get refs substituted."""
+        """oauth_enabled=True with ${secret:...} Authorization: placeholder wins (fix #1425 A1).
+
+        After fix #1425 Problem A, the ${secret:...} placeholder in the Authorization header
+        takes precedence — OAuth bearer injection is skipped and _substitute_secret_refs
+        resolves the placeholder to CC_SECRET_* so the proxy sidecar can substitute at runtime.
+        """
         from ..mcp_config_manager import McpServerType
 
         coordinator = temp_coordinator
@@ -832,8 +837,11 @@ class TestIssue1375SecretRefs:
         }
         result = await coordinator._get_mcp_sdk_config(mock_cfg, name_to_placeholder)
 
-        assert result["headers"]["Authorization"] == "Bearer oauth-bearer-token"
+        # Placeholder wins: OAuth bearer is NOT injected; ${secret:foo} is resolved to CC_SECRET_*.
+        assert result["headers"]["Authorization"] == "CC_SECRET_foo_11111111"
         assert result["headers"]["X-Custom"] == "CC_SECRET_bar_22222222"
+        # OAuth token must NOT be present anywhere in the config.
+        assert "oauth-bearer-token" not in str(result)
 
     @pytest.mark.asyncio
     async def test_issue_671_delete_session_no_legion_system(self, temp_coordinator, sample_session_config):
@@ -1299,6 +1307,173 @@ class TestIssue1115SessionConfigStorage:
             )
 
             await coordinator.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# Issue #1425 — Problem A: OAuth MCP credential bypass (5 scenarios)
+# ---------------------------------------------------------------------------
+
+
+class TestIssue1425OAuthPlaceholder:
+    """Tests for fix #1425 Problem A: ${secret:...} placeholder preservation for oauth_enabled servers."""
+
+    @pytest.mark.asyncio
+    async def test_issue_1425_a1_placeholder_wins_over_oauth_bearer(self, temp_coordinator):
+        """A1: oauth_enabled=True + Authorization=Bearer ${secret:GH_PAT} → placeholder resolved,
+        no real token in resulting config."""
+        from ..mcp_config_manager import McpServerType
+
+        coordinator = temp_coordinator
+        mock_cfg = MagicMock()
+        mock_cfg.id = "mcp-gh-id"
+        mock_cfg.name = "gh-mcp"
+        mock_cfg.type = McpServerType.SSE
+        mock_cfg.oauth_enabled = True
+        mock_cfg.to_sdk_config.return_value = {
+            "type": "sse",
+            "url": "https://mcp.github.com/sse",
+            "headers": {"Authorization": "Bearer ${secret:GH_PAT}"},
+        }
+
+        mock_token = MagicMock()
+        mock_token.access_token = "real-github-token-abc123"
+        coordinator.oauth_manager.get_stored_token = AsyncMock(return_value=mock_token)
+        mock_store = MagicMock()
+        mock_store.get_token_expiry = AsyncMock(return_value=None)
+        coordinator.oauth_manager.get_token_store = MagicMock(return_value=mock_store)
+
+        result = await coordinator._get_mcp_sdk_config(
+            mock_cfg, {"GH_PAT": "CC_SECRET_GH_PAT_deadbeef"}
+        )
+
+        assert result["headers"]["Authorization"] == "Bearer CC_SECRET_GH_PAT_deadbeef"
+        assert "real-github-token-abc123" not in str(result)
+
+    @pytest.mark.asyncio
+    async def test_issue_1425_a2_oauth_injection_when_no_auth_header(self, temp_coordinator):
+        """A2: oauth_enabled=True + Authorization absent → OAuth bearer injected (original behaviour)."""
+        from ..mcp_config_manager import McpServerType
+
+        coordinator = temp_coordinator
+        mock_cfg = MagicMock()
+        mock_cfg.id = "mcp-no-auth-id"
+        mock_cfg.name = "no-auth-mcp"
+        mock_cfg.type = McpServerType.HTTP
+        mock_cfg.oauth_enabled = True
+        mock_cfg.to_sdk_config.return_value = {
+            "type": "http",
+            "url": "https://example.com/mcp",
+            "headers": {},
+        }
+
+        mock_token = MagicMock()
+        mock_token.access_token = "injected-oauth-token"
+        coordinator.oauth_manager.get_stored_token = AsyncMock(return_value=mock_token)
+        mock_store = MagicMock()
+        mock_store.get_token_expiry = AsyncMock(return_value=None)
+        coordinator.oauth_manager.get_token_store = MagicMock(return_value=mock_store)
+
+        result = await coordinator._get_mcp_sdk_config(mock_cfg, {})
+
+        assert result["headers"]["Authorization"] == "Bearer injected-oauth-token"
+
+    @pytest.mark.asyncio
+    async def test_issue_1425_a3_hardcoded_auth_gets_oauth_overwrite(self, temp_coordinator):
+        """A3: oauth_enabled=True + Authorization=Bearer hardcoded-token (no ${secret:...}) →
+        OAuth injection overwrites the hardcoded value (original behaviour preserved)."""
+        from ..mcp_config_manager import McpServerType
+
+        coordinator = temp_coordinator
+        mock_cfg = MagicMock()
+        mock_cfg.id = "mcp-hardcoded-id"
+        mock_cfg.name = "hardcoded-mcp"
+        mock_cfg.type = McpServerType.HTTP
+        mock_cfg.oauth_enabled = True
+        mock_cfg.to_sdk_config.return_value = {
+            "type": "http",
+            "url": "https://example.com/mcp",
+            "headers": {"Authorization": "Bearer hardcoded-static-token"},
+        }
+
+        mock_token = MagicMock()
+        mock_token.access_token = "fresh-oauth-token"
+        coordinator.oauth_manager.get_stored_token = AsyncMock(return_value=mock_token)
+        mock_store = MagicMock()
+        mock_store.get_token_expiry = AsyncMock(return_value=None)
+        coordinator.oauth_manager.get_token_store = MagicMock(return_value=mock_store)
+
+        result = await coordinator._get_mcp_sdk_config(mock_cfg, {})
+
+        assert result["headers"]["Authorization"] == "Bearer fresh-oauth-token"
+
+    @pytest.mark.asyncio
+    async def test_issue_1425_a4_placeholder_sub_unchanged_when_oauth_disabled(self, temp_coordinator):
+        """A4: oauth_enabled=False + Authorization=Bearer ${secret:X} → placeholder substituted
+        by _substitute_secret_refs, OAuth path not entered (regression guard)."""
+        from ..mcp_config_manager import McpServerType
+
+        coordinator = temp_coordinator
+        mock_cfg = MagicMock()
+        mock_cfg.id = "mcp-no-oauth-id"
+        mock_cfg.name = "no-oauth-mcp"
+        mock_cfg.type = McpServerType.HTTP
+        mock_cfg.oauth_enabled = False
+        mock_cfg.to_sdk_config.return_value = {
+            "type": "http",
+            "url": "https://example.com/mcp",
+            "headers": {"Authorization": "Bearer ${secret:MY_KEY}"},
+        }
+
+        # Patch get_stored_token so we can assert it was never called.
+        mock_get_token = AsyncMock()
+        coordinator.oauth_manager.get_stored_token = mock_get_token
+
+        result = await coordinator._get_mcp_sdk_config(
+            mock_cfg, {"MY_KEY": "CC_SECRET_MY_KEY_cafebabe"}
+        )
+
+        assert result["headers"]["Authorization"] == "Bearer CC_SECRET_MY_KEY_cafebabe"
+        # OAuth injection must not have been called when oauth_enabled=False.
+        mock_get_token.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_issue_1425_a5_token_field_never_in_debug_log(self, temp_coordinator, caplog):
+        """A5: 'token=' field is never present in [MCP config] log lines (no raw token leaks)."""
+        import logging
+
+        from ..mcp_config_manager import McpServerType
+
+        coordinator = temp_coordinator
+        mock_cfg = MagicMock()
+        mock_cfg.id = "mcp-log-id"
+        mock_cfg.name = "log-mcp"
+        mock_cfg.type = McpServerType.HTTP
+        mock_cfg.oauth_enabled = True
+        mock_cfg.to_sdk_config.return_value = {
+            "type": "http",
+            "url": "https://example.com/mcp",
+            "headers": {},
+        }
+
+        mock_token = MagicMock()
+        mock_token.access_token = "SECRET_SHOULD_NOT_APPEAR_IN_LOG"
+        coordinator.oauth_manager.get_stored_token = AsyncMock(return_value=mock_token)
+        mock_store = MagicMock()
+        mock_store.get_token_expiry = AsyncMock(return_value=12345678)
+        coordinator.oauth_manager.get_token_store = MagicMock(return_value=mock_store)
+
+        with caplog.at_level(logging.DEBUG):
+            await coordinator._get_mcp_sdk_config(mock_cfg, {})
+
+        for record in caplog.records:
+            msg = record.getMessage()
+            if "[MCP config]" in msg:
+                assert "token=" not in msg, (
+                    f"Raw token field found in MCP config log: {msg!r}"
+                )
+                assert "SECRET_SHOULD_NOT_APPEAR_IN_LOG" not in msg, (
+                    f"Raw token value found in MCP config log: {msg!r}"
+                )
 
 
 class TestIssue1396GhMountRemoved:


### PR DESCRIPTION
## Summary

Three independent bugs in the proxy credential isolation pipeline, all allowing secrets to leak past the `CC_SECRET_*` placeholder system:

- **Problem A** (`session_coordinator.py`): `_get_mcp_sdk_config()` unconditionally injected an OAuth bearer token into the Authorization header, destroying any `${secret:<name>}` placeholder the operator had written. The placeholder was meant to be resolved by the proxy sidecar at runtime; instead the real token was written into the SDK config and leaked into coordinator debug logs. Fix: skip OAuth injection when a `${secret:...}` placeholder is already present; the placeholder wins.

- **Problem B** (`scheduler_service.py`): `_fire_script_schedule()` resolved vault secrets to plaintext and passed them as `--env KEY=VALUE` to `docker exec`, making values visible via process listing. Fix: pass the `CC_SECRET_*` placeholder string instead of the resolved value; the proxy sidecar substitutes on outbound HTTP. Fails-closed (RuntimeError) if a placeholder is missing from `session_info.secret_placeholders` — operator must restart the session to regenerate.

- **Problem C** (`docker/proxy/addon.py`): The carry-buffer chunk filter in `responseheaders()` held back `max_needle_len − 1` bytes of every SSE chunk waiting for an end-of-stream sentinel that never arrives for long-lived SSE connections. MCP SSE clients timed out. Fix: detect `Content-Type: text/event-stream` and install an unbuffered filter that flushes each chunk immediately. Per-chunk scrubbing still applies; accepted residual risk is a secret straddling two SSE chunk boundaries (documented).

## Test plan

- [ ] A1–A5: `src/tests/test_session_coordinator.py::TestIssue1425OAuthPlaceholder` — 5 new tests
- [ ] Updated `test_issue_1375_oauth_and_secret_ref_interaction` to assert new (correct) behavior
- [ ] B1–B5: `src/tests/test_scheduler_script_schedule.py::test_issue_1425_b*` — 5 new tests
- [ ] Updated tests 26–28 (secrets_injected, post_rotation, no_secret_in_logs) to assert placeholder behavior
- [ ] C1–C5: `src/tests/test_proxy_addon_1400.py::TestIssue1425SSEUnbufferedFilter` — 5 new tests
- [ ] `uv run ruff check src/` — zero violations ✅
- [ ] Full test suite: 1647 passed, 1 pre-existing failure (unrelated template_manager test) ✅

## ⚠ PROXY IMAGE REBUILD REQUIRED

`addon.py` is baked into the proxy image at build time (`Dockerfile:47`). The running image will **not** pick up Problem C automatically. After deploying this change, rebuild the proxy image on every host that runs the sidecar:

```bash
docker image rm claude-proxy:local
docker build -t claude-proxy:local src/docker/proxy/
```

The WebUI auto-builds `claude-proxy:local` when the image is **missing** but will **not** rebuild an existing image. An explicit `docker image rm` step is required.

## Migration notes (Problem A)

Users who relied on the bug — `oauth_enabled=True` with a `${secret:NAME}` placeholder they never populated in the vault — will now get a `ValueError` from `_substitute_secret_refs()` at session start (fail-loud rather than silently sending a wrong token). Populate the secret in the vault or remove the `${secret:...}` reference from the MCP server Authorization header.

Resolves #1425

🤖 Generated with [Claude Code](https://claude.ai/claude-code)