### PR TITLE
perf: cache parent session names in _handle_list_minions

### DIFF
--- a/src/legion/mcp/legion_mcp_tools.py
+++ b/src/legion/mcp/legion_mcp_tools.py
@@ -1693,10 +1693,12 @@ class LegionMCPTools:
             session_manager = self.system.session_coordinator.session_manager
             visible_ids = await self.system.comm_router.get_visible_minions(from_minion_id)
             minions = []
+            session_name_cache: dict[str, str] = {}
             for vid in visible_ids:
                 session = await session_manager.get_session_info(vid)
                 if session:
                     minions.append(session)
+                    session_name_cache[session.session_id] = session.name
 
             # Format minion list
             minion_lines = []
@@ -1720,9 +1722,12 @@ class LegionMCPTools:
 
                 if minion.parent_overseer_id is None:
                     parent_display = "user"
+                elif minion.parent_overseer_id in session_name_cache:
+                    parent_display = session_name_cache[minion.parent_overseer_id]
                 else:
                     parent_session = await session_manager.get_session_info(minion.parent_overseer_id)
                     parent_display = parent_session.name if parent_session else "unknown"
+                    session_name_cache[minion.parent_overseer_id] = parent_display
 
                 minion_lines.append(
                     f"• **{name}** (slug: {slug}, ID: {minion.session_id})\n"


### PR DESCRIPTION
## Summary

- Introduce a call-scoped `session_name_cache` dict populated during the visible-minions load loop
- Parent resolution in the display loop now hits the cache instead of calling `get_session_info` again for already-visible parents
- Non-visible parents are still fetched via `get_session_info` but cached so repeated lookups for the same parent cost only one await

Resolves #1436

## Test plan

- [x] `test_issue_1433_list_minions_includes_parent_field` — parent resolves via cache hit, output unchanged
- [x] `test_issue_1433_list_minions_parent_unknown_fallback` — cache-miss path still calls `get_session_info`, shows `unknown`
- [x] `uv run ruff check src/` — zero violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)