### PR TITLE
fix: reparent_minion crash + list_minions parent visibility

### DIFF
--- a/src/legion/mcp/legion_mcp_tools.py
+++ b/src/legion/mcp/legion_mcp_tools.py
@@ -915,10 +915,10 @@ class LegionMCPTools:
 
             # Validate: named minion must be a descendant of the caller (or caller themselves)
             if named_minion.session_id != parent_overseer_id:
-                caller_descendants = await self.system.session_coordinator.get_descendants(
+                _desc_page = await self.system.session_coordinator.get_descendants(
                     parent_overseer_id
                 )
-                descendant_ids = {d["session_id"] for d in caller_descendants}
+                descendant_ids = {d["session_id"] for d in _desc_page["descendants"]}
 
                 if named_minion.session_id not in descendant_ids:
                     return {
@@ -1328,11 +1328,11 @@ class LegionMCPTools:
 
             if not is_direct_child:
                 # Search full descendant subtree for the target
-                descendants = await self.system.session_coordinator.get_descendants(
+                _desc_page = await self.system.session_coordinator.get_descendants(
                     parent_overseer_id
                 )
                 target_desc = None
-                for d in descendants:
+                for d in _desc_page["descendants"]:
                     d_slug = _slugify(d["name"])
                     if d_slug == target_slug:
                         target_desc = d
@@ -1465,9 +1465,9 @@ class LegionMCPTools:
             subject_slug = _slugify(subject_name)
             new_parent_slug = _slugify(new_parent_name)
 
-            # Resolve IDs from caller's descendant list
-            # (get_descendants mocked as list in tests; follows existing codebase pattern)
-            caller_descendants = await self.system.session_coordinator.get_descendants(caller_id)
+            # get_descendants returns a paginated dict; extract the list from ["descendants"]
+            _desc_page = await self.system.session_coordinator.get_descendants(caller_id)
+            caller_descendants = _desc_page["descendants"]
 
             subject_id = None
             new_parent_id = None
@@ -1718,8 +1718,15 @@ class LegionMCPTools:
                 capabilities = ", ".join(minion.capabilities) if minion.capabilities else "None"
                 cwd = minion.working_directory or "N/A"
 
+                if minion.parent_overseer_id is None:
+                    parent_display = "user"
+                else:
+                    parent_session = await session_manager.get_session_info(minion.parent_overseer_id)
+                    parent_display = parent_session.name if parent_session else "unknown"
+
                 minion_lines.append(
                     f"• **{name}** (slug: {slug}, ID: {minion.session_id})\n"
+                    f"  - Parent: {parent_display}\n"
                     f"  - Role: {role}\n"
                     f"  - State: {state}\n"
                     f"  - Working Directory: {cwd}\n"

--- a/src/tests/test_legion_mcp_tools.py
+++ b/src/tests/test_legion_mcp_tools.py
@@ -1074,3 +1074,188 @@ async def test_issue_1419_update_schedule_handler_rejects_non_empty_prompt_on_sc
     assert result.get("is_error") is True
     assert "script-type" in result["content"][0]["text"].lower()
     svc.update_schedule.assert_not_called()
+
+
+# ── Regression tests for issue #1433 ──
+
+
+@pytest.mark.asyncio
+async def test_issue_1433_reparent_extracts_descendants_from_dict():
+    """
+    Issue #1433 regression: _handle_reparent_minion must extract ["descendants"]
+    from the paginated dict returned by get_descendants, not iterate the dict itself.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from src.legion.mcp.legion_mcp_tools import LegionMCPTools
+    from src.session_manager import SessionState
+
+    caller_id = "caller-session-id"
+
+    caller_session = MagicMock()
+    caller_session.session_id = caller_id
+    caller_session.name = "CallerMinion"
+    caller_session.state = SessionState.ACTIVE
+
+    # Simulate the real paginated return shape from get_descendants
+    paginated_result = {
+        "descendants": [
+            {"name": "ChildA", "session_id": "child-a-id"},
+            {"name": "NewParent", "session_id": "new-parent-id"},
+        ],
+        "total": 2,
+        "limit": 50,
+        "offset": 0,
+        "has_more": False,
+    }
+
+    session_manager = MagicMock()
+    session_manager.get_session_info = AsyncMock(return_value=caller_session)
+
+    session_coordinator = MagicMock()
+    session_coordinator.session_manager = session_manager
+    session_coordinator.get_descendants = AsyncMock(return_value=paginated_result)
+
+    overseer_controller = MagicMock()
+    overseer_controller.reparent_minion = AsyncMock(
+        return_value={"descendants_moved": 0}
+    )
+
+    mock_system = MagicMock()
+    mock_system.session_coordinator = session_coordinator
+    mock_system.overseer_controller = overseer_controller
+
+    mcp_tools = LegionMCPTools(mock_system)
+
+    result = await mcp_tools._handle_reparent_minion({
+        "_caller_id": caller_id,
+        "subject_name": "ChildA",
+        "new_parent_name": "NewParent",
+    })
+
+    assert result.get("is_error") is False, f"Expected success, got: {result}"
+    overseer_controller.reparent_minion.assert_awaited_once_with(
+        subject_id="child-a-id",
+        new_parent_id="new-parent-id",
+        caller_id=caller_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_issue_1433_list_minions_includes_parent_field():
+    """
+    Issue #1433: list_minions must include a Parent: line for each minion.
+    Root minions (parent_overseer_id=None) show "Parent: user";
+    children show the parent's name.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from src.legion.mcp.legion_mcp_tools import LegionMCPTools
+    from src.session_manager import SessionState
+
+    root_session = MagicMock()
+    root_session.session_id = "root-id"
+    root_session.project_id = "legion-123"
+    root_session.name = "RootMinion"
+    root_session.slug = "rootminion"
+    root_session.role = "Root Role"
+    root_session.state = SessionState.ACTIVE
+    root_session.capabilities = []
+    root_session.working_directory = "/work"
+    root_session.parent_overseer_id = None
+
+    child_session = MagicMock()
+    child_session.session_id = "child-id"
+    child_session.project_id = "legion-123"
+    child_session.name = "ChildMinion"
+    child_session.slug = "childminion"
+    child_session.role = "Child Role"
+    child_session.state = SessionState.ACTIVE
+    child_session.capabilities = []
+    child_session.working_directory = "/work"
+    child_session.parent_overseer_id = "root-id"
+
+    async def mock_get_session_info(session_id):
+        return {"root-id": root_session, "child-id": child_session}.get(session_id)
+
+    session_manager = MagicMock()
+    session_manager.get_session_info = mock_get_session_info
+
+    session_coordinator = MagicMock()
+    session_coordinator.session_manager = session_manager
+
+    mock_legion = MagicMock()
+    legion_coordinator = MagicMock()
+    legion_coordinator.get_legion = AsyncMock(return_value=mock_legion)
+
+    comm_router = MagicMock()
+    comm_router.get_visible_minions = AsyncMock(return_value=["root-id", "child-id"])
+
+    mock_system = MagicMock()
+    mock_system.session_coordinator = session_coordinator
+    mock_system.legion_coordinator = legion_coordinator
+    mock_system.comm_router = comm_router
+
+    mcp_tools = LegionMCPTools(mock_system)
+
+    result = await mcp_tools._handle_list_minions({"_from_minion_id": "child-id"})
+
+    assert result.get("is_error") is False, f"Got error: {result}"
+    text = result["content"][0]["text"]
+
+    assert "Parent: user" in text, f"Root minion should show 'Parent: user'; got:\n{text}"
+    assert "Parent: RootMinion" in text, f"Child should show 'Parent: RootMinion'; got:\n{text}"
+
+
+@pytest.mark.asyncio
+async def test_issue_1433_list_minions_parent_unknown_fallback():
+    """
+    Issue #1433: When parent_overseer_id points to a missing/disposed session,
+    list_minions must show "Parent: unknown" and not crash.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from src.legion.mcp.legion_mcp_tools import LegionMCPTools
+    from src.session_manager import SessionState
+
+    orphan_session = MagicMock()
+    orphan_session.session_id = "orphan-id"
+    orphan_session.project_id = "legion-456"
+    orphan_session.name = "OrphanMinion"
+    orphan_session.slug = "orphanminion"
+    orphan_session.role = "Orphan Role"
+    orphan_session.state = SessionState.ACTIVE
+    orphan_session.capabilities = []
+    orphan_session.working_directory = "/work"
+    orphan_session.parent_overseer_id = "gone-parent-id"  # points to missing session
+
+    async def mock_get_session_info(session_id):
+        if session_id == "orphan-id":
+            return orphan_session
+        return None  # gone-parent-id returns None
+
+    session_manager = MagicMock()
+    session_manager.get_session_info = mock_get_session_info
+
+    session_coordinator = MagicMock()
+    session_coordinator.session_manager = session_manager
+
+    mock_legion = MagicMock()
+    legion_coordinator = MagicMock()
+    legion_coordinator.get_legion = AsyncMock(return_value=mock_legion)
+
+    comm_router = MagicMock()
+    comm_router.get_visible_minions = AsyncMock(return_value=["orphan-id"])
+
+    mock_system = MagicMock()
+    mock_system.session_coordinator = session_coordinator
+    mock_system.legion_coordinator = legion_coordinator
+    mock_system.comm_router = comm_router
+
+    mcp_tools = LegionMCPTools(mock_system)
+
+    result = await mcp_tools._handle_list_minions({"_from_minion_id": "orphan-id"})
+
+    assert result.get("is_error") is False, f"Got error: {result}"
+    text = result["content"][0]["text"]
+    assert "Parent: unknown" in text, f"Should show 'Parent: unknown'; got:\n{text}"

--- a/src/tests/test_overseer_controller.py
+++ b/src/tests/test_overseer_controller.py
@@ -96,11 +96,14 @@ class TestSpawnWithParentName:
             return_value=parent
         )
 
-        # get_descendants returns Parent as descendant of Grandparent
-        mock_system.session_coordinator.get_descendants = AsyncMock(return_value=[
-            {"session_id": "parent-id", "name": "Parent", "role": "worker",
-             "state": "active", "parent_id": "gp-id"}
-        ])
+        # get_descendants returns paginated dict; extract ["descendants"] before iterating
+        mock_system.session_coordinator.get_descendants = AsyncMock(return_value={
+            "descendants": [
+                {"session_id": "parent-id", "name": "Parent", "role": "worker",
+                 "state": "active", "parent_id": "gp-id"}
+            ],
+            "total": 1, "limit": 50, "offset": 0, "has_more": False,
+        })
 
         # Mock spawn_minion to capture what parent_overseer_id is passed
         child_session = _make_session("child-id", "Child", parent_id="parent-id")
@@ -146,7 +149,9 @@ class TestSpawnWithParentName:
             return_value=unrelated
         )
         # Caller has no descendants
-        mock_system.session_coordinator.get_descendants = AsyncMock(return_value=[])
+        mock_system.session_coordinator.get_descendants = AsyncMock(return_value={
+            "descendants": [], "total": 0, "limit": 50, "offset": 0, "has_more": False,
+        })
 
         args = {
             "_parent_overseer_id": "caller-id",
@@ -290,13 +295,16 @@ class TestDisposeDescendant:
         sm = mock_system.session_coordinator.session_manager
         sm.get_session_info = AsyncMock(side_effect=lambda sid: session_map.get(sid))
 
-        # get_descendants returns full subtree under Grandparent
-        mock_system.session_coordinator.get_descendants = AsyncMock(return_value=[
-            {"session_id": "parent-id", "name": "Parent", "role": "worker",
-             "state": "active", "parent_id": "gp-id"},
-            {"session_id": "child-id", "name": "Child", "role": "worker",
-             "state": "active", "parent_id": "parent-id"},
-        ])
+        # get_descendants returns paginated dict; extract ["descendants"] before iterating
+        mock_system.session_coordinator.get_descendants = AsyncMock(return_value={
+            "descendants": [
+                {"session_id": "parent-id", "name": "Parent", "role": "worker",
+                 "state": "active", "parent_id": "gp-id"},
+                {"session_id": "child-id", "name": "Child", "role": "worker",
+                 "state": "active", "parent_id": "parent-id"},
+            ],
+            "total": 2, "limit": 50, "offset": 0, "has_more": False,
+        })
 
         mock_system.overseer_controller.dispose_minion = AsyncMock(
             return_value={
@@ -373,7 +381,9 @@ class TestDisposeDescendant:
         sm.get_session_info = AsyncMock(side_effect=lambda sid: session_map.get(sid))
 
         # No descendants
-        mock_system.session_coordinator.get_descendants = AsyncMock(return_value=[])
+        mock_system.session_coordinator.get_descendants = AsyncMock(return_value={
+            "descendants": [], "total": 0, "limit": 50, "offset": 0, "has_more": False,
+        })
 
         args = {
             "_parent_overseer_id": "caller-id",


### PR DESCRIPTION
## Summary
Resolves #1433

Fixes two bugs in `src/legion/mcp/legion_mcp_tools.py`:

1. **`reparent_minion` TypeError crash** — `_handle_reparent_minion` iterated the paginated dict returned by `get_descendants()` directly, yielding string keys instead of minion records and crashing with `TypeError: string indices must be integers, not 'str'`. Fixed by extracting `["descendants"]` before iteration. The same extraction bug existed (but was unreachable in happy-path flows) in `_handle_spawn_minion` and `_handle_dispose_minion` — fixed at all three sites.

2. **`list_minions` missing Parent field** — Each minion entry now includes a `Parent: <name>` line. Root minions (no `parent_overseer_id`) show `Parent: user`; disposed/missing parent sessions fall back to `Parent: unknown`. Change is additive — existing parsers that look for `Role:` / `State:` / etc. are unaffected.

## Changes Made
- `src/legion/mcp/legion_mcp_tools.py`: Extract `_desc_page["descendants"]` in `_handle_reparent_minion`, `_handle_spawn_minion`, and `_handle_dispose_minion`; add `Parent:` field to `_handle_list_minions` output
- `src/tests/test_legion_mcp_tools.py`: Add `test_issue_1433_reparent_extracts_descendants_from_dict`, `test_issue_1433_list_minions_includes_parent_field`, `test_issue_1433_list_minions_parent_unknown_fallback`
- `src/tests/test_overseer_controller.py`: Update four existing `get_descendants` mocks from plain-list to correct paginated-dict shape

## Testing
- All 1675 tests pass (1 pre-existing failure in `test_template_manager` unrelated to this change)
- `uv run ruff check` reports zero violations on all modified files
- Regression tests added that would have caught the reparent crash before it shipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)