### PR TITLE
feat: queue UX — clear history, schedule name label, timestamps

### DIFF
--- a/frontend/src/components/tasks/QueueSection.vue
+++ b/frontend/src/components/tasks/QueueSection.vue
@@ -40,6 +40,19 @@
           <span class="history-count">{{ terminalCount }}</span>
         </button>
 
+        <!-- Clear history button -->
+        <button
+          v-if="terminalCount > 0"
+          class="btn btn-sm btn-link text-muted p-0"
+          title="Clear history"
+          @click.stop="doClearHistory"
+        >
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+            <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V6z"/>
+            <path fill-rule="evenodd" d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1v1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4H4.118zM2.5 3V2h11v1h-11z"/>
+          </svg>
+        </button>
+
         <!-- Pause / Resume toggle -->
         <button
           v-if="isPaused"
@@ -90,8 +103,11 @@
 
         <!-- Content preview -->
         <span class="item-content flex-grow-1" :title="item.content">
-          {{ truncate(item.content, 60) }}
+          {{ displayLabel(item) }}
         </span>
+
+        <!-- Timestamp -->
+        <span class="item-timestamp text-muted">{{ displayTimestamp(item) }}</span>
 
         <!-- Action buttons -->
         <button
@@ -135,6 +151,7 @@
 import { ref, computed, watch } from 'vue'
 import { useQueueStore } from '@/stores/queue'
 import { useSessionStore } from '@/stores/session'
+import { formatQueueTimestamp } from '@/utils/time'
 
 const props = defineProps({
   height: {
@@ -210,6 +227,21 @@ const isPaused = computed(() => {
 function truncate(text, maxLen) {
   if (!text) return ''
   return text.length > maxLen ? text.slice(0, maxLen) + '...' : text
+}
+
+function displayLabel(item) {
+  if (item.metadata?.schedule_name) return item.metadata.schedule_name
+  return truncate(item.content, 60)
+}
+
+function displayTimestamp(item) {
+  const ts = item.status === 'sent' && item.sent_at ? item.sent_at : item.created_at
+  return formatQueueTimestamp(ts)
+}
+
+async function doClearHistory() {
+  if (!sessionId.value) return
+  await queueStore.clearHistory(sessionId.value)
 }
 
 async function doCancel(queueId) {
@@ -364,5 +396,11 @@ async function doLoadMore() {
 
 .load-more-row {
   border-top: 1px solid var(--bs-border-color);
+}
+
+.item-timestamp {
+  font-size: 0.75rem;
+  flex-shrink: 0;
+  white-space: nowrap;
 }
 </style>

--- a/frontend/src/stores/queue.js
+++ b/frontend/src/stores/queue.js
@@ -125,6 +125,16 @@ export const useQueueStore = defineStore('queue', () => {
     }
   }
 
+  async function clearHistory(sessionId) {
+    try {
+      const data = await api.delete(`/api/sessions/${sessionId}/queue/history`)
+      return data.cleared_count
+    } catch (error) {
+      console.error('Failed to clear queue history:', error)
+      throw error
+    }
+  }
+
   async function pauseQueue(sessionId, paused) {
     try {
       const data = await api.put(`/api/sessions/${sessionId}/queue/pause`, { paused })
@@ -182,6 +192,7 @@ export const useQueueStore = defineStore('queue', () => {
     cancelItem,
     requeueItem,
     clearQueue,
+    clearHistory,
     pauseQueue,
     handleQueueUpdate,
     updatePauseState,

--- a/frontend/src/utils/time.js
+++ b/frontend/src/utils/time.js
@@ -80,6 +80,29 @@ export function formatDateSeparatorLabel(timestamp) {
 }
 
 /**
+ * Format a queue item timestamp as "YYYY-MM-DD h:mma" in local time.
+ * Hour has no leading zero; am/pm is lowercase.
+ *
+ * @param {number|string|null} timestamp - Timestamp from backend (Unix seconds or ISO)
+ * @returns {string} Formatted string, or empty string for missing timestamp
+ */
+export function formatQueueTimestamp(timestamp) {
+  if (!timestamp) return ''
+  const date = parseTimestamp(timestamp)
+  if (isNaN(date.getTime())) return ''
+
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  const hours24 = date.getHours()
+  const minutes = String(date.getMinutes()).padStart(2, '0')
+  const period = hours24 < 12 ? 'am' : 'pm'
+  const hours12 = hours24 % 12 || 12
+
+  return `${year}-${month}-${day} ${hours12}:${minutes}${period}`
+}
+
+/**
  * Get relative time (e.g., "2 minutes ago")
  *
  * @param {number|string} timestamp - Timestamp from backend

--- a/src/queue_manager.py
+++ b/src/queue_manager.py
@@ -18,6 +18,8 @@ from .timestamp_utils import get_unix_timestamp
 queue_logger = get_logger('queue_manager', category='QUEUE')
 logger = logging.getLogger(__name__)
 
+_TERMINAL_STATUSES: frozenset[str] = frozenset({"sent", "failed", "cancelled"})
+
 
 @dataclass
 class QueueItem:
@@ -80,9 +82,11 @@ class QueueManager:
         Replay queue.jsonl to rebuild in-memory state for a session.
 
         Returns list of all items (including terminal states for history).
+        Terminal items whose created_at <= cleared_at_max (from history_cleared markers) are dropped.
         """
         queue_file = self._get_queue_file(session_dir)
         items_by_id: dict[str, QueueItem] = {}
+        cleared_at_max: float = 0.0
 
         if not queue_file.exists():
             self._queues[session_id] = []
@@ -103,7 +107,12 @@ class QueueManager:
                     entry_type = entry.get("type")
                     queue_id = entry.get("queue_id")
 
-                    if entry_type == "enqueue":
+                    if entry_type == "history_cleared":
+                        ts = entry.get("cleared_at", 0.0)
+                        if ts > cleared_at_max:
+                            cleared_at_max = ts
+
+                    elif entry_type == "enqueue":
                         item = QueueItem(
                             queue_id=queue_id,
                             session_id=session_id,
@@ -127,7 +136,10 @@ class QueueManager:
         except Exception as e:
             logger.error(f"Failed to load queue for session {session_id}: {e}")
 
-        all_items = list(items_by_id.values())
+        all_items = [
+            i for i in items_by_id.values()
+            if not (i.status in _TERMINAL_STATUSES and cleared_at_max > 0 and i.created_at <= cleared_at_max)
+        ]
         all_items.sort(key=lambda x: x.position)
         self._queues[session_id] = all_items
 
@@ -297,6 +309,30 @@ class QueueManager:
 
         if count:
             queue_logger.info(f"Cleared {count} pending items for session {session_id}")
+        return count
+
+    async def clear_history(self, session_id: str, session_dir: Path) -> int:
+        """
+        Remove terminal (sent/failed/cancelled) items from the queue.
+
+        Appends a history_cleared marker to queue.jsonl so that load_queue
+        will drop these items on replay. Does not affect pending items.
+        Returns count of removed items.
+        """
+        queue = self._queues.get(session_id, [])
+        terminal_items = [i for i in queue if i.status in _TERMINAL_STATUSES]
+        if not terminal_items:
+            return 0
+
+        cleared_at = max(i.created_at for i in terminal_items)
+        await self._append_entry(session_dir, {
+            "type": "history_cleared",
+            "cleared_at": cleared_at,
+        })
+
+        self._queues[session_id] = [i for i in queue if i.status not in _TERMINAL_STATUSES]
+        count = len(terminal_items)
+        queue_logger.info(f"Cleared history ({count} terminal items) for session {session_id}")
         return count
 
     # =========================================================================

--- a/src/routers/queue.py
+++ b/src/routers/queue.py
@@ -71,6 +71,16 @@ def build_router(webui) -> APIRouter:
         await webui._broadcast_queue_update(session_id, "cleared", {"count": count})
         return {"cancelled_count": count}
 
+    @router.delete("/api/sessions/{session_id}/queue/history")
+    @handle_exceptions("clear queue history")
+    async def clear_queue_history(session_id: str):
+        """Remove terminal (sent/failed/cancelled) queue items."""
+        if not await webui.service.get_session_exists(session_id):
+            raise HTTPException(status_code=404, detail="Session not found")
+        count = await webui.coordinator.clear_queue_history(session_id)
+        await webui._broadcast_queue_update(session_id, "history_cleared", {"count": count})
+        return {"cleared_count": count}
+
     @router.put("/api/sessions/{session_id}/queue/pause")
     @handle_exceptions("pause queue")
     async def pause_queue(session_id: str, request: Request):

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -764,6 +764,13 @@ class SessionCoordinator:
             return 0
         return await self.queue_manager.clear_pending(session_id, session_dir)
 
+    async def clear_queue_history(self, session_id: str) -> int:
+        """Remove terminal (sent/failed/cancelled) queue items. Returns count removed."""
+        session_dir = await self.session_manager.get_session_directory(session_id)
+        if not session_dir:
+            return 0
+        return await self.queue_manager.clear_history(session_id, session_dir)
+
     async def get_queue(self, session_id: str, limit: int = 100, offset: int = 0) -> dict:
         """Get queue items for a session, paginated, most recent first."""
         all_items = [item.to_dict() for item in self.queue_manager.get_queue(session_id)]

--- a/src/tests/integration/test_api_queue.py
+++ b/src/tests/integration/test_api_queue.py
@@ -223,3 +223,68 @@ class TestQueueConfig:
         )
         assert resp.status_code == 200
         assert resp.json()["config"]["min_wait_seconds"] == 20
+
+
+class TestClearHistory:
+    async def test_clear_history_returns_count(self, api_integration_env):
+        client = api_integration_env["client"]
+        session = await _create_session(api_integration_env)
+        sid = session["session_id"]
+
+        # Enqueue 2 items and cancel them (terminal state)
+        for i in range(2):
+            enqueue_resp = await client.post(
+                f"/api/sessions/{sid}/queue-message",
+                json={"content": f"History item {i}"},
+            )
+            queue_id = enqueue_resp.json()["queue_id"]
+            await client.delete(f"/api/sessions/{sid}/queue/{queue_id}")
+
+        resp = await client.delete(f"/api/sessions/{sid}/queue/history")
+        assert resp.status_code == 200
+        assert resp.json()["cleared_count"] == 2
+
+    async def test_clear_history_preserves_pending(self, api_integration_env):
+        client = api_integration_env["client"]
+        session = await _create_session(api_integration_env)
+        sid = session["session_id"]
+
+        # Enqueue one item and cancel it, keep another pending
+        enqueue_resp = await client.post(
+            f"/api/sessions/{sid}/queue-message",
+            json={"content": "to cancel"},
+        )
+        queue_id = enqueue_resp.json()["queue_id"]
+        await client.delete(f"/api/sessions/{sid}/queue/{queue_id}")
+
+        await client.post(
+            f"/api/sessions/{sid}/queue-message",
+            json={"content": "keep me"},
+        )
+
+        resp = await client.delete(f"/api/sessions/{sid}/queue/history")
+        assert resp.status_code == 200
+        assert resp.json()["cleared_count"] == 1
+
+        queue_resp = await client.get(f"/api/sessions/{sid}/queue")
+        pending = [i for i in queue_resp.json()["items"] if i["status"] == "pending"]
+        assert len(pending) == 1
+        assert pending[0]["content"] == "keep me"
+
+    async def test_clear_history_emits_queue_update(self, api_integration_env):
+        client = api_integration_env["client"]
+        session = await _create_session(api_integration_env)
+        sid = session["session_id"]
+
+        # Enqueue and cancel an item so there is history to clear
+        enqueue_resp = await client.post(
+            f"/api/sessions/{sid}/queue-message",
+            json={"content": "terminal"},
+        )
+        queue_id = enqueue_resp.json()["queue_id"]
+        await client.delete(f"/api/sessions/{sid}/queue/{queue_id}")
+
+        resp = await client.delete(f"/api/sessions/{sid}/queue/history")
+        assert resp.status_code == 200
+        # Endpoint returns cleared_count (broadcast is fire-and-forget, not asserted here)
+        assert "cleared_count" in resp.json()

--- a/src/tests/test_queue_manager.py
+++ b/src/tests/test_queue_manager.py
@@ -289,3 +289,65 @@ class TestQueueManagerJSONLReplay:
         items = await mgr2.load_queue(sid, sdir)
         assert items[0].status == "failed"
         assert items[0].error == "test error"
+
+
+class TestClearHistory:
+    """Tests for QueueManager.clear_history and load_queue history_cleared handling."""
+
+    @pytest.mark.asyncio
+    async def test_clear_history_removes_terminal_items_only(self, queue_manager, temp_session):
+        sid, sdir = temp_session
+        pending_item = await queue_manager.enqueue(sid, sdir, "pending")
+        sent_item = await queue_manager.enqueue(sid, sdir, "sent")
+        failed_item = await queue_manager.enqueue(sid, sdir, "failed")
+        await queue_manager.mark_sent(sid, sdir, sent_item.queue_id)
+        await queue_manager.mark_failed(sid, sdir, failed_item.queue_id, "err")
+
+        count = await queue_manager.clear_history(sid, sdir)
+
+        assert count == 2
+        remaining = queue_manager.get_queue(sid)
+        assert len(remaining) == 1
+        assert remaining[0].queue_id == pending_item.queue_id
+        assert queue_manager.get_pending_count(sid) == 1
+
+    @pytest.mark.asyncio
+    async def test_clear_history_persists_across_reload(self, temp_session):
+        sid, sdir = temp_session
+        mgr1 = QueueManager()
+        pending_item = await mgr1.enqueue(sid, sdir, "pending")
+        sent_item = await mgr1.enqueue(sid, sdir, "sent")
+        await mgr1.mark_sent(sid, sdir, sent_item.queue_id)
+        await mgr1.clear_history(sid, sdir)
+
+        mgr2 = QueueManager()
+        items = await mgr2.load_queue(sid, sdir)
+        assert len(items) == 1
+        assert items[0].queue_id == pending_item.queue_id
+
+    @pytest.mark.asyncio
+    async def test_clear_history_empty_returns_zero(self, queue_manager, temp_session):
+        sid, sdir = temp_session
+        await queue_manager.enqueue(sid, sdir, "pending only")
+        count = await queue_manager.clear_history(sid, sdir)
+        assert count == 0
+
+    @pytest.mark.asyncio
+    async def test_clear_history_then_new_terminal_items_persist(self, temp_session):
+        """Items added after clear must not be dropped on reload (boundary guard)."""
+        sid, sdir = temp_session
+        mgr1 = QueueManager()
+        old_item = await mgr1.enqueue(sid, sdir, "old")
+        await mgr1.mark_sent(sid, sdir, old_item.queue_id)
+        await mgr1.clear_history(sid, sdir)
+
+        # Enqueue and send a new item after the clear
+        new_item = await mgr1.enqueue(sid, sdir, "new")
+        await mgr1.mark_sent(sid, sdir, new_item.queue_id)
+
+        # Reload — new sent item must survive
+        mgr2 = QueueManager()
+        items = await mgr2.load_queue(sid, sdir)
+        queue_ids = {i.queue_id for i in items}
+        assert new_item.queue_id in queue_ids
+        assert old_item.queue_id not in queue_ids


### PR DESCRIPTION
## Summary
Resolves #1498

Adds three UX improvements to the message queue (QueueSection): clear history button, schedule name label, and per-item timestamp column.

## Changes Made

**Backend**
- `QueueManager.clear_history()`: appends a `history_cleared` marker to `queue.jsonl`; `load_queue()` replays the log and filters terminal items whose `created_at <= cleared_at_max`
- `SessionCoordinator.clear_queue_history()`: delegates to QueueManager with session directory resolution
- `DELETE /api/sessions/{session_id}/queue/history`: new endpoint broadcasting `history_cleared` event

**Frontend**
- `time.js formatQueueTimestamp()`: formats Unix timestamp as `YYYY-MM-DD h:mma` in local time (manual 12-hour clock to avoid locale variance)
- `queue.js clearHistory()`: store action calling the new DELETE endpoint
- `QueueSection.vue`:
  - Trash icon button (shown when terminal items exist) calls `clearHistory`
  - Content label shows `item.metadata.schedule_name` when set, falls back to truncated content; full prompt in tooltip
  - Timestamp column on every row: `sent_at` for sent items, `created_at` otherwise

**Tests**
- 4 unit tests (`TestClearHistory` in `test_queue_manager.py`)
- 3 integration tests (`TestClearHistory` in `test_api_queue.py`)

## Testing
- 31 unit tests pass (`uv run pytest src/tests/ -v`)
- Ruff linting: zero violations
- Servers running for manual review: backend :8498, frontend :5498

🤖 Generated with [Claude Code](https://claude.com/claude-code)