### PR TITLE
fix: suppress CLAUDE_CODE_ATTRIBUTION_HEADER for LiteLLM-routed sessions

### DIFF
--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -1521,8 +1521,19 @@ class SessionCoordinator:
                 catalog_model_update["model"] = model_alias
                 if effective_config.docker_enabled:
                     _proxy_mgr.register_session_routing(session_id, virtual_key, base_url)
+                    # Inject CLAUDE_CODE_ATTRIBUTION_HEADER=0 into the agent container so
+                    # the billing header doesn't cache-bust 3rd-party / local LLM APIs.
+                    # Must go through CLAUDE_DOCKER_EXTRA_ENV (not litellm_env) because
+                    # _merged_extra_env only reaches the wrapper process, not the container.
+                    _extra = json.loads(docker_env_vars.get("CLAUDE_DOCKER_EXTRA_ENV", "{}"))
+                    _extra["CLAUDE_CODE_ATTRIBUTION_HEADER"] = "0"
+                    docker_env_vars["CLAUDE_DOCKER_EXTRA_ENV"] = json.dumps(_extra)
                 else:
-                    litellm_env = {"ANTHROPIC_BASE_URL": base_url, "ANTHROPIC_API_KEY": virtual_key}
+                    litellm_env = {
+                        "ANTHROPIC_BASE_URL": base_url,
+                        "ANTHROPIC_API_KEY": virtual_key,
+                        "CLAUDE_CODE_ATTRIBUTION_HEADER": "0",
+                    }
 
             # Override 3 fields computed earlier in this method:
             #   system_prompt — assembled above (includes legion guide, history ref, etc.)

--- a/src/tests/test_session_provider_routing.py
+++ b/src/tests/test_session_provider_routing.py
@@ -303,3 +303,69 @@ async def test_docker_catalog_routes_via_registry_not_env(coordinator):
     call_kwargs = factory.call_args.kwargs
     extra_env = call_kwargs.get("extra_env") or {}
     assert "ANTHROPIC_BASE_URL" not in extra_env
+
+
+# ── Issue #1467: attribution header suppression ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_non_docker_catalog_suppresses_attribution_header(coordinator):
+    """Non-Docker catalog sessions receive CLAUDE_CODE_ATTRIBUTION_HEADER=0 in extra_env."""
+    proxy = _make_proxy_manager()
+    coordinator.litellm_proxy_manager = proxy
+
+    config = SessionConfig(
+        provider_catalog_id="bedrock",
+        provider_model_id="claude-3-5-sonnet",
+    )
+    session_id = await _create_session(coordinator, config)
+
+    factory, _ = _make_sdk_factory()
+    coordinator.set_sdk_factory(factory)
+
+    await coordinator.start_session(session_id)
+
+    extra_env = factory.call_args.kwargs.get("extra_env") or {}
+    assert extra_env.get("CLAUDE_CODE_ATTRIBUTION_HEADER") == "0"
+
+
+@pytest.mark.asyncio
+async def test_native_session_no_attribution_header(coordinator):
+    """Sessions without a catalog provider do NOT get the attribution header suppressed."""
+    config = SessionConfig()
+    session_id = await _create_session(coordinator, config)
+
+    factory, _ = _make_sdk_factory()
+    coordinator.set_sdk_factory(factory)
+
+    await coordinator.start_session(session_id)
+
+    extra_env = factory.call_args.kwargs.get("extra_env") or {}
+    assert "CLAUDE_CODE_ATTRIBUTION_HEADER" not in extra_env
+
+
+@pytest.mark.asyncio
+async def test_docker_catalog_attribution_header_in_extra_env_json(coordinator):
+    """Docker catalog sessions encode CLAUDE_CODE_ATTRIBUTION_HEADER=0 in CLAUDE_DOCKER_EXTRA_ENV."""
+    import json
+
+    proxy = _make_proxy_manager(port=4000)
+    coordinator.litellm_proxy_manager = proxy
+
+    config = SessionConfig(
+        provider_catalog_id="cat",
+        provider_model_id="mod",
+        docker_enabled=True,
+        cli_path="/usr/bin/claude",
+    )
+    session_id = await _create_session(coordinator, config)
+
+    factory, _ = _make_sdk_factory()
+    coordinator.set_sdk_factory(factory)
+
+    await coordinator.start_session(session_id)
+
+    extra_env = factory.call_args.kwargs.get("extra_env") or {}
+    raw = extra_env.get("CLAUDE_DOCKER_EXTRA_ENV", "{}")
+    container_env = json.loads(raw)
+    assert container_env.get("CLAUDE_CODE_ATTRIBUTION_HEADER") == "0"


### PR DESCRIPTION
## Summary

Claude Code's billing attribution header cache-busts 3rd-party and local LLM APIs when sessions route through LiteLLM. This adds `CLAUDE_CODE_ATTRIBUTION_HEADER=0` for any session using a provider catalog model.

## The Docker subtlety

The issue's suggested fix (adding to `litellm_env`) works correctly for non-Docker sessions where `_merged_extra_env` is the Claude Code process environment directly. For Docker sessions, `_merged_extra_env` only reaches the **wrapper** process — the agent container gets its env from `CLAUDE_DOCKER_EXTRA_ENV` (a JSON dict the wrapper unpacks into `--env KEY` flags for `docker run`). So the Docker path updates `docker_env_vars["CLAUDE_DOCKER_EXTRA_ENV"]` directly after the routing registration.

## Changes

- `src/session_coordinator.py` — add `CLAUDE_CODE_ATTRIBUTION_HEADER=0` to both the non-Docker (`litellm_env`) and Docker (`CLAUDE_DOCKER_EXTRA_ENV`) paths inside the provider catalog block
- `src/tests/test_session_provider_routing.py` — three new tests: non-Docker catalog sets the var, native session does not, Docker catalog encodes it in `CLAUDE_DOCKER_EXTRA_ENV`

## Test plan

- [ ] `uv run pytest src/tests/test_session_provider_routing.py -v` — all tests pass including 3 new ones
- [ ] Start a non-Docker session with a catalog provider — `CLAUDE_CODE_ATTRIBUTION_HEADER=0` visible in `--debug-sdk` env output
- [ ] Start a Docker session with a catalog provider — `CLAUDE_CODE_ATTRIBUTION_HEADER=0` present in container env (`docker exec <container> env | grep ATTRIBUTION`)
- [ ] Start a session without a catalog provider — `CLAUDE_CODE_ATTRIBUTION_HEADER` absent

Resolves #1467

🤖 Generated with [Claude Code](https://claude.com/claude-code)