### PR TITLE
fix: watchdog detects silent consumer death in _message_processing_loop (#1503)

### DIFF
--- a/src/claude_sdk.py
+++ b/src/claude_sdk.py
@@ -675,6 +675,12 @@ class ClaudeSDK:
                                     "immediate_cli_failure",
                                     Exception(error_msg),
                                 )
+                    finally:
+                        if not self._shutdown_event.is_set():
+                            sdk_logger.warning(
+                                f"[session {self.session_id}] consume_all_responses exited "
+                                f"while shutdown_event not set — watchdog will surface FAILED"
+                            )
 
                 # Start response consumer as background task
                 response_consumer_task = asyncio.create_task(consume_all_responses())
@@ -682,6 +688,9 @@ class ClaudeSDK:
 
                 # Main message loop - just send queries, consumer handles all responses
                 while not self._shutdown_event.is_set():
+                    if not await self._check_consumer_alive(response_consumer_task):
+                        break
+
                     try:
                         message_data = await asyncio.wait_for(
                             self._message_queue.get(),
@@ -816,6 +825,39 @@ class ClaudeSDK:
             sdk_logger.info(f"Total loop runtime: {cleanup_time - loop_start_time:.3f}s")
             sdk_logger.info("Message processing loop ENDED")
 
+
+    async def _check_consumer_alive(self, task: asyncio.Task) -> bool:
+        """Return False and transition to FAILED if consumer exited outside of shutdown."""
+        if not task.done():
+            return True
+        if self._shutdown_event.is_set():
+            return True
+
+        # Consumer died unexpectedly. Build a diagnostic.
+        exc: BaseException | None = None
+        if task.cancelled():
+            reason = "Response consumer task was cancelled"
+        else:
+            exc = task.exception()
+            reason = (
+                f"Response consumer exited with exception: {exc!r}"
+                if exc is not None
+                else "Response consumer exited normally (subprocess stdout closed?)"
+            )
+
+        sdk_logger.error(f"[session {self.session_id}] {reason}")
+
+        self.info.state = SessionState.FAILED
+        self.info.error_message = reason
+
+        if self.error_callback:
+            await self._safe_callback(
+                self.error_callback,
+                "consumer_task_died",
+                exc if exc is not None else Exception(reason),
+            )
+
+        return False
 
     def _get_sdk_options(self):
         """Configure SDK options with correct parameter names for new ClaudeSDKClient pattern."""

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -4384,7 +4384,12 @@ class SessionCoordinator:
                     logger.exception(f"Failed to reset processing state for session {session_id}")
 
                 # Handle critical errors that require session state updates
-                if error_type in ["startup_failed", "message_processing_loop_error", "immediate_cli_failure"]:
+                if error_type in [
+                    "startup_failed",
+                    "message_processing_loop_error",
+                    "immediate_cli_failure",
+                    "consumer_task_died",          # Issue #1503
+                ]:
                     # logger.info(f"Handling critical SDK error: {error_type}")
 
                     # Extract user-friendly error message, preserve raw for details

--- a/src/tests/test_claude_sdk.py
+++ b/src/tests/test_claude_sdk.py
@@ -1,6 +1,7 @@
 """Tests for Claude Code SDK wrapper."""
 
 import asyncio
+import contextlib
 import tempfile
 
 import pytest
@@ -261,6 +262,114 @@ class TestClaudeSDK:
 
         assert converted["type"] == "result"
         assert "deferred_tool_use" not in converted
+
+    # --- Issue #1503: _check_consumer_alive watchdog tests ---
+
+    @pytest.mark.asyncio
+    async def test_check_consumer_alive_detects_clean_exit(self, temp_dir, session_id):
+        """Issue #1503: consumer task that returned normally must be flagged dead."""
+        errors_received = []
+
+        async def error_callback(error_type, exc):
+            errors_received.append((error_type, exc))
+
+        sdk = ClaudeSDK(
+            session_id=session_id,
+            working_directory=temp_dir,
+            error_callback=error_callback,
+        )
+        sdk.info.state = SessionState.RUNNING
+
+        async def immediate_return():
+            return
+
+        task = asyncio.create_task(immediate_return())
+        await task  # ensure task.done() is True
+
+        alive = await sdk._check_consumer_alive(task)
+
+        assert alive is False
+        assert sdk.info.state == SessionState.FAILED
+        assert sdk.info.error_message is not None
+        assert len(errors_received) == 1
+        assert errors_received[0][0] == "consumer_task_died"
+
+    @pytest.mark.asyncio
+    async def test_check_consumer_alive_detects_cancelled(self, temp_dir, session_id):
+        """Issue #1503: CancelledError leaking through consumer must be flagged dead
+        when shutdown_event is not set."""
+        errors_received = []
+
+        async def error_callback(error_type, exc):
+            errors_received.append((error_type, exc))
+
+        sdk = ClaudeSDK(
+            session_id=session_id,
+            working_directory=temp_dir,
+            error_callback=error_callback,
+        )
+        sdk.info.state = SessionState.RUNNING
+
+        async def gets_cancelled():
+            await asyncio.sleep(10)
+
+        task = asyncio.create_task(gets_cancelled())
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+        alive = await sdk._check_consumer_alive(task)
+
+        assert alive is False
+        assert sdk.info.state == SessionState.FAILED
+        assert errors_received[0][0] == "consumer_task_died"
+
+    @pytest.mark.asyncio
+    async def test_check_consumer_alive_silent_during_shutdown(self, temp_dir, session_id):
+        """Issue #1503: a finished consumer during intentional shutdown is not a failure."""
+        errors_received = []
+
+        async def error_callback(error_type, exc):
+            errors_received.append((error_type, exc))
+
+        sdk = ClaudeSDK(
+            session_id=session_id,
+            working_directory=temp_dir,
+            error_callback=error_callback,
+        )
+        sdk.info.state = SessionState.RUNNING
+        sdk._shutdown_event.set()
+
+        async def immediate_return():
+            return
+
+        task = asyncio.create_task(immediate_return())
+        await task
+
+        alive = await sdk._check_consumer_alive(task)
+
+        assert alive is True
+        assert sdk.info.state == SessionState.RUNNING  # untouched
+        assert errors_received == []
+
+    @pytest.mark.asyncio
+    async def test_check_consumer_alive_healthy_task(self, temp_dir, session_id):
+        """Issue #1503: watchdog returns True and leaves state unchanged for a running task."""
+        sdk = ClaudeSDK(session_id=session_id, working_directory=temp_dir)
+        sdk.info.state = SessionState.RUNNING
+
+        async def long_running():
+            await asyncio.sleep(10)
+
+        task = asyncio.create_task(long_running())
+        try:
+            alive = await sdk._check_consumer_alive(task)
+            assert alive is True
+            assert sdk.info.state == SessionState.RUNNING
+        finally:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
 
 
 class TestSessionInfo:


### PR DESCRIPTION
## Summary
Resolves #1503

`consume_all_responses` could exit silently while `_message_processing_loop` kept running — leaving the session stuck in `RUNNING` state with no error event pushed to the frontend. This happened on two paths: normal generator exhaustion (subprocess stdout closed, e.g. Docker container restart) and `BaseException` subclasses (e.g. `CancelledError`) that bypassed the existing `except Exception` guard.

## Changes Made

- **`src/claude_sdk.py`** — Add `_check_consumer_alive(task)`: called at the top of each main-loop iteration; returns `False` and transitions to `SessionState.FAILED` if the consumer task has exited outside of intentional shutdown. Wire into the `while` loop with an immediate `break` on failure.
- **`src/claude_sdk.py`** — Add `finally` block to `consume_all_responses` that logs a warning when the consumer exits while `_shutdown_event` is not set (debug aid; side-effects are owned by the watchdog).
- **`src/session_coordinator.py`** — Add `"consumer_task_died"` to the critical-error list in `_create_error_callback` so the coordinator transitions to `SessionState.ERROR`, resets `is_processing`, notifies the frontend, and removes the dead SDK from `_active_sdks`.

## Testing

- 4 new unit tests in `src/tests/test_claude_sdk.py` covering all watchdog paths:
  - clean exit (generator exhaustion)
  - `CancelledError` leak
  - intentional shutdown (no false positive)
  - healthy running task (no false positive)
- All 22 tests in `test_claude_sdk.py` pass; 14 pre-existing failures in unrelated OAuth/route-count tests are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)