### PR TITLE
feat: LiteLLM provider catalog REST API (Phase 4 of #1427)

### DIFF
--- a/src/litellm_proxy_manager.py
+++ b/src/litellm_proxy_manager.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import uuid
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from src.logging_config import get_logger
@@ -37,6 +38,9 @@ class LiteLLMProxyManager:
         self._server_task: asyncio.Task | None = None
         self._rebuild_lock = asyncio.Lock()
         self._running = False
+        self._last_restart: datetime | None = None
+        self._last_error: str | None = None
+        self._model_count: int = 0
         try:
             from litellm.proxy.proxy_server import app as _  # noqa: F401
         except ImportError as e:
@@ -48,13 +52,19 @@ class LiteLLMProxyManager:
 
     async def start(self) -> None:
         """Build model_list from catalog and start the uvicorn task."""
-        model_list = await self._build_model_list()
-        await self._launch_server(model_list)
-        self._running = True
-        legion_logger.info(
-            f"LiteLLM proxy started on port {self._port} with {len(model_list)} model(s), "
-            f"bound to 0.0.0.0:{self._port} (auth via virtual key)"
-        )
+        try:
+            model_list = await self._build_model_list()
+            await self._launch_server(model_list)
+            self._running = True
+            self._last_restart = datetime.now(UTC)
+            self._last_error = None
+            legion_logger.info(
+                f"LiteLLM proxy started on port {self._port} with {len(model_list)} model(s), "
+                f"bound to 0.0.0.0:{self._port} (auth via virtual key)"
+            )
+        except Exception as e:
+            self._last_error = f"{type(e).__name__}: {e}"
+            raise
 
     async def stop(self) -> None:
         """Gracefully stop the uvicorn task."""
@@ -82,6 +92,18 @@ class LiteLLMProxyManager:
     @property
     def port(self) -> int:
         return self._port
+
+    @property
+    def last_restart(self) -> datetime | None:
+        return self._last_restart
+
+    @property
+    def last_error(self) -> str | None:
+        return self._last_error
+
+    @property
+    def model_count(self) -> int:
+        return self._model_count
 
     # ── Virtual Key Registry ───────────────────────────────────────────────
 
@@ -154,6 +176,7 @@ class LiteLLMProxyManager:
                         **resolved_params,
                     },
                 })
+        self._model_count = len(model_list)
         return model_list
 
     async def _launch_server(self, model_list: list[dict]) -> None:

--- a/src/routers/__init__.py
+++ b/src/routers/__init__.py
@@ -24,6 +24,7 @@ from . import (
     poll,
     profiles,
     projects,
+    provider_catalog,
     proxy,
     queue,
     schedules,
@@ -48,6 +49,7 @@ def register_all(app: FastAPI, webui) -> None:
     app.include_router(config.build_router(webui))
     app.include_router(fleet.build_router(webui))
     app.include_router(core.build_router(webui))
+    app.include_router(provider_catalog.build_router(webui))
     app.include_router(proxy.build_router(webui))
     app.include_router(secrets.build_router(webui))
     app.include_router(profiles.build_router(webui))

--- a/src/routers/_models.py
+++ b/src/routers/_models.py
@@ -375,6 +375,17 @@ class PermissionResponseRequest(BaseModel):
     updated_input: dict | None = None
 
 
+class ProviderCatalogEntryRequest(BaseModel):
+    id: str
+    display_name: str
+    provider_type: str
+    litellm_params_template: dict[str, str] = Field(default_factory=dict)
+    models: list[dict] = Field(default_factory=list)
+
+    class Config:
+        extra = "allow"  # forward-compat for new provider-specific fields
+
+
 def _validate_additional_directories(dirs: list[str] | None, working_directory: str | None) -> list[str] | None:
     """Validate additional directories: absolute paths, no duplicates, not same as working_dir.
     Returns None (not []) when there are no valid entries so callers can distinguish

--- a/src/routers/provider_catalog.py
+++ b/src/routers/provider_catalog.py
@@ -1,0 +1,78 @@
+"""Provider catalog admin endpoints: /api/provider-catalog/*
+
+Extra top-level fields on PUT are silently dropped on round-trip; semantic
+validation is handled by ProviderCatalogManager._validate_entry.
+"""
+
+from fastapi import APIRouter, HTTPException
+
+from ..exception_handlers import handle_exceptions
+from ._models import ProviderCatalogEntryRequest
+
+
+def build_router(webui) -> APIRouter:
+    router = APIRouter()
+
+    @router.get("/api/provider-catalog")
+    @handle_exceptions("list provider catalog entries")
+    async def list_entries():
+        entries = await webui.provider_catalog_manager.list_entries()
+        cfg = await webui.app_config_manager.get_config()
+        return {
+            "entries": entries,
+            "pending_changes": cfg.provider_catalog.pending_changes,
+        }
+
+    @router.post("/api/provider-catalog", status_code=201)
+    @handle_exceptions("create provider catalog entry", value_error_status=400)
+    async def create_entry(request: ProviderCatalogEntryRequest):
+        entry = await webui.provider_catalog_manager.create_entry(request.model_dump())
+        return {"entry": entry}
+
+    @router.put("/api/provider-catalog/{entry_id}")
+    @handle_exceptions("update provider catalog entry", value_error_status=400)
+    async def update_entry(entry_id: str, request: ProviderCatalogEntryRequest):
+        body = request.model_dump()
+        body["id"] = entry_id  # path wins over body for the id field
+        try:
+            entry = await webui.provider_catalog_manager.update_entry(entry_id, body)
+        except KeyError as e:
+            raise HTTPException(status_code=404, detail=str(e)) from e
+        return {"entry": entry}
+
+    @router.delete("/api/provider-catalog/{entry_id}")
+    @handle_exceptions("delete provider catalog entry")
+    async def delete_entry(entry_id: str):
+        try:
+            await webui.provider_catalog_manager.delete_entry(entry_id)
+        except KeyError as e:
+            raise HTTPException(status_code=404, detail=str(e)) from e
+        return {"deleted": True}
+
+    @router.post("/api/provider-catalog/restart")
+    @handle_exceptions("restart litellm proxy")
+    async def restart_proxy():
+        # pending_changes is only cleared on success; a rebuild failure leaves it
+        # set so the admin can see the error via /status and retry.
+        await webui.litellm_proxy_manager.rebuild()
+        await webui.provider_catalog_manager.clear_pending_changes()
+        return _status_payload(pending_changes=False)
+
+    @router.get("/api/provider-catalog/status")
+    @handle_exceptions("get provider catalog status")
+    async def get_status():
+        cfg = await webui.app_config_manager.get_config()
+        return _status_payload(pending_changes=cfg.provider_catalog.pending_changes)
+
+    def _status_payload(*, pending_changes: bool) -> dict:
+        mgr = webui.litellm_proxy_manager
+        return {
+            "running": mgr.is_running,
+            "port": mgr.port,
+            "pending_changes": pending_changes,
+            "model_count": mgr.model_count,
+            "last_restart": mgr.last_restart.isoformat() if mgr.last_restart else None,
+            "last_error": mgr.last_error,
+        }
+
+    return router

--- a/src/tests/test_litellm_proxy_manager.py
+++ b/src/tests/test_litellm_proxy_manager.py
@@ -37,6 +37,9 @@ def _make_manager():
         mgr._server_task = None
         mgr._rebuild_lock = asyncio.Lock()
         mgr._running = False
+        mgr._last_restart = None
+        mgr._last_error = None
+        mgr._model_count = 0
         return mgr, mock_types
 
 
@@ -167,3 +170,45 @@ def test_routing_registry_independent_of_key_registry(manager):
     manager.unregister_session_routing("sess-3")
     # Key registry should still be clean
     assert manager._key_registry == {}
+
+
+# ── Telemetry Attribute Tests (issue #1427 Phase 4) ───────────────────────────
+
+
+def test_telemetry_attributes_default_to_none(manager):
+    assert manager.last_restart is None
+    assert manager.last_error is None
+
+
+def test_model_count_zero_before_start(manager):
+    assert manager.model_count == 0
+
+
+@pytest.mark.asyncio
+async def test_build_model_list_updates_model_count(manager):
+    manager._catalog_manager.list_entries.return_value = [
+        {
+            "id": "prov-a",
+            "models": [
+                {"id": "m1", "litellm_model": "anthropic/claude-sonnet-4-6"},
+                {"id": "m2", "litellm_model": "anthropic/claude-haiku-4-5"},
+            ],
+            "litellm_params_template": {},
+        }
+    ]
+    manager._catalog_manager.resolve_params.return_value = {}
+
+    result = await manager._build_model_list()
+
+    assert len(result) == 2
+    assert manager.model_count == 2
+
+
+@pytest.mark.asyncio
+async def test_build_model_list_empty_catalog_sets_count_zero(manager):
+    manager._catalog_manager.list_entries.return_value = []
+
+    result = await manager._build_model_list()
+
+    assert result == []
+    assert manager.model_count == 0

--- a/src/tests/test_provider_catalog_router.py
+++ b/src/tests/test_provider_catalog_router.py
@@ -1,0 +1,332 @@
+"""
+Tests for /api/provider-catalog/* endpoints (issue #1427 Phase 4).
+
+Covers:
+  - GET  /api/provider-catalog        — list entries + pending_changes flag
+  - POST /api/provider-catalog        — create (201) and 400 on ValueError
+  - PUT  /api/provider-catalog/{id}   — update (200), 404 on KeyError, path id wins
+  - DELETE /api/provider-catalog/{id} — delete (200), 404 on KeyError
+  - POST /api/provider-catalog/restart — invokes rebuild + clear_pending_changes; 500 on failure
+  - GET  /api/provider-catalog/status  — all six fields; last_restart ISO / null
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_ENTRY = {
+    "id": "prov-a",
+    "display_name": "Provider A",
+    "provider_type": "anthropic",
+    "litellm_params_template": {"api_key": "${secret:key}"},
+    "models": [{"id": "m1", "display_name": "M1", "litellm_model": "anthropic/claude-sonnet-4-6"}],
+}
+
+_ENTRY_BODY = {
+    "id": "prov-a",
+    "display_name": "Provider A",
+    "provider_type": "anthropic",
+    "litellm_params_template": {"api_key": "${secret:key}"},
+    "models": [{"id": "m1", "display_name": "M1", "litellm_model": "anthropic/claude-sonnet-4-6"}],
+}
+
+
+def _make_proxy_mgr(
+    is_running: bool = True,
+    port: int = 4000,
+    model_count: int = 0,
+    last_restart: datetime | None = None,
+    last_error: str | None = None,
+) -> MagicMock:
+    mgr = MagicMock()
+    mgr.is_running = is_running
+    mgr.port = port
+    mgr.model_count = model_count
+    mgr.last_restart = last_restart
+    mgr.last_error = last_error
+    mgr.rebuild = AsyncMock()
+    return mgr
+
+
+def _make_catalog_mgr(
+    entries: list | None = None,
+    pending_changes: bool = False,
+) -> MagicMock:
+    mgr = AsyncMock()
+    mgr.list_entries.return_value = entries or []
+    mgr.create_entry.return_value = _ENTRY
+    mgr.update_entry.return_value = _ENTRY
+    mgr.delete_entry.return_value = None
+    mgr.clear_pending_changes.return_value = None
+    return mgr
+
+
+def _make_config(pending_changes: bool = False) -> MagicMock:
+    cfg = MagicMock()
+    cfg.provider_catalog.pending_changes = pending_changes
+    return cfg
+
+
+def _make_webui(
+    proxy_mgr: MagicMock | None = None,
+    catalog_mgr: MagicMock | None = None,
+    pending_changes: bool = False,
+) -> MagicMock:
+    webui = MagicMock()
+    webui.litellm_proxy_manager = proxy_mgr or _make_proxy_mgr()
+    webui.provider_catalog_manager = catalog_mgr or _make_catalog_mgr()
+    webui.app_config_manager = AsyncMock()
+    webui.app_config_manager.get_config.return_value = _make_config(pending_changes)
+    return webui
+
+
+async def _client(webui) -> AsyncClient:
+    from fastapi import FastAPI
+
+    from src.routers.provider_catalog import build_router
+
+    app = FastAPI()
+    app.include_router(build_router(webui))
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+# ---------------------------------------------------------------------------
+# GET /api/provider-catalog
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_entries_returns_entries_and_pending_flag():
+    entries = [_ENTRY]
+    catalog = _make_catalog_mgr(entries=entries)
+    webui = _make_webui(catalog_mgr=catalog, pending_changes=True)
+
+    async with await _client(webui) as client:
+        resp = await client.get("/api/provider-catalog")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["entries"] == entries
+    assert body["pending_changes"] is True
+
+
+@pytest.mark.asyncio
+async def test_list_entries_empty_catalog():
+    webui = _make_webui(pending_changes=False)
+
+    async with await _client(webui) as client:
+        resp = await client.get("/api/provider-catalog")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["entries"] == []
+    assert body["pending_changes"] is False
+
+
+# ---------------------------------------------------------------------------
+# POST /api/provider-catalog
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_entry_returns_201_with_entry():
+    webui = _make_webui()
+
+    async with await _client(webui) as client:
+        resp = await client.post("/api/provider-catalog", json=_ENTRY_BODY)
+
+    assert resp.status_code == 201
+    assert resp.json()["entry"]["id"] == "prov-a"
+
+
+@pytest.mark.asyncio
+async def test_create_entry_400_on_value_error():
+    catalog = _make_catalog_mgr()
+    catalog.create_entry.side_effect = ValueError("Duplicate id")
+    webui = _make_webui(catalog_mgr=catalog)
+
+    async with await _client(webui) as client:
+        resp = await client.post("/api/provider-catalog", json=_ENTRY_BODY)
+
+    assert resp.status_code == 400
+    assert "Duplicate id" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_create_entry_422_on_missing_required_field():
+    webui = _make_webui()
+
+    async with await _client(webui) as client:
+        resp = await client.post(
+            "/api/provider-catalog",
+            json={"id": "x", "provider_type": "anthropic"},  # missing display_name
+        )
+
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/provider-catalog/{entry_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_entry_200_on_success():
+    webui = _make_webui()
+
+    async with await _client(webui) as client:
+        resp = await client.put("/api/provider-catalog/prov-a", json=_ENTRY_BODY)
+
+    assert resp.status_code == 200
+    assert resp.json()["entry"]["id"] == "prov-a"
+
+
+@pytest.mark.asyncio
+async def test_update_entry_404_on_key_error():
+    catalog = _make_catalog_mgr()
+    catalog.update_entry.side_effect = KeyError("Entry 'missing' not found")
+    webui = _make_webui(catalog_mgr=catalog)
+
+    async with await _client(webui) as client:
+        resp = await client.put("/api/provider-catalog/missing", json=_ENTRY_BODY)
+
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_update_entry_path_id_wins_over_body_id():
+    catalog = _make_catalog_mgr()
+    webui = _make_webui(catalog_mgr=catalog)
+
+    body = {**_ENTRY_BODY, "id": "body-id"}  # body says "body-id"
+
+    async with await _client(webui) as client:
+        await client.put("/api/provider-catalog/path-id", json=body)
+
+    # The manager should have been called with the path id, not body id
+    call_args = catalog.update_entry.call_args
+    assert call_args[0][0] == "path-id"  # first positional arg = entry_id
+    assert call_args[0][1]["id"] == "path-id"  # body dict also has path id
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/provider-catalog/{entry_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_entry_200_on_success():
+    webui = _make_webui()
+
+    async with await _client(webui) as client:
+        resp = await client.delete("/api/provider-catalog/prov-a")
+
+    assert resp.status_code == 200
+    assert resp.json()["deleted"] is True
+
+
+@pytest.mark.asyncio
+async def test_delete_entry_404_on_key_error():
+    catalog = _make_catalog_mgr()
+    catalog.delete_entry.side_effect = KeyError("Entry 'gone' not found")
+    webui = _make_webui(catalog_mgr=catalog)
+
+    async with await _client(webui) as client:
+        resp = await client.delete("/api/provider-catalog/gone")
+
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /api/provider-catalog/restart
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_restart_calls_rebuild_and_clears_pending_changes():
+    ts = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    proxy = _make_proxy_mgr(model_count=1, last_restart=ts)
+    catalog = _make_catalog_mgr()
+    webui = _make_webui(proxy_mgr=proxy, catalog_mgr=catalog)
+
+    async with await _client(webui) as client:
+        resp = await client.post("/api/provider-catalog/restart")
+
+    assert resp.status_code == 200
+    proxy.rebuild.assert_awaited_once()
+    catalog.clear_pending_changes.assert_awaited_once()
+
+    body = resp.json()
+    assert body["pending_changes"] is False
+    assert body["model_count"] == 1
+    assert body["last_restart"] == ts.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_restart_500_on_rebuild_failure_does_not_clear_pending():
+    proxy = _make_proxy_mgr()
+    proxy.rebuild.side_effect = RuntimeError("secret not found")
+    catalog = _make_catalog_mgr()
+    webui = _make_webui(proxy_mgr=proxy, catalog_mgr=catalog)
+
+    async with await _client(webui) as client:
+        resp = await client.post("/api/provider-catalog/restart")
+
+    assert resp.status_code == 500
+    catalog.clear_pending_changes.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# GET /api/provider-catalog/status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_status_returns_all_six_fields():
+    ts = datetime(2026, 3, 15, 10, 30, 0, tzinfo=UTC)
+    proxy = _make_proxy_mgr(is_running=True, port=4000, model_count=3, last_restart=ts)
+    webui = _make_webui(proxy_mgr=proxy, pending_changes=True)
+
+    async with await _client(webui) as client:
+        resp = await client.get("/api/provider-catalog/status")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["running"] is True
+    assert body["port"] == 4000
+    assert body["pending_changes"] is True
+    assert body["model_count"] == 3
+    assert body["last_restart"] == ts.isoformat()
+    assert body["last_error"] is None
+
+
+@pytest.mark.asyncio
+async def test_status_last_restart_null_when_not_set():
+    proxy = _make_proxy_mgr(last_restart=None)
+    webui = _make_webui(proxy_mgr=proxy)
+
+    async with await _client(webui) as client:
+        resp = await client.get("/api/provider-catalog/status")
+
+    assert resp.status_code == 200
+    assert resp.json()["last_restart"] is None
+
+
+@pytest.mark.asyncio
+async def test_status_last_error_populated():
+    proxy = _make_proxy_mgr(last_error="ValueError: Secret 'x' not found")
+    webui = _make_webui(proxy_mgr=proxy)
+
+    async with await _client(webui) as client:
+        resp = await client.get("/api/provider-catalog/status")
+
+    assert resp.status_code == 200
+    assert resp.json()["last_error"] == "ValueError: Secret 'x' not found"


### PR DESCRIPTION
## Summary

Part of #1427

Adds the admin REST API for the LiteLLM provider catalog (Phase 4). After this phase the full non-Docker routing flow is exercisable end-to-end with curl alone.

## Changes Made

- **`src/routers/provider_catalog.py`** (new) — 6 endpoints under `/api/provider-catalog/*`:
  - `GET /api/provider-catalog` — list entries + `pending_changes` flag
  - `POST /api/provider-catalog` — create entry (201); 400 on `ValueError`
  - `PUT /api/provider-catalog/{id}` — update entry; 404 on `KeyError`; path id wins over body id
  - `DELETE /api/provider-catalog/{id}` — delete entry; 404 on `KeyError`
  - `POST /api/provider-catalog/restart` — inline `rebuild()`, clears `pending_changes` on success, returns status payload; 500 on failure (pending stays set)
  - `GET /api/provider-catalog/status` — `{running, port, pending_changes, model_count, last_restart, last_error}`
- **`src/litellm_proxy_manager.py`** — telemetry attributes (`last_restart`, `last_error`, `model_count`) tracked in `start()` and `_build_model_list()`; exposed as read-only properties
- **`src/routers/_models.py`** — `ProviderCatalogEntryRequest` Pydantic model (`extra="allow"` for forward-compat)
- **`src/routers/__init__.py`** — register `provider_catalog` router
- **`src/tests/test_provider_catalog_router.py`** (new) — 15 unit tests covering all endpoints and error paths
- **`src/tests/test_litellm_proxy_manager.py`** — 4 new tests for telemetry defaults and `_build_model_list` model count update

## Testing

- `uv run pytest src/tests/test_provider_catalog_router.py src/tests/test_litellm_proxy_manager.py` — 33/33 pass
- `uv run ruff check src/` — zero violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)