### PR TITLE
refactor: eliminate duplicate descendant traversal, cost breakdown, and rates lookup

### DIFF
--- a/src/analytics/aggregator.py
+++ b/src/analytics/aggregator.py
@@ -164,7 +164,9 @@ async def aggregate_by_time(
             breakdown = compute_cost_breakdown(rates, counts)
             for k, v in breakdown.items():
                 bucket["by_token_type"][k] += v
-        estimated_cost, _ = _cost_for_row(pricing, row["model"], counts)
+            estimated_cost = sum(breakdown.values())
+        else:
+            estimated_cost = None
         bucket["by_model"].append(
             {
                 "model": row["model"],

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -139,13 +139,7 @@ class PricingConfig:
 
 def compute_cost(rates: ModelRates, counts: dict[str, Any]) -> float:
     """Compute estimated cost in USD given ModelRates and token counts dict."""
-    m = 1_000_000.0
-    return (
-        rates.input * int(counts.get("input_tokens") or 0) / m
-        + rates.output * int(counts.get("output_tokens") or 0) / m
-        + rates.cache_write * int(counts.get("cache_write_tokens") or 0) / m
-        + rates.cache_read * int(counts.get("cache_read_tokens") or 0) / m
-    )
+    return sum(compute_cost_breakdown(rates, counts).values())
 
 
 def compute_cost_breakdown(rates: ModelRates, counts: dict[str, Any]) -> dict[str, float]:

--- a/src/legion/overseer_controller.py
+++ b/src/legion/overseer_controller.py
@@ -451,25 +451,6 @@ class OverseerController:
             "deleted": deleted
         }
 
-    async def _get_descendant_ids(self, session_id: str) -> set[str]:
-        """Return the set of all descendant session IDs (BFS, excludes session_id itself)."""
-        result: set[str] = set()
-        session = await self.system.session_coordinator.session_manager.get_session_info(session_id)
-        if not session or not session.child_minion_ids:
-            return result
-        queue = list(session.child_minion_ids)
-        visited: set[str] = set()
-        while queue:
-            child_id = queue.pop()
-            if child_id in visited:
-                continue
-            visited.add(child_id)
-            result.add(child_id)
-            child_session = await self.system.session_coordinator.session_manager.get_session_info(child_id)
-            if child_session and child_session.child_minion_ids:
-                queue.extend(child_session.child_minion_ids)
-        return result
-
     async def _recompute_levels(self, session_id: str, level: int, children: list[str]) -> None:
         """Set overseer_level for session_id and all descendants (DFS)."""
         await self.system.session_coordinator.session_manager.update_session(
@@ -532,7 +513,8 @@ class OverseerController:
             if new_parent.project_id != legion_id:
                 raise ValueError("Cannot reparent to a minion in a different legion")
 
-        subject_descendant_ids = await self._get_descendant_ids(subject_id)
+        _desc_page = await self.system.session_coordinator.get_descendants(subject_id)
+        subject_descendant_ids = {d["session_id"] for d in _desc_page["descendants"]}
         if new_parent_id is not None and new_parent_id in subject_descendant_ids:
             raise ValueError(
                 "Cannot reparent: the new parent is a descendant of the subject (would create a cycle)"
@@ -543,7 +525,8 @@ class OverseerController:
             if not caller:
                 raise ValueError(f"Caller {caller_id} not found")
 
-            caller_descendant_ids = await self._get_descendant_ids(caller_id)
+            _caller_desc_page = await self.system.session_coordinator.get_descendants(caller_id)
+            caller_descendant_ids = {d["session_id"] for d in _caller_desc_page["descendants"]}
 
             # Subject must be in caller's descendant closure
             if subject_id not in caller_descendant_ids:


### PR DESCRIPTION
## Summary

Resolves #1435

Three independent mechanical refactors removing duplicated logic introduced by recent changes. No behavioral changes, no API surface changes, no schema changes.

## Changes Made

- **`src/legion/overseer_controller.py`**: Delete private `_get_descendant_ids()` (BFS over `child_minion_ids`) and replace both call sites in `reparent_minion()` with `session_coordinator.get_descendants()`, aligning with the existing MCP layer pattern in `legion_mcp_tools.py`.
- **`src/config_manager.py`**: Implement `compute_cost()` as `sum(compute_cost_breakdown(rates, counts).values())` — pricing arithmetic now lives in one place.
- **`src/analytics/aggregator.py`**: In `aggregate_by_time()`, reuse the `rates` and `breakdown` already fetched for `compute_cost_breakdown()` to compute `estimated_cost = sum(breakdown.values())`, removing the second `get_rates()` call previously hidden inside `_cost_for_row()`.

## Testing

- `uv run pytest src/tests/test_overseer_controller.py src/tests/test_pricing_config.py src/tests/test_analytics_aggregator.py -v` — 51/51 passed
- `uv run ruff check src/` — zero violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)