### PR TITLE
fix: exclude is_default from update_template field coverage check

### DIFF
--- a/src/tests/test_template_manager.py
+++ b/src/tests/test_template_manager.py
@@ -808,8 +808,9 @@ class TestSignatureParity:
 
         # 'config' is the dict container for CONFIG_FIELDS — update_template accepts
         # it directly as a kwarg for full replacement, so it IS in update_params.
-        # Remove it from template_fields to avoid a false mismatch (the field is covered).
-        template_fields -= {"config"}
+        # 'is_default' is server-managed (set only by create_default_templates() at
+        # seed time) and is intentionally absent from update_template()'s signature.
+        template_fields -= {"config", "is_default"}
 
         # update needs template_id as positional, which we already removed
         update_params.discard("template_id")


### PR DESCRIPTION
## Summary
Resolves #1478

`test_update_accepts_all_template_fields` was always failing because `is_default` is intentionally absent from `update_template()`'s signature — it is server-managed (set only by `create_default_templates()` at seed time) and is not user-settable.

## Changes Made
- Added `"is_default"` to the per-test exclusion set in `TestSignatureParity::test_update_accepts_all_template_fields`
- Updated the inline comment to document why both `config` and `is_default` are excluded

## Testing
- `uv run pytest src/tests/test_template_manager.py::TestSignatureParity::test_update_accepts_all_template_fields -v` — PASSED
- `uv run pytest src/tests/test_template_manager.py -v` — 36/36 passed (no regressions)
- `uv run ruff check src/tests/test_template_manager.py` — zero violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)