### PR TITLE
refactor(legion): align logging to single-category-logger pattern

### DIFF
--- a/src/legion/history_rotator.py
+++ b/src/legion/history_rotator.py
@@ -17,17 +17,18 @@ from __future__ import annotations
 
 import asyncio
 import json
-import logging
 import os
 import time
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+from src.logging_config import get_logger
+
 if TYPE_CHECKING:
     from src.config_manager import HistoryRetentionConfig
     from src.legion_system import LegionSystem
 
-logger = logging.getLogger(__name__)
+legion_logger = get_logger('legion', 'HISTORY_ROTATOR')
 
 
 class HistoryRotator:
@@ -53,11 +54,11 @@ class HistoryRotator:
 
     async def start(self) -> None:
         if not self.config.enabled:
-            logger.info("HistoryRotator disabled by config — rotation skipped")
+            legion_logger.info("HistoryRotator disabled by config — rotation skipped")
             return
         self._running = True
         self._task = asyncio.create_task(self._loop())
-        logger.info("HistoryRotator started")
+        legion_logger.info("HistoryRotator started")
 
     async def stop(self) -> None:
         self._running = False
@@ -68,7 +69,7 @@ class HistoryRotator:
             except asyncio.CancelledError:
                 pass
         self._task = None
-        logger.info("HistoryRotator stopped")
+        legion_logger.info("HistoryRotator stopped")
 
     async def request_rotation(self, legion_id: str) -> None:
         """Queue a rotation for legion_id (no-op if already queued or disabled)."""
@@ -104,7 +105,7 @@ class HistoryRotator:
             except asyncio.CancelledError:
                 break
             except Exception as e:
-                logger.exception("HistoryRotator loop error: %s", e)
+                legion_logger.exception("HistoryRotator loop error: %s", e)
 
     async def _periodic_rotation(self) -> None:
         data_dir = self.system.session_coordinator.data_dir
@@ -125,7 +126,7 @@ class HistoryRotator:
             pruned = await asyncio.to_thread(self._rotate_sync, legion_id)
             if pruned > 0:
                 elapsed_ms = int((time.monotonic() - started) * 1000)
-                logger.info(
+                legion_logger.info(
                     "HistoryRotator: legion=%s pruned=%d duration_ms=%d",
                     legion_id,
                     pruned,
@@ -157,11 +158,11 @@ class HistoryRotator:
                     try:
                         entries.append(ScheduleExecution.from_dict(json.loads(line)))
                     except Exception:
-                        logger.warning(
+                        legion_logger.warning(
                             "HistoryRotator: skipping malformed line in %s", history_file
                         )
         except Exception as e:
-            logger.error("HistoryRotator: failed to read %s: %s", history_file, e)
+            legion_logger.error("HistoryRotator: failed to read %s: %s", history_file, e)
             return 0
 
         before = len(entries)
@@ -189,7 +190,7 @@ class HistoryRotator:
                     fh.write(json.dumps(e.to_dict()) + "\n")
             os.replace(tmp_history, history_file)
         except Exception as e:
-            logger.error("HistoryRotator: failed to rewrite %s: %s", history_file, e)
+            legion_logger.error("HistoryRotator: failed to rewrite %s: %s", history_file, e)
             tmp_history.unlink(missing_ok=True)
             return 0
 
@@ -230,5 +231,5 @@ class HistoryRotator:
             tmp.write_text(json.dumps({sid: m.to_dict() for sid, m in cache.items()}, indent=2))
             os.replace(tmp, metrics_file)
         except Exception as e:
-            logger.error("HistoryRotator: failed to seed metrics for %s: %s", legion_id, e)
+            legion_logger.error("HistoryRotator: failed to seed metrics for %s: %s", legion_id, e)
             tmp.unlink(missing_ok=True)

--- a/src/legion/legion_coordinator.py
+++ b/src/legion/legion_coordinator.py
@@ -12,6 +12,10 @@ import asyncio
 import json
 from typing import TYPE_CHECKING, Optional
 
+from src.logging_config import get_logger
+
+legion_logger = get_logger('legion', 'LEGION_COORDINATOR')
+
 if TYPE_CHECKING:
     from src.legion_system import LegionSystem
     from src.project_manager import ProjectInfo
@@ -456,8 +460,7 @@ class LegionCoordinator:
         total_capabilities = len(self.capability_registry)
         total_entries = sum(len(entries) for entries in self.capability_registry.values())
         if total_capabilities > 0:
-            import logging
-            logging.info(
+            legion_logger.info(
                 f"Rebuilt capability registry: {total_capabilities} capabilities, "
                 f"{total_entries} total entries from {len(minions_with_capabilities)} minions"
             )

--- a/src/legion/mcp/legion_mcp_tools.py
+++ b/src/legion/mcp/legion_mcp_tools.py
@@ -14,7 +14,6 @@ Tools are exposed to minions with names like: mcp__legion__send_comm
 """
 
 import asyncio
-import logging
 import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
@@ -28,11 +27,12 @@ except ImportError:
 
 from src.config_resolution import resolve_template_config
 from src.docker_utils import translate_docker_tmp_path
+from src.logging_config import get_logger
 from src.session_config import DEFAULTS as _SESSION_DEFAULTS
 from src.session_config import SessionConfig
 from src.task_utils import task_done_log_exception
 
-logger = logging.getLogger(__name__)
+legion_logger = get_logger('legion', 'MCP_TOOLS')
 
 if TYPE_CHECKING:
     from src.legion_system import LegionSystem
@@ -758,10 +758,6 @@ class LegionMCPTools:
         Returns:
             Tool result with success/error
         """
-        from src.logging_config import get_logger
-
-        coord_logger = get_logger('legion', category='MCP_TOOLS')
-
         parent_overseer_id = args.get("_parent_overseer_id")
         if not parent_overseer_id:
             return self._err("Error: Unable to determine parent overseer ID")
@@ -813,7 +809,7 @@ class LegionMCPTools:
 
             actual_parent_id = named_minion.session_id
             parent_session = named_minion
-            coord_logger.info(
+            legion_logger.info(
                 f"parent_name '{parent_name_param}' resolved to {actual_parent_id} "
                 f"(caller: {parent_overseer_id})"
             )
@@ -931,7 +927,7 @@ class LegionMCPTools:
                 )
 
             except Exception as e:
-                coord_logger.error(f"Error applying template: {e}", exc_info=True)
+                legion_logger.error(f"Error applying template: {e}", exc_info=True)
                 return self._err(f"❌ Error applying template: {str(e)}")
         else:
             # No template - use safe default restricted permissions
@@ -1080,7 +1076,7 @@ class LegionMCPTools:
 
         except Exception as e:
             # Catch-all for unexpected errors
-            coord_logger.error(f"Unexpected error in spawn_minion: {e}", exc_info=True)
+            legion_logger.error(f"Unexpected error in spawn_minion: {e}", exc_info=True)
             return self._err(f"❌ Failed to spawn minion due to unexpected error: {str(e)}")
 
     async def _handle_dispose_minion(self, args: dict[str, Any]) -> dict[str, Any]:
@@ -1097,10 +1093,6 @@ class LegionMCPTools:
         Returns:
             Tool result with success/error
         """
-        from src.logging_config import get_logger
-
-        coord_logger = get_logger('legion', category='MCP_TOOLS')
-
         parent_overseer_id = args.get("_parent_overseer_id")  # This is actually the CALLER's session_id
         if not parent_overseer_id:
             return self._err("Error: Unable to determine caller ID")
@@ -1197,7 +1189,7 @@ class LegionMCPTools:
 
         except Exception as e:
             # Catch-all for unexpected errors
-            coord_logger.error(f"Unexpected error in dispose_minion: {e}", exc_info=True)
+            legion_logger.error(f"Unexpected error in dispose_minion: {e}", exc_info=True)
             return self._err(f"❌ Failed to dispose minion due to unexpected error: {str(e)}")
 
     async def _handle_reparent_minion(self, args: dict[str, Any]) -> dict[str, Any]:
@@ -1215,8 +1207,6 @@ class LegionMCPTools:
             Tool result with success/error
         """
         from src.slug_utils import slugify_name as _slugify
-
-        coord_logger = logger
 
         caller_id = args.get("_caller_id")
         if not caller_id:
@@ -1291,7 +1281,7 @@ class LegionMCPTools:
         except ValueError as e:
             return self._err(f"❌ Cannot reparent: {e}")
         except Exception as e:
-            coord_logger.error(f"Unexpected error in reparent_minion: {e}", exc_info=True)
+            legion_logger.error(f"Unexpected error in reparent_minion: {e}", exc_info=True)
             return self._err(f"❌ Failed to reparent minion: {e}")
 
     async def _handle_search_capability(self, args: dict[str, Any]) -> dict[str, Any]:
@@ -2193,7 +2183,7 @@ class LegionMCPTools:
         restart_id = str(uuid.uuid4())
         self._pending_restarts.add(session_id)
 
-        logger.info(
+        legion_logger.info(
             f"Session {session_id} restart initiated (restart_id={restart_id}, reason={reason})"
         )
 
@@ -2225,7 +2215,7 @@ class LegionMCPTools:
 
                 session_info = await coordinator.session_manager.get_session_info(session_id)
                 if not session_info:
-                    logger.warning(f"Session {session_id} disappeared during restart monitor")
+                    legion_logger.warning(f"Session {session_id} disappeared during restart monitor")
                     return
 
                 if not session_info.is_processing:
@@ -2239,7 +2229,7 @@ class LegionMCPTools:
                     )
 
                     if success:
-                        logger.info(
+                        legion_logger.info(
                             f"Session {session_id} self-restarted successfully "
                             f"(restart_id={restart_id}, reason={reason})"
                         )
@@ -2269,14 +2259,14 @@ class LegionMCPTools:
                             reset_session=False,
                         )
                     else:
-                        logger.error(
+                        legion_logger.error(
                             f"Session {session_id} restart failed (restart_id={restart_id})"
                         )
 
                     return
 
             # Timeout — session still processing after 30 seconds
-            logger.warning(
+            legion_logger.warning(
                 f"Session {session_id} restart timed out (restart_id={restart_id})"
             )
             await coordinator.send_message(
@@ -2286,7 +2276,7 @@ class LegionMCPTools:
             )
 
         except Exception as e:
-            logger.error(
+            legion_logger.error(
                 f"Restart monitor unhandled error for session {session_id}: {e}", exc_info=True
             )
             self.system.broadcast_ui_event({
@@ -2334,5 +2324,5 @@ class LegionMCPTools:
         except ValueError as e:
             return self._err(f"Error: {e}")
         except Exception as e:
-            logger.exception(f"Unexpected error in queue_task for session {session_id}: {e}")
+            legion_logger.exception(f"Unexpected error in queue_task for session {session_id}: {e}")
             return self._err(f"Unexpected error queuing task: {e}")

--- a/src/legion/overseer_controller.py
+++ b/src/legion/overseer_controller.py
@@ -12,9 +12,12 @@ import asyncio
 import uuid
 from typing import TYPE_CHECKING
 
+from src.logging_config import get_logger
 from src.models.permission_mode import PermissionMode
 from src.session_config import SessionConfig
 from src.slug_utils import slugify_name
+
+legion_logger = get_logger('legion', 'OVERSEER')
 
 if TYPE_CHECKING:
     from src.legion_system import LegionSystem
@@ -108,8 +111,7 @@ class OverseerController:
                     )
                 except ValueError as e:
                     # Log error but don't fail minion creation if capability format is invalid
-                    import logging
-                    logging.warning(f"Failed to register capability '{capability}' for minion {minion_id}: {e}")
+                    legion_logger.warning(f"Failed to register capability '{capability}' for minion {minion_id}: {e}")
 
         return minion_id
 
@@ -145,10 +147,7 @@ class OverseerController:
             ValueError: If parent doesn't exist, name duplicate, or legion at capacity
             PermissionError: If parent is not a valid overseer
         """
-        from src.logging_config import get_logger
         from src.models.legion_models import Comm, CommType, InterruptPriority
-
-        coord_logger = get_logger('legion', category='OVERSEER')
 
         # 1. Get parent minion session
         parent_session = await self.system.session_coordinator.session_manager.get_session_info(parent_overseer_id)
@@ -227,7 +226,7 @@ class OverseerController:
                     )
                 except ValueError as e:
                     # Log error but don't fail spawn if capability format is invalid
-                    coord_logger.warning(f"Failed to register capability '{capability}' for spawned minion {child_minion_id}: {e}")
+                    legion_logger.warning(f"Failed to register capability '{capability}' for spawned minion {child_minion_id}: {e}")
 
         # 10. Send SPAWN notification to user
         spawn_comm = Comm(
@@ -247,18 +246,18 @@ class OverseerController:
         # This ensures messages from the spawned minion broadcast to WebSocket clients
         if self.system.message_callback_registrar:
             self.system.message_callback_registrar(child_minion_id)
-            coord_logger.info(f"Registered WebSocket message callback for spawned minion {child_minion_id} ({name})")
+            legion_logger.info(f"Registered WebSocket message callback for spawned minion {child_minion_id} ({name})")
         else:
-            coord_logger.warning(f"No message callback registrar available for minion {child_minion_id} - WebSocket streaming will not work!")
+            legion_logger.warning(f"No message callback registrar available for minion {child_minion_id} - WebSocket streaming will not work!")
 
         # 13. Start child session with permission callback
         # Create permission callback using factory (same pattern as user-created minions)
         permission_callback = None
         if self.system.permission_callback_factory:
             permission_callback = self.system.permission_callback_factory(child_minion_id)
-            coord_logger.info(f"Created permission callback for spawned minion {child_minion_id} ({name})")
+            legion_logger.info(f"Created permission callback for spawned minion {child_minion_id} ({name})")
         else:
-            coord_logger.warning(f"No permission callback factory available for minion {child_minion_id} - permissions will not work!")
+            legion_logger.warning(f"No permission callback factory available for minion {child_minion_id} - permissions will not work!")
 
         await self.system.session_coordinator.start_session(
             child_minion_id,
@@ -272,9 +271,9 @@ class OverseerController:
                 "type": "project_updated",
                 "data": {"project": project.to_dict()}
             })
-            coord_logger.debug(f"Appended project_updated for legion {legion_id} after minion spawn")
+            legion_logger.debug(f"Appended project_updated for legion {legion_id} after minion spawn")
 
-        coord_logger.info(f"Minion {name} spawned by {parent_session.name} (parent={parent_overseer_id}, child={child_minion_id})")
+        legion_logger.info(f"Minion {name} spawned by {parent_session.name} (parent={parent_overseer_id}, child={child_minion_id})")
 
         return {
             "minion_id": child_minion_id
@@ -304,10 +303,7 @@ class OverseerController:
             ValueError: If child not found
             PermissionError: If caller is not parent of child
         """
-        from src.logging_config import get_logger
         from src.models.legion_models import Comm, CommType, InterruptPriority
-
-        coord_logger = get_logger('legion', category='OVERSEER')
 
         # 1. Get parent session
         parent_session = await self.system.session_coordinator.session_manager.get_session_info(parent_overseer_id)
@@ -362,9 +358,9 @@ class OverseerController:
         try:
             deleted = await self.system.scheduler_service.delete_schedules_for_minion(child_minion_id)
             if deleted:
-                coord_logger.info(f"Deleted {deleted} schedules for disposed minion {child_minion_id}")
+                legion_logger.info(f"Deleted {deleted} schedules for disposed minion {child_minion_id}")
         except Exception as e:
-            coord_logger.warning(f"Failed to delete schedules for minion {child_minion_id}: {e}")
+            legion_logger.warning(f"Failed to delete schedules for minion {child_minion_id}: {e}")
 
         # 6. Terminate SDK session
         await self.system.session_coordinator.terminate_session(child_minion_id)
@@ -402,9 +398,9 @@ class OverseerController:
                     child_minion_id, archive_reason="parent_initiated"
                 )
                 deleted = True
-                coord_logger.info(f"Deleted minion session {child_minion_name} ({child_minion_id})")
+                legion_logger.info(f"Deleted minion session {child_minion_name} ({child_minion_id})")
             except Exception as e:
-                coord_logger.warning(f"Failed to delete minion session {child_minion_id}: {e}")
+                legion_logger.warning(f"Failed to delete minion session {child_minion_id}: {e}")
         else:
             # Soft dispose: keep relationships intact, minion can be restarted.
             # Only deregister from capability registry (capabilities are session-specific).
@@ -438,7 +434,7 @@ class OverseerController:
                 "data": {"project": project.to_dict()}
             })
 
-        coord_logger.info(
+        legion_logger.info(
             f"Minion {child_minion_name} {action_word} by {parent_session.name} "
             f"(disposed_id={child_minion_id}, descendants={descendants_disposed}, deleted={deleted})"
         )
@@ -482,10 +478,7 @@ class OverseerController:
         Raises:
             ValueError: On self-reparent, cross-legion, cycle, or MCP authority violation
         """
-        from src.logging_config import get_logger
         from src.models.legion_models import Comm, CommType, InterruptPriority
-
-        coord_logger = get_logger('legion', category='OVERSEER')
 
         if subject_id == new_parent_id:
             raise ValueError("Cannot reparent a minion to itself")
@@ -649,7 +642,7 @@ class OverseerController:
                 "data": {"project": project.to_dict()}
             })
 
-        coord_logger.info(
+        legion_logger.info(
             f"Reparented {subject.name} ({subject_id}) from {old_parent_id} to {new_parent_id} "
             f"(caller={caller_name}, descendants_moved={descendants_moved})"
         )


### PR DESCRIPTION
## Summary
Resolves #1441

Replace scattered inline `import logging` / `logging.getLogger(__name__)` / per-method `get_logger()` calls with a module-level `legion_logger` singleton in four non-compliant Legion files, matching the established pattern already used in `comm_router.py` and `scheduler_service.py`.

## Changes Made
- **`overseer_controller.py`**: Remove 1× inline `import logging` + `logging.warning()` and 3× inline `from src.logging_config import get_logger` + `coord_logger` assignments; add module-level `legion_logger = get_logger('legion', 'OVERSEER')`
- **`mcp/legion_mcp_tools.py`**: Remove `import logging` + `logger = logging.getLogger(__name__)`, 2× inline `get_logger` blocks, and `coord_logger = logger` alias; add module-level `legion_logger = get_logger('legion', 'MCP_TOOLS')`; rename all call sites
- **`legion_coordinator.py`**: Remove inline `import logging; logging.info(...)` inside `rebuild_capability_registry`; add module-level `legion_logger = get_logger('legion', 'LEGION_COORDINATOR')`
- **`history_rotator.py`**: Replace `import logging` + `logger = logging.getLogger(__name__)` with `legion_logger = get_logger('legion', 'HISTORY_ROTATOR')`; rename all call sites — **fixes silent INFO drop** (root logger discards INFO when `--debug-legion` is off)

## Testing
- `uv run ruff check src/legion/` — zero violations
- `uv run pytest src/tests/ -k "legion or overseer or mcp_tools"` — 106 passed, 10 pre-existing failures in `test_overseer_reparent.py` (unrelated: mock not updated for `get_descendants()` from PR #1452)
- No behavior change: ERROR+ records still reach `error.log` and console via the shared handler on the `'legion'` logger; INFO/DEBUG gate on `--debug-legion` as intended

🤖 Generated with [Claude Code](https://claude.com/claude-code)