### PR TITLE
feat: LiteLLM Phase 3 — Docker proxy routing

### DIFF
--- a/src/docker/proxy/addon.py
+++ b/src/docker/proxy/addon.py
@@ -492,6 +492,7 @@ class ProxyAddon:
         self._session_id: str = ""
         self._records: dict[str, dict] = {}        # placeholder → full record dict
         self._refresh_locks: dict[str, asyncio.Lock] = {}
+        self._routing: dict = {"hostname_rewrites": {}, "virtual_key": None}
         self.allowed_domains: set[str] = set()
         self.logger = logging.getLogger("proxy.addon")
         self._log_file = None
@@ -516,7 +517,7 @@ class ProxyAddon:
         ctx.log.info(f"[proxy] Loaded {len(self.allowed_domains)} allowed domains")
 
     async def running(self) -> None:
-        """Fetch secrets after proxy is fully started (async-capable hook)."""
+        """Fetch secrets and routing config after proxy is fully started (async-capable hook)."""
         if not self._session_id:
             return  # load() didn't complete successfully
         try:
@@ -528,13 +529,44 @@ class ProxyAddon:
         except Exception as exc:
             ctx.log.error(f"[proxy] Failed to fetch secrets for session {self._session_id}: {exc}")
 
+        try:
+            self._routing = await self._fetch_routing()
+            if self._routing["hostname_rewrites"]:
+                ctx.log.info(
+                    f"[proxy] Routing enabled: {self._routing['hostname_rewrites']}"
+                )
+        except Exception as exc:
+            ctx.log.warn(
+                f"[proxy] Failed to fetch routing for session {self._session_id}: {exc}"
+            )
+            self._routing = {"hostname_rewrites": {}, "virtual_key": None}
+
     async def requestheaders(self, flow: http.HTTPFlow) -> None:
         """Fires after client headers arrive, before upstream forwarding.
 
-        Performs allowlist enforcement, OAuth2 refresh, and all header/query
-        injection. Body injection is deferred to request() where content is
-        available (or no-ops when streaming).
+        Performs LiteLLM hostname rewrite (Phase 3), allowlist enforcement,
+        OAuth2 refresh, and all header/query injection. Body injection is
+        deferred to request() where content is available (or no-ops when streaming).
         """
+        # ── LiteLLM hostname rewrite (Phase 3) ────────────────────────────────
+        # Applied before the allowlist check so the rewritten host
+        # (cc-webui.internal) is what gets allowlisted — it is already present
+        # in allowlist.json.
+        rewrites = self._routing["hostname_rewrites"]
+        vkey = self._routing.get("virtual_key")
+        src_host = flow.request.pretty_host
+        if src_host in rewrites and vkey:
+            target = rewrites[src_host]              # e.g. "cc-webui.internal:4000"
+            host_part, _, port_str = target.partition(":")
+            port = int(port_str) if port_str else 80
+            flow.request.host = host_part
+            flow.request.port = port
+            flow.request.scheme = "http"             # LiteLLM is plain HTTP on the host
+            flow.request.headers["x-api-key"] = vkey
+            flow.request.headers["Authorization"] = f"Bearer {vkey}"
+            flow.metadata["routed_via_litellm"] = True
+            ctx.log.info(f"[proxy] Routed {src_host} -> {target}")
+
         host = flow.request.pretty_host
         client_ip = (
             flow.client_conn.peername[0] if flow.client_conn.peername else "unknown"
@@ -555,6 +587,11 @@ class ProxyAddon:
         for ph, record in self._records.items():
             target_hosts = record.get("target_hosts") or []
             if not _host_matches_targets(host, target_hosts):
+                continue
+            # Sentinel guard: when the request was rewritten to LiteLLM, skip
+            # secret injection so Anthropic-targeted secrets don't overwrite the
+            # virtual key that was just installed by the rewrite block above.
+            if flow.metadata.get("routed_via_litellm"):
                 continue
             secret_type = record.get("type", "generic")
 
@@ -712,9 +749,9 @@ class ProxyAddon:
     # Internal helpers
     # ------------------------------------------------------------------
 
-    async def _fetch_resolve(self) -> dict[str, dict]:
-        """GET /api/sessions/{id}/secrets/resolve → {placeholder: record_dict}."""
-        url = f"{WEBUI_BASE_URL}/api/sessions/{self._session_id}/secrets/resolve"
+    async def _fetch_json(self, path: str) -> dict:
+        """GET {WEBUI_BASE_URL}{path} with session Bearer auth. Returns parsed JSON."""
+        url = f"{WEBUI_BASE_URL}{path}"
         async with httpx.AsyncClient() as client:
             resp = await client.get(
                 url,
@@ -722,12 +759,20 @@ class ProxyAddon:
                 timeout=10.0,
             )
             resp.raise_for_status()
-            data = resp.json()
+            return resp.json()
+
+    async def _fetch_resolve(self) -> dict[str, dict]:
+        """GET /api/sessions/{id}/secrets/resolve → {placeholder: record_dict}."""
+        data = await self._fetch_json(f"/api/sessions/{self._session_id}/secrets/resolve")
         return {
             secret["placeholder"]: secret
             for secret in data.get("secrets", [])
             if secret.get("placeholder")
         }
+
+    async def _fetch_routing(self) -> dict:
+        """GET /api/sessions/{id}/routing → {hostname_rewrites, virtual_key}."""
+        return await self._fetch_json(f"/api/sessions/{self._session_id}/routing")
 
     async def _get_partner_value(self, name: str) -> str:
         """Return the value of a sibling record (e.g. refresh_token) by name."""

--- a/src/litellm_proxy_manager.py
+++ b/src/litellm_proxy_manager.py
@@ -52,7 +52,8 @@ class LiteLLMProxyManager:
         await self._launch_server(model_list)
         self._running = True
         legion_logger.info(
-            f"LiteLLM proxy started on port {self._port} with {len(model_list)} model(s)"
+            f"LiteLLM proxy started on port {self._port} with {len(model_list)} model(s), "
+            f"bound to 0.0.0.0:{self._port} (auth via virtual key)"
         )
 
     async def stop(self) -> None:
@@ -114,6 +115,14 @@ class LiteLLMProxyManager:
         """Return {virtual_key, base_url} for session_id, or None if not registered."""
         return self._routing_registry.get(session_id)
 
+    def build_hostname_rewrites(self) -> dict[str, str]:
+        """Return the static hostname-rewrite map for Docker sidecars.
+
+        Keys are source hostnames the CLI contacts; values are the rewrite
+        destination (cc-webui.internal:<port>) where LiteLLM is reachable.
+        """
+        return {"api.anthropic.com": f"cc-webui.internal:{self._port}"}
+
     # ── LiteLLM Custom Auth ────────────────────────────────────────────────
 
     async def auth_callback(self, request, api_key: str):
@@ -169,6 +178,6 @@ class LiteLLMProxyManager:
 
         import uvicorn
 
-        config = uvicorn.Config(app, host="127.0.0.1", port=self._port, log_level="warning")
+        config = uvicorn.Config(app, host="0.0.0.0", port=self._port, log_level="warning")
         server = uvicorn.Server(config)
         self._server_task = asyncio.create_task(server.serve())

--- a/src/routers/__init__.py
+++ b/src/routers/__init__.py
@@ -28,6 +28,7 @@ from . import (
     queue,
     schedules,
     secrets,
+    session_routing,
     session_runtime,
     sessions,
     skills,
@@ -61,5 +62,6 @@ def register_all(app: FastAPI, webui) -> None:
     app.include_router(edit_history.build_router(webui))
     app.include_router(files.build_router(webui))
     app.include_router(projects.build_router(webui))
+    app.include_router(session_routing.build_router(webui))
     app.include_router(session_runtime.build_router(webui))
     app.include_router(sessions.build_router(webui))

--- a/src/routers/session_routing.py
+++ b/src/routers/session_routing.py
@@ -1,0 +1,45 @@
+"""
+Session routing endpoint: GET /api/sessions/{id}/routing
+
+Returns per-session LiteLLM hostname rewrites and virtual key for Docker proxy
+sidecars (Phase 3 of issue #1427).
+
+Auth: same per-session Bearer token as /secrets/resolve — reused from secrets.py.
+"""
+
+from fastapi import APIRouter, Depends
+
+from ..exception_handlers import handle_exceptions
+from .secrets import _build_session_token_auth
+
+_EMPTY_ROUTING = {"hostname_rewrites": {}, "virtual_key": None}
+
+
+def build_router(webui) -> APIRouter:
+    router = APIRouter()
+    session_token_auth = _build_session_token_auth(webui)
+
+    @router.get("/api/sessions/{session_id}/routing")
+    @handle_exceptions("get session routing")
+    async def get_session_routing(
+        session_id: str = Depends(session_token_auth),
+    ):
+        """Return LiteLLM routing config for the proxy sidecar.
+
+        Returns 200 with empty rewrites when no catalog is selected — the sidecar
+        always receives the same shape regardless of whether routing is active.
+
+        Authentication: Authorization: Bearer {session_token} (per-session token).
+        Global AuthMiddleware is bypassed via the /routing EXEMPT_SUFFIXES entry.
+        """
+        proxy_mgr = webui.litellm_proxy_manager
+        routing = proxy_mgr.get_session_routing(session_id)
+        if routing is None:
+            return _EMPTY_ROUTING
+
+        return {
+            "hostname_rewrites": proxy_mgr.build_hostname_rewrites(),
+            "virtual_key": routing["virtual_key"],
+        }
+
+    return router

--- a/src/tests/test_proxy_addon_routing.py
+++ b/src/tests/test_proxy_addon_routing.py
@@ -1,0 +1,361 @@
+"""
+Unit tests for Phase 3 LiteLLM routing in the proxy addon (issue #1427).
+
+Covers:
+  - Hostname rewrite: host, port, scheme mutated correctly
+  - Headers: x-api-key and Authorization set to virtual key
+  - Metadata sentinel: flow.metadata["routed_via_litellm"] set
+  - Allowlist still passes for rewritten host (cc-webui.internal)
+  - Negative: empty routing → flow unchanged
+  - Negative: non-Anthropic host with routing enabled → flow unchanged
+  - REQUIRED sentinel guard: secret injection skipped when routed_via_litellm set
+  - Inverse sentinel guard: routing disabled → secret injected as normal
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# mitmproxy stubs (same pattern as test_proxy_addon_1428.py)
+# ---------------------------------------------------------------------------
+
+
+class _FakeQuery:
+    def __init__(self, pairs=None):
+        self._pairs = list(pairs or [])
+
+    def items(self):
+        return list(self._pairs)
+
+    def __setitem__(self, key, value):
+        for i, (k, _) in enumerate(self._pairs):
+            if k == key:
+                self._pairs[i] = (key, value)
+                return
+        self._pairs.append((key, value))
+
+    def __getitem__(self, key):
+        for k, v in self._pairs:
+            if k == key:
+                return v
+        raise KeyError(key)
+
+    def __contains__(self, key):
+        return any(k == key for k, _ in self._pairs)
+
+
+class _FakeHeaders(dict):
+    def get(self, key, default=""):
+        for k, v in self.items():
+            if k.lower() == key.lower():
+                return v
+        return default
+
+
+class _FakeRequest:
+    __slots__ = (
+        "pretty_host", "host", "path", "method", "scheme", "port",
+        "headers", "query", "url", "content", "stream",
+    )
+
+    def __init__(self, host="api.anthropic.com", headers=None, content=None):
+        self.pretty_host = host
+        self.host = host
+        self.path = "/v1/messages"
+        self.method = "POST"
+        self.scheme = "https"
+        self.port = 443
+        self.url = f"https://{host}/v1/messages"
+        self.headers = _FakeHeaders(headers or {"x-api-key": "sk-ant-real"})
+        self.query = _FakeQuery()
+        self.content = content
+        self.stream = None
+
+
+class _FakeResponse:
+    def __init__(self, headers=None, content=b"", status_code=200):
+        self.headers = _FakeHeaders(headers or {"content-type": "application/json"})
+        self.content = content
+        self.status_code = status_code
+        self.stream = None
+
+    @staticmethod
+    def make(status, body, headers):
+        r = _FakeResponse(headers=headers, status_code=status)
+        r.content = body.encode() if isinstance(body, str) else body
+        return r
+
+
+def _install_mitmproxy_stubs():
+    class _HTTPFlow:
+        def __init__(self, host="api.anthropic.com"):
+            self.request = _FakeRequest(host=host)
+            self.response = None
+            self.client_conn = MagicMock()
+            self.client_conn.peername = ("127.0.0.1", 12345)
+            self.metadata = {}
+
+    if "mitmproxy" not in sys.modules:
+        mitmproxy_pkg = types.ModuleType("mitmproxy")
+        mitmproxy_http = types.ModuleType("mitmproxy.http")
+        mitmproxy_ctx = types.ModuleType("mitmproxy.ctx")
+        mitmproxy_tcp = types.ModuleType("mitmproxy.tcp")
+
+        mitmproxy_http.HTTPFlow = _HTTPFlow
+        mitmproxy_http.Response = _FakeResponse
+        mitmproxy_ctx.log = MagicMock()
+        mitmproxy_tcp.TCPFlow = MagicMock
+
+        sys.modules["mitmproxy"] = mitmproxy_pkg
+        sys.modules["mitmproxy.http"] = mitmproxy_http
+        sys.modules["mitmproxy.ctx"] = mitmproxy_ctx
+        sys.modules["mitmproxy.tcp"] = mitmproxy_tcp
+    else:
+        sys.modules["mitmproxy.http"].HTTPFlow = _HTTPFlow
+        sys.modules["mitmproxy.http"].Response = _FakeResponse
+        if not hasattr(sys.modules["mitmproxy.ctx"], "log"):
+            sys.modules["mitmproxy.ctx"].log = MagicMock()
+
+    if "src.docker.proxy.addon" in sys.modules:
+        del sys.modules["src.docker.proxy.addon"]
+
+
+def _make_addon(records=None, routing=None, allowed=None):
+    _install_mitmproxy_stubs()
+    from src.docker.proxy import addon as addon_mod
+
+    a = addon_mod.ProxyAddon.__new__(addon_mod.ProxyAddon)
+    a.allowed_domains = allowed if allowed is not None else {
+        "api.anthropic.com",
+        "cc-webui.internal",
+        "other.example.com",
+    }
+    a._records = {
+        r["placeholder"]: {
+            "name": r["name"],
+            "type": r.get("type", "generic"),
+            "value": r.get("value", ""),
+            "target_hosts": r.get("target_hosts", []),
+            "injection": r.get("injection", {}),
+            "placeholder": r["placeholder"],
+            "scrub": r.get("scrub", {}),
+        }
+        for r in (records or [])
+    }
+    a._refresh_locks = {ph: asyncio.Lock() for ph in a._records}
+    a._routing = routing if routing is not None else {"hostname_rewrites": {}, "virtual_key": None}
+    a._session_id = "test-1427"
+    a._session_token = "test-token"
+    a._log_file = None
+    a._socks5_log_file = None
+    a.logger = MagicMock()
+    return a
+
+
+def _flow(host="api.anthropic.com", request_headers=None):
+    _install_mitmproxy_stubs()
+    flow_cls = sys.modules["mitmproxy.http"].HTTPFlow
+    f = flow_cls(host)
+    if request_headers is not None:
+        f.request.headers = _FakeHeaders(request_headers)
+    return f
+
+
+ROUTING_ENABLED = {
+    "hostname_rewrites": {"api.anthropic.com": "cc-webui.internal:4000"},
+    "virtual_key": "lc-test-vkey-abc",
+}
+
+
+# ---------------------------------------------------------------------------
+# Positive: rewrite applied for api.anthropic.com
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hostname_rewritten_to_cc_webui_internal():
+    addon = _make_addon(routing=ROUTING_ENABLED)
+    f = _flow(host="api.anthropic.com")
+    await addon.requestheaders(f)
+    assert f.request.host == "cc-webui.internal"
+
+
+@pytest.mark.asyncio
+async def test_port_set_to_4000():
+    addon = _make_addon(routing=ROUTING_ENABLED)
+    f = _flow(host="api.anthropic.com")
+    await addon.requestheaders(f)
+    assert f.request.port == 4000
+
+
+@pytest.mark.asyncio
+async def test_scheme_set_to_http():
+    """LiteLLM is plain HTTP — upstream leg must not attempt TLS."""
+    addon = _make_addon(routing=ROUTING_ENABLED)
+    f = _flow(host="api.anthropic.com")
+    await addon.requestheaders(f)
+    assert f.request.scheme == "http"
+
+
+@pytest.mark.asyncio
+async def test_x_api_key_replaced_with_virtual_key():
+    addon = _make_addon(routing=ROUTING_ENABLED)
+    f = _flow(host="api.anthropic.com", request_headers={"x-api-key": "sk-ant-original"})
+    await addon.requestheaders(f)
+    assert f.request.headers.get("x-api-key") == "lc-test-vkey-abc"
+
+
+@pytest.mark.asyncio
+async def test_authorization_header_set_to_bearer_virtual_key():
+    addon = _make_addon(routing=ROUTING_ENABLED)
+    f = _flow(host="api.anthropic.com")
+    await addon.requestheaders(f)
+    assert f.request.headers.get("Authorization") == "Bearer lc-test-vkey-abc"
+
+
+@pytest.mark.asyncio
+async def test_metadata_sentinel_set():
+    addon = _make_addon(routing=ROUTING_ENABLED)
+    f = _flow(host="api.anthropic.com")
+    await addon.requestheaders(f)
+    assert f.metadata.get("routed_via_litellm") is True
+
+
+@pytest.mark.asyncio
+async def test_rewritten_flow_passes_allowlist():
+    """After rewrite, cc-webui.internal is in allowed_domains — flow not denied."""
+    addon = _make_addon(routing=ROUTING_ENABLED)
+    f = _flow(host="api.anthropic.com")
+    await addon.requestheaders(f)
+    assert not f.metadata.get("denied")
+
+
+# ---------------------------------------------------------------------------
+# Negative: no routing → flow unchanged
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_routing_leaves_host_unchanged():
+    addon = _make_addon(routing={"hostname_rewrites": {}, "virtual_key": None})
+    f = _flow(host="api.anthropic.com")
+    original_host = f.request.host
+    await addon.requestheaders(f)
+    assert f.request.host == original_host
+    assert f.request.scheme == "https"
+    assert f.request.port == 443
+
+
+@pytest.mark.asyncio
+async def test_empty_routing_no_sentinel():
+    addon = _make_addon(routing={"hostname_rewrites": {}, "virtual_key": None})
+    f = _flow(host="api.anthropic.com")
+    await addon.requestheaders(f)
+    assert not f.metadata.get("routed_via_litellm")
+
+
+# ---------------------------------------------------------------------------
+# Negative: non-Anthropic host → unchanged even when routing is enabled
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_non_anthropic_host_unchanged():
+    addon = _make_addon(routing=ROUTING_ENABLED)
+    f = _flow(host="other.example.com")
+    await addon.requestheaders(f)
+    assert f.request.host == "other.example.com"
+    assert f.request.scheme == "https"
+    assert not f.metadata.get("routed_via_litellm")
+
+
+# ---------------------------------------------------------------------------
+# REQUIRED: Sentinel guard correctness tests
+#
+# When routed_via_litellm is set, secret injection must be skipped for the
+# rewritten host — even if a secret's target_hosts includes api.anthropic.com
+# or cc-webui.internal (which might match after the rewrite).
+# ---------------------------------------------------------------------------
+
+
+PH_ANTHROPIC = "CC_SECRET_antkey_001122"
+ANTHROPIC_SECRET_VALUE = "sk-ant-original-secret"
+
+
+def _make_secret_record(
+    placeholder: str = PH_ANTHROPIC,
+    value: str = ANTHROPIC_SECRET_VALUE,
+    target_hosts: list | None = None,
+) -> dict:
+    return {
+        "placeholder": placeholder,
+        "name": "antkey",
+        "type": "generic",
+        "value": value,
+        "target_hosts": target_hosts or ["api.anthropic.com"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_sentinel_guard_blocks_secret_injection_when_routed():
+    """REQUIRED: When routing is active, secret injection must be skipped.
+
+    Setup:
+    - A secret targets api.anthropic.com (the rewrite source)
+    - The request has the secret placeholder in x-api-key header
+    - Routing is enabled → header should be the virtual key, not the secret
+
+    After requestheaders(), x-api-key must equal the virtual key, NOT the
+    resolved secret value.
+    """
+    record = _make_secret_record(
+        placeholder=PH_ANTHROPIC,
+        value=ANTHROPIC_SECRET_VALUE,
+        target_hosts=["api.anthropic.com", "cc-webui.internal"],
+    )
+    addon = _make_addon(records=[record], routing=ROUTING_ENABLED)
+    f = _flow(
+        host="api.anthropic.com",
+        request_headers={"x-api-key": PH_ANTHROPIC},
+    )
+
+    await addon.requestheaders(f)
+
+    # Virtual key must be present — not the secret value
+    assert f.request.headers.get("x-api-key") == "lc-test-vkey-abc"
+    assert ANTHROPIC_SECRET_VALUE not in f.request.headers.get("x-api-key", "")
+    assert f.metadata.get("routed_via_litellm") is True
+
+
+@pytest.mark.asyncio
+async def test_sentinel_guard_inverse_routing_disabled_injects_secret():
+    """REQUIRED inverse: when routing is disabled, secret IS injected normally.
+
+    Same secret setup but with empty routing — the placeholder in x-api-key
+    must be replaced with the real secret value by the injection loop.
+    """
+    record = _make_secret_record(
+        placeholder=PH_ANTHROPIC,
+        value=ANTHROPIC_SECRET_VALUE,
+        target_hosts=["api.anthropic.com"],
+    )
+    addon = _make_addon(
+        records=[record],
+        routing={"hostname_rewrites": {}, "virtual_key": None},
+    )
+    f = _flow(
+        host="api.anthropic.com",
+        request_headers={"x-api-key": PH_ANTHROPIC},
+    )
+
+    await addon.requestheaders(f)
+
+    # Secret must be injected — no routing to intercept it
+    assert f.request.headers.get("x-api-key") == ANTHROPIC_SECRET_VALUE
+    assert not f.metadata.get("routed_via_litellm")

--- a/src/tests/test_session_routing_endpoint.py
+++ b/src/tests/test_session_routing_endpoint.py
@@ -1,0 +1,175 @@
+"""
+Tests for GET /api/sessions/{session_id}/routing endpoint (issue #1427 Phase 3).
+
+Covers:
+  - 401 when no Bearer header
+  - 401 when wrong Bearer token
+  - 200 with empty rewrites when no catalog is selected
+  - 200 with populated rewrites and virtual_key when catalog selected
+  - Hostname rewrite map uses proxy_mgr.port
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+def _make_session(token: str = "valid-token") -> MagicMock:
+    session = MagicMock()
+    session.secret_fetch_token = token
+    return session
+
+
+def _make_webui(
+    session: MagicMock | None = None,
+    proxy_mgr: MagicMock | None = None,
+) -> MagicMock:
+    webui = MagicMock()
+    webui.coordinator.session_manager.get_session_info = AsyncMock(
+        return_value=session
+    )
+    webui.litellm_proxy_manager = proxy_mgr
+    return webui
+
+
+def _make_proxy_mgr(port: int = 4000, routing: dict | None = None) -> MagicMock:
+    mgr = MagicMock()
+    mgr.port = port
+    mgr.get_session_routing.return_value = routing
+    mgr.build_hostname_rewrites.return_value = {
+        "api.anthropic.com": f"cc-webui.internal:{port}"
+    }
+    return mgr
+
+
+@pytest.fixture
+def session_id() -> str:
+    return "test-session-1427"
+
+
+@pytest.fixture
+def valid_token() -> str:
+    return "correct-session-token"
+
+
+async def _client(webui) -> AsyncClient:
+    from fastapi import FastAPI
+
+    from src.routers.session_routing import build_router
+
+    app = FastAPI()
+    app.include_router(build_router(webui))
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+# ---------------------------------------------------------------------------
+# Auth tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_bearer_returns_401(session_id, valid_token):
+    session = _make_session(token=valid_token)
+    webui = _make_webui(session=session)
+
+    async with await _client(webui) as client:
+        resp = await client.get(f"/api/sessions/{session_id}/routing")
+
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_wrong_bearer_returns_401(session_id, valid_token):
+    session = _make_session(token=valid_token)
+    webui = _make_webui(session=session)
+
+    async with await _client(webui) as client:
+        resp = await client.get(
+            f"/api/sessions/{session_id}/routing",
+            headers={"Authorization": "Bearer wrong-token"},
+        )
+
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_missing_session_returns_401(session_id):
+    webui = _make_webui(session=None)
+
+    async with await _client(webui) as client:
+        resp = await client.get(
+            f"/api/sessions/{session_id}/routing",
+            headers={"Authorization": "Bearer any-token"},
+        )
+
+    assert resp.status_code in (401, 404)
+
+
+# ---------------------------------------------------------------------------
+# No catalog selected — returns empty rewrites
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_catalog_returns_empty_rewrites(session_id, valid_token):
+    session = _make_session(token=valid_token)
+    proxy_mgr = _make_proxy_mgr(routing=None)
+    webui = _make_webui(session=session, proxy_mgr=proxy_mgr)
+
+    async with await _client(webui) as client:
+        resp = await client.get(
+            f"/api/sessions/{session_id}/routing",
+            headers={"Authorization": f"Bearer {valid_token}"},
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["hostname_rewrites"] == {}
+    assert body["virtual_key"] is None
+
+
+# ---------------------------------------------------------------------------
+# Catalog selected — returns populated rewrites and virtual_key
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_catalog_selected_returns_rewrites_and_vkey(session_id, valid_token):
+    session = _make_session(token=valid_token)
+    routing = {"virtual_key": "lc-abc123", "base_url": "http://127.0.0.1:4000/"}
+    proxy_mgr = _make_proxy_mgr(port=4000, routing=routing)
+    webui = _make_webui(session=session, proxy_mgr=proxy_mgr)
+
+    async with await _client(webui) as client:
+        resp = await client.get(
+            f"/api/sessions/{session_id}/routing",
+            headers={"Authorization": f"Bearer {valid_token}"},
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["virtual_key"] == "lc-abc123"
+    assert "api.anthropic.com" in body["hostname_rewrites"]
+    assert "cc-webui.internal:4000" in body["hostname_rewrites"]["api.anthropic.com"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("port", [4000, 4001, 9000])
+async def test_rewrite_map_uses_proxy_port(session_id, valid_token, port):
+    session = _make_session(token=valid_token)
+    routing = {"virtual_key": "lc-xyz", "base_url": f"http://127.0.0.1:{port}/"}
+    proxy_mgr = _make_proxy_mgr(port=port, routing=routing)
+    webui = _make_webui(session=session, proxy_mgr=proxy_mgr)
+
+    async with await _client(webui) as client:
+        resp = await client.get(
+            f"/api/sessions/{session_id}/routing",
+            headers={"Authorization": f"Bearer {valid_token}"},
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert f"cc-webui.internal:{port}" in body["hostname_rewrites"]["api.anthropic.com"]

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -43,7 +43,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
     EXEMPT_PREFIXES = ('/assets/',)
     # Issue #827: The per-session secrets resolve endpoint uses its own Bearer token auth,
     # not the global operator token. Exempt it from global AuthMiddleware.
-    EXEMPT_SUFFIXES = ('/secrets/resolve',)
+    EXEMPT_SUFFIXES = ('/secrets/resolve', '/routing')
     # Issue #1134: Session-scoped proxy write-back endpoints (per-session Bearer token auth).
     # Matches /api/sessions/{uuid}/secrets/{name} (PATCH) and /api/sessions/{uuid}/events (POST).
     _PROXY_WRITE_BACK_PATTERN = re.compile(r'^/api/sessions/[^/]+/(secrets/[^/]+|events)$')


### PR DESCRIPTION
## Summary

Part of #1427

Wires the mitmproxy sidecar so Docker sessions with a provider catalog selected route `api.anthropic.com` traffic through the in-process LiteLLM proxy on the host. When no catalog is selected, nothing changes — the proxy passes traffic directly to `api.anthropic.com`.

## Changes Made

- **`GET /api/sessions/{id}/routing`** (new endpoint) — returns `{hostname_rewrites, virtual_key}` for the sidecar; uses the same per-session Bearer token auth as `/secrets/resolve`; returns 200 with empty rewrites when no catalog is selected
- **`/routing` added to `AuthMiddleware.EXEMPT_SUFFIXES`** — consistent with `/secrets/resolve` exemption
- **LiteLLM binds to `0.0.0.0` (was `127.0.0.1`)** — required so the Docker sidecar can reach the proxy via `cc-webui.internal:<port>`; the `start()` log line now explicitly states: `"bound to 0.0.0.0:{port} (auth via virtual key)"`. Authentication is virtual-key gated via LiteLLM's `custom_auth_callback`; future hardening can pin to the docker0 bridge IP
- **`build_hostname_rewrites()` helper** on `LiteLLMProxyManager` — returns the static rewrite map keyed by source host
- **`_fetch_json()` helper** on `ProxyAddon` — unifies the HTTP GET pattern shared by `_fetch_resolve()` and new `_fetch_routing()`
- **`ProxyAddon.running()`** — fetches routing config after secrets; logs `[proxy] Routing enabled: {...}` if active; degrades gracefully on fetch failure
- **`ProxyAddon.requestheaders()`** — applies rewrite before the allowlist check: mutates `host`/`port`/`scheme`, replaces `x-api-key` and `Authorization` with the virtual key, sets `flow.metadata["routed_via_litellm"]` sentinel; the secret-injection loop skips records when the sentinel is set to prevent Anthropic-targeted secrets from overwriting the installed virtual key

## Testing

20 unit tests added — all passing, zero ruff violations:

- `test_session_routing_endpoint.py`: 401 no Bearer, 401 wrong Bearer, 401 missing session, 200 empty rewrites (no catalog), 200 populated rewrites+key (catalog selected), port parameterization (3 values)
- `test_proxy_addon_routing.py`: hostname rewrite, port=4000, scheme=http, x-api-key replaced, Authorization header set, metadata sentinel, allowlist pass, empty routing leaves flow unchanged, non-Anthropic host unchanged, **sentinel guard correctness** (secret injection skipped when `routed_via_litellm` set), **inverse sentinel guard** (routing disabled → secret injected normally)

## Manual Smoke-Test Checklist

> Phase 4 (REST CRUD) and Phase 5 (UI) are not yet built. Testing Phase 3 requires hand-editing config JSON.

- [ ] Start backend: `uv run python main.py --host 0.0.0.0 --debug-all --data-dir test_data --port 8001`
- [ ] Add catalog entry to `~/.config/cc_webui/config.json` under `provider_catalog.entries` (see plan for JSON snippet)
- [ ] Restart; verify log: `LiteLLM proxy started on port 4000 with 1 model(s), bound to 0.0.0.0:4000 (auth via virtual key)`
- [ ] Verify `curl http://127.0.0.1:4000/v1/models` returns the model alias
- [ ] Create Docker-enabled session; stop it; patch `state.json` to set `provider_catalog_id` + `provider_model_id`; start from UI
- [ ] Proxy container logs show `[proxy] Loaded N secret(s)` then `[proxy] Routing enabled: {'api.anthropic.com': 'cc-webui.internal:4000'}`
- [ ] Send message; proxy logs show `[proxy] Routed api.anthropic.com -> cc-webui.internal:4000` then `[proxy] ALLOW ... -> cc-webui.internal/v1/messages`
- [ ] LiteLLM logs show `POST /v1/messages 200` with `user_id=<session_id>`
- [ ] Negative: session without catalog shows no `Routing enabled:` line; traffic goes to `api.anthropic.com`
- [ ] Terminate catalog session; `GET /api/sessions/{id}/routing` (with session token) returns empty rewrites

🤖 Generated with [Claude Code](https://claude.com/claude-code)