### PR TITLE
feat: LiteLLM Phase 2 — session integration

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -5,6 +5,7 @@ Handles application config file creation, loading, and validation.
 Config file location: ~/.config/cc_webui/config.json
 """
 
+import asyncio
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -514,6 +515,28 @@ def save_config(config: AppConfig, config_file: Path = CONFIG_FILE) -> None:
     """Save config to file."""
     config_file.parent.mkdir(parents=True, exist_ok=True)
     config_file.write_text(json.dumps(config.to_dict(), indent=2) + "\n")
+
+
+class AppConfigManager:
+    """Async wrapper around load_config/save_config with in-memory cache and write lock."""
+
+    def __init__(self, config_file: Path = CONFIG_FILE):
+        self._config_file = config_file
+        self._cache: AppConfig | None = None
+        self._lock = asyncio.Lock()
+
+    async def get_config(self) -> AppConfig:
+        if self._cache is not None:
+            return self._cache
+        async with self._lock:
+            if self._cache is None:
+                self._cache = load_config(self._config_file)
+            return self._cache
+
+    async def save_config(self, config: AppConfig) -> None:
+        async with self._lock:
+            save_config(config, self._config_file)
+            self._cache = config
 
 
 def check_network_binding(host: str, config: AppConfig, config_file: Path = CONFIG_FILE) -> bool:

--- a/src/config_resolution.py
+++ b/src/config_resolution.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 PROFILE_AREAS: dict[str, set[str]] = {
     "model": {
         "model", "thinking_mode", "thinking_budget_tokens", "effort",
+        "provider_catalog_id", "provider_model_id",
     },
     "permissions": {
         "permission_mode", "allowed_tools", "disallowed_tools",

--- a/src/litellm_proxy_manager.py
+++ b/src/litellm_proxy_manager.py
@@ -14,6 +14,9 @@ if TYPE_CHECKING:
 
 legion_logger = get_logger("legion", category="LITELLM_PROXY")
 
+# Separator between catalog_id and model_id in LiteLLM model_name aliases.
+MODEL_ALIAS_SEP = "--"
+
 
 class LiteLLMProxyManager:
     """
@@ -30,6 +33,7 @@ class LiteLLMProxyManager:
         self._vault = vault
         self._port = port
         self._key_registry: dict[str, str] = {}  # api_key -> session_id
+        self._routing_registry: dict[str, dict] = {}  # session_id -> {virtual_key, base_url}
         self._server_task: asyncio.Task | None = None
         self._rebuild_lock = asyncio.Lock()
         self._running = False
@@ -96,6 +100,20 @@ class LiteLLMProxyManager:
         """Return session_id for api_key, or None if not registered."""
         return self._key_registry.get(api_key)
 
+    # ── Routing Registry ──────────────────────────────────────────────────────
+
+    def register_session_routing(self, session_id: str, virtual_key: str, base_url: str) -> None:
+        """Store virtual key + base URL for a session (used by Docker delivery, Phase 3)."""
+        self._routing_registry[session_id] = {"virtual_key": virtual_key, "base_url": base_url}
+
+    def unregister_session_routing(self, session_id: str) -> None:
+        """Remove routing entry for session_id (no-op if absent)."""
+        self._routing_registry.pop(session_id, None)
+
+    def get_session_routing(self, session_id: str) -> dict | None:
+        """Return {virtual_key, base_url} for session_id, or None if not registered."""
+        return self._routing_registry.get(session_id)
+
     # ── LiteLLM Custom Auth ────────────────────────────────────────────────
 
     async def auth_callback(self, request, api_key: str):
@@ -119,7 +137,7 @@ class LiteLLMProxyManager:
         for entry in entries:
             resolved_params = await self._catalog_manager.resolve_params(entry, self._vault)
             for model in entry.get("models", []):
-                model_name = f"{entry['id']}--{model['id']}"
+                model_name = f"{entry['id']}{MODEL_ALIAS_SEP}{model['id']}"
                 model_list.append({
                     "model_name": model_name,
                     "litellm_params": {

--- a/src/routers/_models.py
+++ b/src/routers/_models.py
@@ -248,6 +248,8 @@ class TemplateUpdateRequest(BaseModel):
     env_scrub_enabled: bool | None = None
     # Non-secret direct env passthrough (issue #1396)
     extra_env: dict[str, str] | None = None
+    provider_catalog_id: str | None = None
+    provider_model_id: str | None = None
     # Composable profiles (issue #1062)
     profile_ids: dict[str, str] | None = None
     # Issue #1230: full config dict (preferred over flat fields above)

--- a/src/routers/templates.py
+++ b/src/routers/templates.py
@@ -95,6 +95,8 @@ def build_router(webui) -> APIRouter:
             env_scrub_enabled=request.env_scrub_enabled,
             # Non-secret direct env passthrough (issue #1396)
             extra_env=request.extra_env,
+            provider_catalog_id=request.provider_catalog_id,
+            provider_model_id=request.provider_model_id,
             profile_ids=request.profile_ids,
         )
 

--- a/src/session_config.py
+++ b/src/session_config.py
@@ -82,6 +82,10 @@ class SessionConfig(BaseModel):
     # Template linkage (issue #1059)
     template_id: str | None = None
 
+    # Provider catalog routing (issue #1427)
+    provider_catalog_id: str | None = None
+    provider_model_id: str | None = None
+
 
 # Fields that exist on both MinionTemplate and SessionConfig (the mergeable set).
 # Excludes identity fields (template_id, name, role, description, capabilities,
@@ -100,6 +104,7 @@ CONFIG_FIELDS: set[str] = {
     "skill_creating_enabled",
     "mcp_server_ids", "enable_claudeai_mcp_servers", "strict_mcp_config",
     "bare_mode", "env_scrub_enabled", "extra_env",
+    "provider_catalog_id", "provider_model_id",
 }
 
 # Default values for all CONFIG_FIELDS — derived from a fresh SessionConfig instance.

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -26,6 +26,7 @@ from .claude_sdk import ClaudeSDK
 from .config_resolution import resolve_effective_config
 from .data_storage import DataStorageManager
 from .hooks.pretooluse_handler import InternalPermissionHandler
+from .litellm_proxy_manager import MODEL_ALIAS_SEP
 from .logging_config import get_logger
 from .mcp_config_manager import McpServerType
 from .message_parser import MessageParser, MessageProcessor
@@ -222,7 +223,7 @@ class SessionCoordinator:
     - Real-time communication pipeline
     """
 
-    def __init__(self, data_dir: Path = None, experimental: bool = False):
+    def __init__(self, data_dir: Path = None, experimental: bool = False, litellm_proxy_manager=None):
         self.data_dir = data_dir or Path("data")
         self.experimental = experimental
         self.session_manager = SessionManager(self.data_dir)
@@ -271,6 +272,8 @@ class SessionCoordinator:
 
         # Track applied permission updates for state management
         self._permission_updates: dict[str, list[dict]] = {}  # session_id -> list of applied updates
+
+        self.litellm_proxy_manager = litellm_proxy_manager
 
         # Display projections per session (Issue #310)
         # Tracks tool lifecycle state and computes display metadata for frontend
@@ -1494,6 +1497,23 @@ class SessionCoordinator:
                     update={"auto_memory_directory": str(_session_memory_dir)}
                 )
 
+            litellm_env: dict[str, str] = {}
+            catalog_model_update: dict = {}
+            _proxy_mgr = self.litellm_proxy_manager
+            if (
+                effective_config.provider_catalog_id
+                and effective_config.provider_model_id
+                and _proxy_mgr is not None
+            ):
+                virtual_key = _proxy_mgr.register_session_key(session_id)
+                model_alias = f"{effective_config.provider_catalog_id}{MODEL_ALIAS_SEP}{effective_config.provider_model_id}"
+                base_url = f"http://127.0.0.1:{_proxy_mgr.port}/"
+                catalog_model_update["model"] = model_alias
+                if effective_config.docker_enabled:
+                    _proxy_mgr.register_session_routing(session_id, virtual_key, base_url)
+                else:
+                    litellm_env = {"ANTHROPIC_BASE_URL": base_url, "ANTHROPIC_API_KEY": virtual_key}
+
             # Override 3 fields computed earlier in this method:
             #   system_prompt — assembled above (includes legion guide, history ref, etc.)
             #   allowed_tools — merged MCP + session tools list built above
@@ -1502,6 +1522,7 @@ class SessionCoordinator:
                 "system_prompt": minion_system_prompt,
                 "allowed_tools": all_tools,
                 "cli_path": effective_cli_path,
+                **catalog_model_update,
             })
 
             # Issue #906: Custom auto-memory directory (claude mode + directory set) — create dir
@@ -1518,6 +1539,15 @@ class SessionCoordinator:
                 is_legion=("legion" in mcp_servers),
             )
 
+            # extra_env merge order: user-set < docker wrapper vars < litellm routing.
+            _merged_extra_env: dict[str, str] = {}
+            if effective_config.extra_env:
+                _merged_extra_env.update(effective_config.extra_env)
+            if docker_env_vars:
+                _merged_extra_env.update(docker_env_vars)
+            if litellm_env:
+                _merged_extra_env.update(litellm_env)
+
             sdk = self._sdk_factory(
                 session_id=session_id,
                 working_directory=session_info.working_directory,
@@ -1533,7 +1563,7 @@ class SessionCoordinator:
                 mcp_servers=mcp_servers if mcp_servers else None,
                 experimental=self.experimental,
                 stderr_callback=self._create_stderr_callback(session_id),
-                extra_env=docker_env_vars if docker_env_vars else None,
+                extra_env=_merged_extra_env,
                 permission_handler=permission_handler,
             )
             # Issue #707: Set auto-approval callback so can_use_tool can notify us
@@ -1653,6 +1683,10 @@ class SessionCoordinator:
             if sdk:
                 await sdk.terminate()
                 del self._active_sdks[session_id]
+
+            if self.litellm_proxy_manager is not None:
+                self.litellm_proxy_manager.unregister_session_key(session_id)
+                self.litellm_proxy_manager.unregister_session_routing(session_id)
 
             # Terminate session through manager
             success = await self.session_manager.terminate_session(session_id)

--- a/src/template_manager.py
+++ b/src/template_manager.py
@@ -346,6 +346,8 @@ class TemplateManager:
         env_scrub_enabled: bool | None = None,
         # Non-secret direct env passthrough (issue #1396)
         extra_env: dict[str, str] | None = None,
+        provider_catalog_id: str | None = None,
+        provider_model_id: str | None = None,
         # Deprecated: template_overrides absorbed into config
         template_overrides: dict[str, Any] | None = None,
     ) -> MinionTemplate:
@@ -417,6 +419,8 @@ class TemplateManager:
             "bare_mode": bare_mode,
             "env_scrub_enabled": env_scrub_enabled,
             "extra_env": extra_env,
+            "provider_catalog_id": provider_catalog_id,
+            "provider_model_id": provider_model_id,
         }
         for field_name, value in local_vars.items():
             if value is not None and field_name in CONFIG_FIELDS:

--- a/src/tests/test_app_config_manager.py
+++ b/src/tests/test_app_config_manager.py
@@ -1,0 +1,71 @@
+"""Unit tests for AppConfigManager — issue #1427 Phase 2."""
+
+import asyncio
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from src.config_manager import AppConfig, AppConfigManager
+
+
+def _write_config(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data) + "\n")
+
+
+@pytest.mark.asyncio
+async def test_get_config_returns_defaults_for_missing_file():
+    with tempfile.TemporaryDirectory() as tmp:
+        cfg_file = Path(tmp) / "config.json"
+        mgr = AppConfigManager(config_file=cfg_file)
+        config = await mgr.get_config()
+    assert isinstance(config, AppConfig)
+
+
+@pytest.mark.asyncio
+async def test_get_config_caches_result():
+    with tempfile.TemporaryDirectory() as tmp:
+        cfg_file = Path(tmp) / "config.json"
+        _write_config(cfg_file, {})
+        mgr = AppConfigManager(config_file=cfg_file)
+        first = await mgr.get_config()
+        second = await mgr.get_config()
+    assert first is second
+
+
+@pytest.mark.asyncio
+async def test_save_config_persists_to_disk_and_updates_cache():
+    with tempfile.TemporaryDirectory() as tmp:
+        cfg_file = Path(tmp) / "config.json"
+        mgr = AppConfigManager(config_file=cfg_file)
+        config = await mgr.get_config()
+        config.legion.max_concurrent_minions = 99
+        await mgr.save_config(config)
+
+        # Cache should be updated
+        cached = await mgr.get_config()
+        assert cached.legion.max_concurrent_minions == 99
+
+        # Disk should be updated
+        fresh = AppConfigManager(config_file=cfg_file)
+        disk_config = await fresh.get_config()
+        assert disk_config.legion.max_concurrent_minions == 99
+
+
+@pytest.mark.asyncio
+async def test_concurrent_save_config_serializes():
+    """Lock must prevent interleaved writes."""
+    with tempfile.TemporaryDirectory() as tmp:
+        cfg_file = Path(tmp) / "config.json"
+        mgr = AppConfigManager(config_file=cfg_file)
+
+        async def _save(n: int) -> None:
+            config = await mgr.get_config()
+            config.legion.max_concurrent_minions = n
+            await mgr.save_config(config)
+
+        await asyncio.gather(*[_save(i) for i in range(10)])
+        final = await mgr.get_config()
+        # Any one of the values is fine — we just need no exception and a valid int
+        assert isinstance(final.legion.max_concurrent_minions, int)

--- a/src/tests/test_claude_sdk_env.py
+++ b/src/tests/test_claude_sdk_env.py
@@ -118,3 +118,11 @@ class TestResolveEnvVars:
         with patch("src.config_manager.load_config", return_value=_suppression_off_config()):
             env = sdk._resolve_env_vars()
         assert env["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"] == "1"
+
+    def test_issue_1427_extra_env_reaches_non_docker_sdk(self):
+        """Regression: extra_env passed to ClaudeSDK constructor appears in _resolve_env_vars() output."""
+        sdk = _make_sdk(extra_env={"FOO": "bar", "ANOTHER": "val"})
+        with patch("src.config_manager.load_config", return_value=_suppression_off_config()):
+            env = sdk._resolve_env_vars()
+        assert env.get("FOO") == "bar"
+        assert env.get("ANOTHER") == "val"

--- a/src/tests/test_litellm_proxy_manager.py
+++ b/src/tests/test_litellm_proxy_manager.py
@@ -33,6 +33,7 @@ def _make_manager():
         mgr._vault = vault
         mgr._port = 4000
         mgr._key_registry = {}
+        mgr._routing_registry = {}
         mgr._server_task = None
         mgr._rebuild_lock = asyncio.Lock()
         mgr._running = False
@@ -128,3 +129,41 @@ async def test_auth_callback_invalid_key_raises_401(manager):
 
 def test_is_running_false_before_start(manager):
     assert manager.is_running is False
+
+
+# ── Routing Registry Tests (issue #1427 Phase 2) ──────────────────────────────
+
+
+def test_register_session_routing_stores_entry(manager):
+    manager.register_session_routing("sess-1", "lc-abc", "http://127.0.0.1:4000/")
+    entry = manager.get_session_routing("sess-1")
+    assert entry == {"virtual_key": "lc-abc", "base_url": "http://127.0.0.1:4000/"}
+
+
+def test_get_session_routing_unknown_returns_none(manager):
+    assert manager.get_session_routing("never-registered") is None
+
+
+def test_unregister_session_routing_removes_entry(manager):
+    manager.register_session_routing("sess-2", "lc-xyz", "http://127.0.0.1:4000/")
+    manager.unregister_session_routing("sess-2")
+    assert manager.get_session_routing("sess-2") is None
+
+
+def test_unregister_session_routing_nonexistent_is_noop(manager):
+    manager.unregister_session_routing("does-not-exist")
+    assert manager._routing_registry == {}
+
+
+def test_routing_registry_independent_of_key_registry(manager):
+    """Key registry and routing registry are separate — operations on one don't affect the other."""
+    manager.register_session_key("sess-3")
+    manager.register_session_routing("sess-3", "lc-key", "http://127.0.0.1:4000/")
+
+    manager.unregister_session_key("sess-3")
+    # Routing entry should still be present
+    assert manager.get_session_routing("sess-3") is not None
+
+    manager.unregister_session_routing("sess-3")
+    # Key registry should still be clean
+    assert manager._key_registry == {}

--- a/src/tests/test_session_config.py
+++ b/src/tests/test_session_config.py
@@ -39,3 +39,24 @@ def test_extra_env_in_defaults():
     """extra_env must appear in DEFAULTS with value None."""
     assert "extra_env" in DEFAULTS
     assert DEFAULTS["extra_env"] is None
+
+
+# ── Issue #1427 Phase 2: provider catalog routing fields ───────────────────────
+
+
+def test_provider_catalog_id_defaults_none():
+    assert SessionConfig().provider_catalog_id is None
+
+
+def test_provider_model_id_defaults_none():
+    assert SessionConfig().provider_model_id is None
+
+
+def test_provider_catalog_fields_in_config_fields():
+    assert "provider_catalog_id" in CONFIG_FIELDS
+    assert "provider_model_id" in CONFIG_FIELDS
+
+
+def test_provider_catalog_fields_in_defaults():
+    assert DEFAULTS.get("provider_catalog_id") is None
+    assert DEFAULTS.get("provider_model_id") is None

--- a/src/tests/test_session_provider_routing.py
+++ b/src/tests/test_session_provider_routing.py
@@ -1,0 +1,305 @@
+"""Tests for LiteLLM catalog routing in session_coordinator — issue #1427 Phase 2."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+import pytest
+
+from ..session_config import SessionConfig
+from ..session_coordinator import SessionCoordinator
+
+
+def _make_proxy_manager(port: int = 4000) -> MagicMock:
+    """Return a mock LiteLLMProxyManager."""
+    mgr = MagicMock()
+    mgr.port = port
+    mgr.is_running = True
+    mgr.register_session_key.return_value = "lc-test-virtual-key"
+    mgr.register_session_routing = MagicMock()
+    mgr.unregister_session_key = MagicMock()
+    mgr.unregister_session_routing = MagicMock()
+    return mgr
+
+
+def _make_sdk_factory():
+    """Return (factory, mock_instance) pair."""
+    mock_sdk = AsyncMock()
+    mock_sdk.start.return_value = True
+    mock_sdk.is_running.return_value = False
+    factory = Mock(return_value=mock_sdk)
+    return factory, mock_sdk
+
+
+@pytest.fixture
+async def coordinator():
+    with tempfile.TemporaryDirectory() as tmp:
+        coord = SessionCoordinator(Path(tmp))
+        await coord.initialize()
+        yield coord
+        await coord.cleanup()
+
+
+async def _create_session(coordinator, config: SessionConfig, working_dir: str = "/tmp"):
+    """Helper to create a project+session and return session_id."""
+    project = await coordinator.project_manager.create_project(
+        name="Test", working_directory=working_dir
+    )
+    import uuid
+    session_id = str(uuid.uuid4())
+    await coordinator.create_session(
+        session_id=session_id,
+        project_id=project.project_id,
+        config=config,
+    )
+    return session_id
+
+
+# ── P2-A: Non-Docker + catalog selected ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_non_docker_catalog_injects_base_url_and_api_key(coordinator):
+    """SDK factory receives ANTHROPIC_BASE_URL + ANTHROPIC_API_KEY in extra_env."""
+    proxy = _make_proxy_manager(port=4000)
+    coordinator.litellm_proxy_manager = proxy
+
+    config = SessionConfig(
+        provider_catalog_id="bedrock",
+        provider_model_id="claude-3-5-sonnet",
+    )
+    session_id = await _create_session(coordinator, config)
+
+    factory, _ = _make_sdk_factory()
+    coordinator.set_sdk_factory(factory)
+
+    await coordinator.start_session(session_id)
+
+    call_kwargs = factory.call_args.kwargs
+    extra_env = call_kwargs.get("extra_env") or {}
+    assert extra_env.get("ANTHROPIC_BASE_URL") == "http://127.0.0.1:4000/"
+    assert extra_env.get("ANTHROPIC_API_KEY") == "lc-test-virtual-key"
+
+
+@pytest.mark.asyncio
+async def test_non_docker_catalog_overrides_model_to_alias(coordinator):
+    """SDK config.model is set to '{catalog_id}--{model_id}'."""
+    proxy = _make_proxy_manager()
+    coordinator.litellm_proxy_manager = proxy
+
+    config = SessionConfig(
+        provider_catalog_id="bedrock",
+        provider_model_id="claude-3-5-sonnet",
+    )
+    session_id = await _create_session(coordinator, config)
+
+    factory, _ = _make_sdk_factory()
+    coordinator.set_sdk_factory(factory)
+
+    await coordinator.start_session(session_id)
+
+    sdk_config = factory.call_args.kwargs["config"]
+    assert sdk_config.model == "bedrock--claude-3-5-sonnet"
+
+
+@pytest.mark.asyncio
+async def test_non_docker_catalog_calls_register_session_key(coordinator):
+    """register_session_key is called once with the session_id."""
+    proxy = _make_proxy_manager()
+    coordinator.litellm_proxy_manager = proxy
+
+    config = SessionConfig(
+        provider_catalog_id="my-catalog",
+        provider_model_id="my-model",
+    )
+    session_id = await _create_session(coordinator, config)
+
+    factory, _ = _make_sdk_factory()
+    coordinator.set_sdk_factory(factory)
+
+    await coordinator.start_session(session_id)
+
+    proxy.register_session_key.assert_called_once_with(session_id)
+
+
+@pytest.mark.asyncio
+async def test_non_docker_catalog_does_not_call_register_session_routing(coordinator):
+    """register_session_routing is NOT called for non-Docker sessions."""
+    proxy = _make_proxy_manager()
+    coordinator.litellm_proxy_manager = proxy
+
+    config = SessionConfig(
+        provider_catalog_id="cat",
+        provider_model_id="mod",
+    )
+    session_id = await _create_session(coordinator, config)
+
+    factory, _ = _make_sdk_factory()
+    coordinator.set_sdk_factory(factory)
+
+    await coordinator.start_session(session_id)
+
+    proxy.register_session_routing.assert_not_called()
+
+
+# ── P2-B: Non-Docker + no catalog (native pass-through) ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_native_session_no_catalog_no_url_override(coordinator):
+    """Sessions without catalog selection get no ANTHROPIC_BASE_URL override."""
+    proxy = _make_proxy_manager()
+    coordinator.litellm_proxy_manager = proxy
+
+    config = SessionConfig()  # No provider_catalog_id
+    session_id = await _create_session(coordinator, config)
+
+    factory, _ = _make_sdk_factory()
+    coordinator.set_sdk_factory(factory)
+
+    await coordinator.start_session(session_id)
+
+    call_kwargs = factory.call_args.kwargs
+    extra_env = call_kwargs.get("extra_env") or {}
+    assert "ANTHROPIC_BASE_URL" not in extra_env
+    assert "ANTHROPIC_API_KEY" not in extra_env
+
+
+@pytest.mark.asyncio
+async def test_native_session_model_unchanged(coordinator):
+    """Sessions without catalog selection keep their original model string."""
+    proxy = _make_proxy_manager()
+    coordinator.litellm_proxy_manager = proxy
+
+    config = SessionConfig(model="claude-opus-4-7")
+    session_id = await _create_session(coordinator, config)
+
+    factory, _ = _make_sdk_factory()
+    coordinator.set_sdk_factory(factory)
+
+    await coordinator.start_session(session_id)
+
+    sdk_config = factory.call_args.kwargs["config"]
+    assert sdk_config.model == "claude-opus-4-7"
+
+
+# ── P2-C: extra_env reaches non-Docker SDK (regression fix) ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_extra_env_reaches_non_docker_sdk(coordinator):
+    """Non-Docker sessions receive effective_config.extra_env (regression test)."""
+    config = SessionConfig(extra_env={"MY_TEST_VAR": "hello"})
+    session_id = await _create_session(coordinator, config)
+
+    factory, _ = _make_sdk_factory()
+    coordinator.set_sdk_factory(factory)
+
+    await coordinator.start_session(session_id)
+
+    call_kwargs = factory.call_args.kwargs
+    extra_env = call_kwargs.get("extra_env") or {}
+    assert extra_env.get("MY_TEST_VAR") == "hello"
+
+
+# ── P2-D: Virtual key lifecycle ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_terminate_unregisters_key_and_routing(coordinator):
+    """terminate_session calls unregister_session_key and unregister_session_routing."""
+    proxy = _make_proxy_manager()
+    coordinator.litellm_proxy_manager = proxy
+
+    config = SessionConfig(
+        provider_catalog_id="cat",
+        provider_model_id="mod",
+    )
+    session_id = await _create_session(coordinator, config)
+
+    factory, mock_sdk = _make_sdk_factory()
+    mock_sdk.terminate = AsyncMock()
+    coordinator.set_sdk_factory(factory)
+    await coordinator.start_session(session_id)
+
+    await coordinator.terminate_session(session_id)
+
+    proxy.unregister_session_key.assert_called_with(session_id)
+    proxy.unregister_session_routing.assert_called_with(session_id)
+
+
+# ── Backward compat: no proxy manager injected ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_no_proxy_manager_start_is_noop(coordinator):
+    """start_session with no proxy manager and catalog set completes without error."""
+    assert coordinator.litellm_proxy_manager is None
+
+    config = SessionConfig(
+        provider_catalog_id="cat",
+        provider_model_id="mod",
+    )
+    session_id = await _create_session(coordinator, config)
+
+    factory, _ = _make_sdk_factory()
+    coordinator.set_sdk_factory(factory)
+
+    # Should not raise
+    result = await coordinator.start_session(session_id)
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_no_proxy_manager_terminate_is_noop(coordinator):
+    """terminate_session with no proxy manager does not raise."""
+    assert coordinator.litellm_proxy_manager is None
+
+    config = SessionConfig()
+    session_id = await _create_session(coordinator, config)
+
+    factory, mock_sdk = _make_sdk_factory()
+    mock_sdk.terminate = AsyncMock()
+    coordinator.set_sdk_factory(factory)
+    await coordinator.start_session(session_id)
+
+    # Should not raise
+    await coordinator.terminate_session(session_id)
+
+
+# ── Docker + catalog: routing stashed, not in extra_env ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_docker_catalog_routes_via_registry_not_env(coordinator):
+    """Docker sessions with catalog call register_session_routing, not extra_env injection.
+
+    Using cli_path to bypass the docker-resolve block while keeping docker_enabled=True,
+    so the catalog injection sees docker_enabled and calls register_session_routing.
+    """
+    proxy = _make_proxy_manager(port=4000)
+    coordinator.litellm_proxy_manager = proxy
+
+    # cli_path bypasses the `if effective_config.docker_enabled and not effective_config.cli_path:`
+    # block, but docker_enabled=True is still visible to the catalog injection code.
+    config = SessionConfig(
+        provider_catalog_id="cat",
+        provider_model_id="mod",
+        docker_enabled=True,
+        cli_path="/usr/bin/claude",
+    )
+    session_id = await _create_session(coordinator, config)
+
+    factory, _ = _make_sdk_factory()
+    coordinator.set_sdk_factory(factory)
+
+    await coordinator.start_session(session_id)
+
+    proxy.register_session_routing.assert_called_once_with(
+        session_id, "lc-test-virtual-key", "http://127.0.0.1:4000/"
+    )
+
+    # ANTHROPIC_BASE_URL must NOT appear in extra_env for Docker sessions
+    call_kwargs = factory.call_args.kwargs
+    extra_env = call_kwargs.get("extra_env") or {}
+    assert "ANTHROPIC_BASE_URL" not in extra_env

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -171,6 +171,19 @@ class ClaudeWebUI:
         )
         self.coordinator._watchdog = self._watchdog
 
+        from .config_manager import AppConfigManager
+        from .litellm_proxy_manager import LiteLLMProxyManager
+        from .provider_catalog import ProviderCatalogManager
+        self.app_config_manager = AppConfigManager(config_file=config_file) if config_file else AppConfigManager()
+        self.provider_catalog_manager = ProviderCatalogManager(self.app_config_manager)
+        _litellm_port = _cfg.provider_catalog.litellm_port
+        self.litellm_proxy_manager = LiteLLMProxyManager(
+            self.provider_catalog_manager,
+            self.coordinator.credential_vault,
+            port=_litellm_port,
+        )
+        self.coordinator.litellm_proxy_manager = self.litellm_proxy_manager
+
         # Issue #1127: Audit subsystem — analytics DB + AuditWriter
         _analytics_db_path = (data_dir or Path("data")) / "analytics.db"
         self._analytics_db = AnalyticsDB(_analytics_db_path)
@@ -483,6 +496,14 @@ class ClaudeWebUI:
         """Initialize the WebUI application"""
         from .config_manager import load_config
         await self.coordinator.initialize()
+
+        try:
+            await self.litellm_proxy_manager.start()
+        except Exception:
+            logger.exception(
+                "LiteLLM proxy failed to start — catalog-selected sessions will be unavailable; "
+                "native sessions continue normally"
+            )
         config = load_config(self.config_file) if self.config_file else load_config()
         if config.features.skill_sync_enabled:
             await self.skill_manager.sync()
@@ -800,6 +821,10 @@ class ClaudeWebUI:
         # Issue #1130: Stop session watchdog service
         if hasattr(self, '_watchdog') and self._watchdog is not None:
             await self._watchdog.stop()
+        try:
+            await self.litellm_proxy_manager.stop()
+        except Exception:
+            logger.exception("Error stopping LiteLLM proxy during cleanup")
         await self.coordinator.cleanup()
         logger.info("WebUI cleanup completed")
 


### PR DESCRIPTION
## Summary

Part of #1427

Wire LiteLLM proxy into the session lifecycle so catalog-selected sessions route through the local proxy instead of Anthropic directly.

## Changes Made

- **AppConfigManager**: async wrapper with double-checked-locking cache around `load_config`/`save_config`
- **SessionConfig**: `provider_catalog_id` and `provider_model_id` fields added; registered in `CONFIG_FIELDS` and `PROFILE_AREAS["model"]`
- **LiteLLMProxyManager**: `MODEL_ALIAS_SEP` constant; routing registry (`register/unregister/get_session_routing`) for Docker delivery (Phase 3)
- **SessionCoordinator.start_session()**: catalog injection — mint virtual key, build model alias (`{catalog_id}--{model_id}`), inject `ANTHROPIC_BASE_URL`/`ANTHROPIC_API_KEY` into `extra_env` for non-Docker; stash in routing registry for Docker; fix `extra_env` merge order (user-set < docker wrapper < litellm routing)
- **SessionCoordinator.terminate_session()**: unregister virtual key and routing entry on teardown
- **ClaudeWebUI**: instantiate `AppConfigManager`, `ProviderCatalogManager`, `LiteLLMProxyManager` on startup; wire proxy into coordinator; start/stop in `initialize()`/`cleanup()` with non-fatal error handling
- **TemplateUpdateRequest / update_template()**: expose `provider_catalog_id` and `provider_model_id` to keep structural coverage tests green
- **Tests**: `test_app_config_manager.py`, `test_session_provider_routing.py` (new); routing registry tests in `test_litellm_proxy_manager.py`; provider field tests in `test_session_config.py`; `extra_env` regression in `test_claude_sdk_env.py`

## Manual Smoke-Test Checklist

- [ ] Start backend with a configured provider catalog entry; verify LiteLLM proxy starts on the configured port
- [ ] Create a session with `provider_catalog_id` + `provider_model_id` set; confirm `ANTHROPIC_BASE_URL` and `ANTHROPIC_API_KEY` appear in SDK env (check `sdk_debug.log`)
- [ ] Confirm model string in SDK config is `{catalog_id}--{model_id}` (not the raw model id)
- [ ] Send a message in the catalog session; confirm traffic routes through the proxy (check LiteLLM logs)
- [ ] Terminate the catalog session; confirm virtual key is removed from proxy (no leftover keys)
- [ ] Create a session WITHOUT `provider_catalog_id`; confirm no `ANTHROPIC_BASE_URL` override and native model string preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)