### PR TITLE
refactor: extract shared content-encoding header helper in proxy addon

### DIFF
--- a/src/docker/proxy/addon.py
+++ b/src/docker/proxy/addon.py
@@ -198,16 +198,18 @@ def _is_sse_response(flow: http.HTTPFlow) -> bool:
     return ct.startswith("text/event-stream")
 
 
+def _get_content_encoding(headers) -> str:
+    return headers.get("content-encoding", "").strip().lower()
+
+
 def _is_encoded_response(flow: http.HTTPFlow) -> bool:
     if not flow.response:
         return False
-    ce = flow.response.headers.get("content-encoding", "").strip().lower()
-    return bool(ce) and ce != "identity"
+    return _get_content_encoding(flow.response.headers) not in ("", "identity")
 
 
 def _is_encoded_request(flow: http.HTTPFlow) -> bool:
-    ce = flow.request.headers.get("content-encoding", "").strip().lower()
-    return bool(ce) and ce != "identity"
+    return _get_content_encoding(flow.request.headers) not in ("", "identity")
 
 
 def _scrub_response_headers(flow: http.HTTPFlow, value: str, placeholder: str) -> bool:


### PR DESCRIPTION
## Summary
Resolves #1439

Eliminates duplicated content-encoding header extraction logic in the proxy addon by introducing a single `_get_content_encoding(headers) -> str` helper.

## Changes Made
- Add `_get_content_encoding(headers) -> str` private helper in `src/docker/proxy/addon.py`, inserted between `_is_sse_response` and `_is_encoded_response`
- Rewrite `_is_encoded_response` to delegate to the helper, replacing the inline `.get("content-encoding", "").strip().lower()` + `bool(ce) and ce != "identity"` logic with `not in ("", "identity")`
- Rewrite `_is_encoded_request` identically — same extraction, same comparison form
- No behavior change; call sites at `requestheaders()` and `responseheaders()` hooks are unaffected

## Testing
- `uv run pytest src/tests/test_proxy_addon_1400.py src/tests/test_proxy_addon_1428.py -v` — 43 tests passed
- `uv run ruff check src/` — zero violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)