### PR TITLE
fix: restore green CI — 17 failing tests across four groups (#1510)

### DIFF
--- a/src/docker/proxy/addon.py
+++ b/src/docker/proxy/addon.py
@@ -17,6 +17,10 @@ Typed injection/scrub handlers are inlined (addon.py must be self-contained
 inside the Docker image — it cannot import from the host src/ tree).
 """
 
+from __future__ import (
+    annotations,  # lazy annotation evaluation — tcp.TCPFlow removed in mitmproxy 11+
+)
+
 import asyncio
 import base64
 import ipaddress

--- a/src/routers/queue.py
+++ b/src/routers/queue.py
@@ -39,6 +39,16 @@ def build_router(webui) -> APIRouter:
         result = await webui.coordinator.get_queue(session_id, limit=limit, offset=offset)
         return result
 
+    @router.delete("/api/sessions/{session_id}/queue/history")
+    @handle_exceptions("clear queue history")
+    async def clear_queue_history(session_id: str):
+        """Remove terminal (sent/failed/cancelled) queue items."""
+        if not await webui.service.get_session_exists(session_id):
+            raise HTTPException(status_code=404, detail="Session not found")
+        count = await webui.coordinator.clear_queue_history(session_id)
+        await webui._broadcast_queue_update(session_id, "history_cleared", {"count": count})
+        return {"cleared_count": count}
+
     @router.delete("/api/sessions/{session_id}/queue/{queue_id}")
     @handle_exceptions("cancel queue item")
     async def cancel_queue_item(session_id: str, queue_id: str):
@@ -70,16 +80,6 @@ def build_router(webui) -> APIRouter:
         count = await webui.coordinator.clear_queue(session_id)
         await webui._broadcast_queue_update(session_id, "cleared", {"count": count})
         return {"cancelled_count": count}
-
-    @router.delete("/api/sessions/{session_id}/queue/history")
-    @handle_exceptions("clear queue history")
-    async def clear_queue_history(session_id: str):
-        """Remove terminal (sent/failed/cancelled) queue items."""
-        if not await webui.service.get_session_exists(session_id):
-            raise HTTPException(status_code=404, detail="Session not found")
-        count = await webui.coordinator.clear_queue_history(session_id)
-        await webui._broadcast_queue_update(session_id, "history_cleared", {"count": count})
-        return {"cleared_count": count}
 
     @router.put("/api/sessions/{session_id}/queue/pause")
     @handle_exceptions("pause queue")

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -266,11 +266,7 @@ async def api_integration_env(request, tmp_path):
     # Cleanup
     await client.aclose()
     try:
-        for session_id in list(coordinator._active_sdks.keys()):
-            try:
-                await coordinator.terminate_session(session_id)
-            except Exception:
-                pass
+        await webui.cleanup()
     except Exception:
         pass
 

--- a/src/tests/test_issue_813_oauth.py
+++ b/src/tests/test_issue_813_oauth.py
@@ -247,6 +247,7 @@ async def test_get_mcp_sdk_config_injects_bearer_token(tmp_path: Path):
     mcp_cfg.id = "srv-oauth"
     mcp_cfg.type = McpServerType.HTTP
     mcp_cfg.oauth_enabled = True
+    mcp_cfg.shared_connection = False
     mcp_cfg.to_sdk_config.return_value = {
         "type": "http",
         "url": "https://mcp.example.com/v1/mcp",
@@ -269,6 +270,7 @@ async def test_get_mcp_sdk_config_no_token_no_header(tmp_path: Path):
     mcp_cfg.id = "srv-no-token"
     mcp_cfg.type = McpServerType.HTTP
     mcp_cfg.oauth_enabled = True
+    mcp_cfg.shared_connection = False
     mcp_cfg.to_sdk_config.return_value = {
         "type": "http",
         "url": "https://mcp.example.com/v1/mcp",
@@ -346,6 +348,7 @@ async def test_get_mcp_sdk_config_non_oauth_passthrough(tmp_path: Path):
     mcp_cfg.id = "srv-stdio"
     mcp_cfg.type = McpServerType.STDIO
     mcp_cfg.oauth_enabled = False
+    mcp_cfg.shared_connection = False
     mcp_cfg.to_sdk_config.return_value = expected
 
     sdk_config = await coordinator._get_mcp_sdk_config(mcp_cfg)

--- a/src/tests/test_issue_976_oauth_refresh.py
+++ b/src/tests/test_issue_976_oauth_refresh.py
@@ -276,6 +276,7 @@ def _make_mcp_cfg(server_id: str = "srv-oauth") -> MagicMock:
     mcp_cfg.id = server_id
     mcp_cfg.type = McpServerType.HTTP
     mcp_cfg.oauth_enabled = True
+    mcp_cfg.shared_connection = False
     mcp_cfg.to_sdk_config.return_value = {
         "type": "http",
         "url": "https://mcp.example.com/v1/mcp",

--- a/src/tests/test_route_inventory.py
+++ b/src/tests/test_route_inventory.py
@@ -5,7 +5,7 @@ def test_route_count_unchanged():
     from src.web_server import create_app
     app = create_app()
     api_routes = [r for r in app.routes if hasattr(r, "methods")]
-    assert len(api_routes) == 139, (
-        f"Expected 139 routes (+1 usage from #1125, +1 edit-history from #1128, +3 audit from #1127, +1 analytics from #1132, -2 legacy images from #1261, +1 oauth import-as-secret from #1381, -1 cancel-schedule from #1416, +1 reparent-minion from #1422, +1 session-routing from #1427-phase3, +6 provider-catalog from #1427-phase4), got {len(api_routes)}. "
+    assert len(api_routes) == 140, (
+        f"Expected 140 routes (+1 usage from #1125, +1 edit-history from #1128, +3 audit from #1127, +1 analytics from #1132, -2 legacy images from #1261, +1 oauth import-as-secret from #1381, -1 cancel-schedule from #1416, +1 reparent-minion from #1422, +1 session-routing from #1427-phase3, +6 provider-catalog from #1427-phase4, +1 queue-history from #1502), got {len(api_routes)}. "
         "A route was added or removed."
     )

--- a/src/tests/test_session_coordinator.py
+++ b/src/tests/test_session_coordinator.py
@@ -789,6 +789,7 @@ class TestIssue1375SecretRefs:
         mock_cfg = MagicMock()
         mock_cfg.type = McpServerType.STDIO
         mock_cfg.oauth_enabled = False
+        mock_cfg.shared_connection = False
         mock_cfg.to_sdk_config.return_value = {
             "type": "stdio",
             "command": "mcp-server",
@@ -816,6 +817,7 @@ class TestIssue1375SecretRefs:
         mock_cfg.name = "oauth-server"
         mock_cfg.type = McpServerType.HTTP
         mock_cfg.oauth_enabled = True
+        mock_cfg.shared_connection = False
         mock_cfg.to_sdk_config.return_value = {
             "type": "http",
             "url": "https://example.com/mcp",
@@ -1418,6 +1420,7 @@ class TestIssue1425OAuthPlaceholder:
         mock_cfg.name = "gh-mcp"
         mock_cfg.type = McpServerType.SSE
         mock_cfg.oauth_enabled = True
+        mock_cfg.shared_connection = False
         mock_cfg.to_sdk_config.return_value = {
             "type": "sse",
             "url": "https://mcp.github.com/sse",
@@ -1449,6 +1452,7 @@ class TestIssue1425OAuthPlaceholder:
         mock_cfg.name = "no-auth-mcp"
         mock_cfg.type = McpServerType.HTTP
         mock_cfg.oauth_enabled = True
+        mock_cfg.shared_connection = False
         mock_cfg.to_sdk_config.return_value = {
             "type": "http",
             "url": "https://example.com/mcp",
@@ -1478,6 +1482,7 @@ class TestIssue1425OAuthPlaceholder:
         mock_cfg.name = "hardcoded-mcp"
         mock_cfg.type = McpServerType.HTTP
         mock_cfg.oauth_enabled = True
+        mock_cfg.shared_connection = False
         mock_cfg.to_sdk_config.return_value = {
             "type": "http",
             "url": "https://example.com/mcp",
@@ -1507,6 +1512,7 @@ class TestIssue1425OAuthPlaceholder:
         mock_cfg.name = "no-oauth-mcp"
         mock_cfg.type = McpServerType.HTTP
         mock_cfg.oauth_enabled = False
+        mock_cfg.shared_connection = False
         mock_cfg.to_sdk_config.return_value = {
             "type": "http",
             "url": "https://example.com/mcp",
@@ -1538,6 +1544,7 @@ class TestIssue1425OAuthPlaceholder:
         mock_cfg.name = "log-mcp"
         mock_cfg.type = McpServerType.HTTP
         mock_cfg.oauth_enabled = True
+        mock_cfg.shared_connection = False
         mock_cfg.to_sdk_config.return_value = {
             "type": "http",
             "url": "https://example.com/mcp",


### PR DESCRIPTION
## Summary

Resolves #1510

Fixes all 17 reproducible test failures across four groups.

## Changes Made

**Group A — `src/docker/proxy/addon.py`** (production code)
- Add `from __future__ import annotations` so `tcp.TCPFlow` in the `tcp_start` type annotation is evaluated lazily — `TCPFlow` was removed in mitmproxy 11+ and causes `AttributeError` at module load time on Python <3.14

**Group B — OAuth/MCP test mocks** (13 tests across 3 files)
- `test_issue_813_oauth.py` (3), `test_issue_976_oauth_refresh.py` (1 helper), `test_session_coordinator.py` (7)
- Add `shared_connection = False` to each `MagicMock` `mcp_cfg` object so `_get_mcp_sdk_config()` takes the direct OAuth path instead of calling `shared_mcp_manager.get_or_open()`, which now passes config attributes to httpx/pydantic and rejects `MagicMock` values

**Group C — `test_route_inventory.py`** (1 test)
- Bump expected route count 139 → 140; `DELETE /api/sessions/{id}/queue/history` was added by #1502

**Group D — `src/routers/queue.py` + `src/tests/integration/conftest.py`** (3 tests)
- Move `DELETE /queue/history` registration before `DELETE /queue/{queue_id}` — FastAPI matched the literal path segment "history" as the `{queue_id}` parameter, returning 404
- Fix `api_integration_env` fixture teardown to call `webui.cleanup()` so the LiteLLM proxy is stopped between tests, eliminating the port-4000 bind conflict that caused tests 2 and 3 of `TestClearHistory` to error in fixture setup

## Testing

- `uv run pytest src/tests/test_issue_813_oauth.py src/tests/test_issue_976_oauth_refresh.py src/tests/test_session_coordinator.py::TestIssue1375SecretRefs src/tests/test_session_coordinator.py::TestIssue1425OAuthPlaceholder src/tests/test_route_inventory.py src/tests/integration/test_api_queue.py::TestClearHistory` — 50 passed
- `uv run pytest src/tests/ --ignore=src/tests/integration` — 1629 passed, 0 failures
- `uv run ruff check src/` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)