### PR TITLE
fix: handle ClosedResourceError when upstream MCP connection drops

### DIFF
--- a/src/mcp/shared_connection_manager.py
+++ b/src/mcp/shared_connection_manager.py
@@ -13,6 +13,7 @@ from contextlib import AsyncExitStack
 from dataclasses import dataclass, field
 from typing import Any
 
+import anyio
 from mcp.client.sse import sse_client
 from mcp.client.stdio import StdioServerParameters, stdio_client
 from mcp.client.streamable_http import streamablehttp_client
@@ -73,6 +74,8 @@ class SharedMcpConnectionManager:
             if conn is None:
                 conn = _SharedConn(cfg_id=cfg.id)
                 self._conns[cfg.id] = conn
+                await self._open_locked(cfg, conn)
+            elif conn.session is None:
                 await self._open_locked(cfg, conn)
             conn.refcount += 1
         _logger.info("shared MCP attach cfg=%s refcount=%d", cfg.id, conn.refcount)
@@ -162,9 +165,28 @@ class SharedMcpConnectionManager:
             session = conn.session
             if session is None:
                 return _disconnect_error_result_named(conn.cfg_id)
-            return await session.call_tool(name, arguments)
+            try:
+                return await session.call_tool(name, arguments)
+            except (anyio.ClosedResourceError, anyio.BrokenResourceError):
+                _logger.warning(
+                    "shared MCP upstream closed during call cfg=%s tool=%s — marking disconnected",
+                    conn.cfg_id,
+                    name,
+                )
+                await self._mark_disconnected_locked(conn)
+                return _disconnect_error_result_named(conn.cfg_id)
         finally:
             conn.reconnect_lock.release()
+
+    async def _mark_disconnected_locked(self, conn: _SharedConn) -> None:
+        """Tear down the dead session. Caller must hold conn.reconnect_lock."""
+        if conn.exit_stack is not None:
+            try:
+                await conn.exit_stack.aclose()
+            except Exception:
+                _logger.debug("Error closing exit_stack on disconnect cfg=%s", conn.cfg_id)
+        conn.session = None
+        conn.exit_stack = None
 
     async def _open_locked(self, cfg, conn: _SharedConn) -> None:
         """Open the transport, wrap in ClientSession, run initialize, cache tools."""
@@ -267,13 +289,7 @@ class SharedMcpConnectionManager:
                     "shared MCP refresh: cfg %s not found, leaving conn closed", server_id
                 )
                 return
-            if conn.exit_stack is not None:
-                try:
-                    await conn.exit_stack.aclose()
-                except Exception:
-                    _logger.exception("Error closing for refresh cfg=%s", server_id)
-            conn.session = None
-            conn.exit_stack = None
+            await self._mark_disconnected_locked(conn)
             try:
                 await self._open_locked(cfg, conn)
             except Exception:

--- a/src/tests/test_shared_mcp_connection.py
+++ b/src/tests/test_shared_mcp_connection.py
@@ -3,6 +3,7 @@
 from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import anyio
 import pytest
 from mcp.types import CallToolResult, TextContent, Tool
 
@@ -421,3 +422,76 @@ async def test_missing_secret_raises_and_no_transport_opened():
             await mgr._open_locked(cfg, conn)
 
     assert not transport_opened, "transport must not open when secret resolution fails"
+
+
+# ---------------------------------------------------------------------------
+# ClosedResourceError / BrokenResourceError handling (issue #1488)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_call_tool_returns_disconnect_on_closed_resource_error():
+    mgr = _make_mgr()
+    cfg = _http_cfg()
+
+    with patch.object(SharedMcpConnectionManager, "_open_locked", _stub_open_locked):
+        conn = await mgr.get_or_open(cfg)
+
+    conn.session.call_tool = AsyncMock(side_effect=anyio.ClosedResourceError())
+
+    result = await mgr.call_tool(cfg, "t1", {})
+
+    assert result.isError is True
+    assert "disconnected" in result.content[0].text.lower()
+    assert conn.session is None
+    assert conn.exit_stack is None
+
+
+@pytest.mark.asyncio
+async def test_next_call_after_closed_resource_error_triggers_reopen():
+    mgr = _make_mgr()
+    cfg = _http_cfg()
+    open_calls = []
+
+    async def counting_open(self, c, conn):
+        open_calls.append(c.id)
+        conn.session = _fake_session()
+        conn.exit_stack = MagicMock()
+        conn.exit_stack.aclose = AsyncMock()
+        conn.cached_tools = [Tool(name="t1", description="tool1", inputSchema={"type": "object"})]
+
+    with patch.object(SharedMcpConnectionManager, "_open_locked", counting_open):
+        conn = await mgr.get_or_open(cfg)
+
+    assert len(open_calls) == 1
+
+    # First call raises ClosedResourceError — session should be cleared
+    conn.session.call_tool = AsyncMock(side_effect=anyio.ClosedResourceError())
+    result = await mgr.call_tool(cfg, "t1", {})
+    assert result.isError is True
+    assert conn.session is None
+
+    # Second call should trigger reopen via get_or_open's elif branch
+    with patch.object(SharedMcpConnectionManager, "_open_locked", counting_open):
+        result2 = await mgr.call_tool(cfg, "t1", {})
+
+    assert len(open_calls) == 2
+    assert result2.isError is False
+
+
+@pytest.mark.asyncio
+async def test_broken_resource_error_also_recovers():
+    mgr = _make_mgr()
+    cfg = _http_cfg()
+
+    with patch.object(SharedMcpConnectionManager, "_open_locked", _stub_open_locked):
+        conn = await mgr.get_or_open(cfg)
+
+    conn.session.call_tool = AsyncMock(side_effect=anyio.BrokenResourceError())
+
+    result = await mgr.call_tool(cfg, "t1", {})
+
+    assert result.isError is True
+    assert "disconnected" in result.content[0].text.lower()
+    assert conn.session is None
+    assert conn.exit_stack is None


### PR DESCRIPTION
## Summary
Resolves #1488

When the upstream MCP server closes its connection (idle timeout, network blip, server-side close), `anyio` raises `ClosedResourceError` or `BrokenResourceError` inside `session.call_tool()`. Previously this exception bubbled up as an opaque error and left `conn.session` pointing at the dead `ClientSession`, causing every subsequent call to fail identically.

## Changes Made

**`src/mcp/shared_connection_manager.py`** (~20 LOC):
- Catch `anyio.ClosedResourceError` and `anyio.BrokenResourceError` in `_call_tool_locked`; on catch, tear down the dead session and return a clear disconnect message (same format as the existing timeout path)
- Add `_mark_disconnected_locked` helper: `aclose()`s the exit stack (swallowing errors — transport is already broken), nulls `session` and `exit_stack`; reused by `_on_token_refreshed` to eliminate duplicate teardown logic
- Fix `get_or_open` to call `_open_locked` when `conn` exists but `conn.session is None`, so the next call after a disconnect automatically reconnects

**`src/tests/test_shared_mcp_connection.py`** (3 new tests):
- `test_call_tool_returns_disconnect_on_closed_resource_error` — verifies disconnect result + session cleared
- `test_next_call_after_closed_resource_error_triggers_reopen` — verifies `_open_locked` runs again on the next call
- `test_broken_resource_error_also_recovers` — same as test 1 for `BrokenResourceError`

## Out of Scope (follow-up)
AC4 (manual disconnect/reconnect via Library while sessions are attached) has a separate race in `mark_draining` + refcount logic. That is a distinct defect with a different fix surface and is not included here.

## Testing
- `uv run pytest src/tests/test_shared_mcp_connection.py -v` — 16/16 pass (13 existing + 3 new)
- `uv run ruff check src/mcp/shared_connection_manager.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)