### PR TITLE
fix: escape letter-based emoticons in comark markdown preprocessing

### DIFF
--- a/frontend/src/components/common/__tests__/markdownPreprocess.test.js
+++ b/frontend/src/components/common/__tests__/markdownPreprocess.test.js
@@ -135,4 +135,108 @@ describe('preprocessPortColons', () => {
     const input = 'some :word here'
     expect(preprocessPortColons(input)).toBe(input)
   })
+
+  // §4.1 — letter emoticons
+  it('escapes :D in prose', () => {
+    expect(preprocessPortColons('nice work :D'))
+      .toBe('nice work \\:D')
+  })
+
+  it('escapes :P, :O, :S, :X uppercase emoticons', () => {
+    expect(preprocessPortColons('feeling :P then :O then :S then :X'))
+      .toBe('feeling \\:P then \\:O then \\:S then \\:X')
+  })
+
+  it('escapes :D at start of line', () => {
+    expect(preprocessPortColons(':D wow'))
+      .toBe('\\:D wow')
+  })
+
+  it('escapes :D followed by punctuation', () => {
+    expect(preprocessPortColons('cool :D.'))
+      .toBe('cool \\:D.')
+  })
+
+  it('escapes :D at end of string', () => {
+    expect(preprocessPortColons('nice :D'))
+      .toBe('nice \\:D')
+  })
+
+  // §4.2 — paren / pipe / semicolon emoticons
+  it('escapes :) emoticon', () => {
+    expect(preprocessPortColons('hello :) world'))
+      .toBe('hello \\:) world')
+  })
+
+  it('escapes :( emoticon', () => {
+    expect(preprocessPortColons('oh no :( sad'))
+      .toBe('oh no \\:( sad')
+  })
+
+  it('escapes ;) wink', () => {
+    expect(preprocessPortColons('right ;) ok'))
+      .toBe('right \\;) ok')
+  })
+
+  it('escapes :| neutral emoticon', () => {
+    expect(preprocessPortColons('meh :| whatever'))
+      .toBe('meh \\:| whatever')
+  })
+
+  it('escapes mixed emoticons in one line', () => {
+    expect(preprocessPortColons('hi :D, sad :(, wink ;)'))
+      .toBe('hi \\:D, sad \\:(, wink \\;)')
+  })
+
+  // §4.3 — must NOT escape valid MDC components
+  it('leaves multi-letter MDC component :Alert alone', () => {
+    const input = 'see :Alert for details'
+    expect(preprocessPortColons(input)).toBe(input)
+  })
+
+  it('leaves :Alert{type="info"} component invocation alone', () => {
+    const input = ':Alert{type="info"} heads up'
+    expect(preprocessPortColons(input)).toBe(input)
+  })
+
+  it('leaves single-letter MDC component with attributes :D{prop=x} alone', () => {
+    const input = ':D{prop=x} component'
+    expect(preprocessPortColons(input)).toBe(input)
+  })
+
+  it('leaves :Door (starts with :D but continues with letters) alone', () => {
+    const input = 'open the :Door now'
+    expect(preprocessPortColons(input)).toBe(input)
+  })
+
+  // §4.4 — code / table / boundary preservation
+  it('leaves emoticons in fenced code blocks alone', () => {
+    const input = 'see\n```\nprint(":D")\nemoji = ":)"\n```\nafter'
+    expect(preprocessPortColons(input)).toBe(input)
+  })
+
+  it('leaves emoticons in inline code spans alone', () => {
+    const input = 'use `:D` literally'
+    expect(preprocessPortColons(input)).toBe(input)
+  })
+
+  it('leaves emoticons in indented code blocks alone', () => {
+    const input = 'para\n\n    log(":D happened")\n\nmore'
+    expect(preprocessPortColons(input)).toBe(input)
+  })
+
+  it('leaves GFM table alignment row unchanged', () => {
+    const input = '| col | num |\n|---:|:---|\n| 1   | a   |'
+    expect(preprocessPortColons(input)).toBe(input)
+  })
+
+  it('leaves lowercase :d alone (not a conventional emoticon)', () => {
+    const input = 'the :d thing'
+    expect(preprocessPortColons(input)).toBe(input)
+  })
+
+  it('leaves :D embedded after a word character alone', () => {
+    const input = 'abc:D thing'
+    expect(preprocessPortColons(input)).toBe(input)
+  })
 })

--- a/frontend/src/components/common/markdownPreprocess.js
+++ b/frontend/src/components/common/markdownPreprocess.js
@@ -19,19 +19,23 @@ export function preprocessLeadingThematicBreak(content) {
 // Module-level with g flag — lastIndex must be reset at the start of each call.
 const CODE_SEGMENT = /(```[\s\S]*?```|~~~[\s\S]*?~~~|`[^`\n]*?`)/g
 const INDENTED_CODE = /^ {4,}\S/
+const TABLE_DELIM = /^[\s|:\-]+$/
+// Escapes port colons (:\d) and letter/punctuation emoticons (:D :P :O :S :X :) :( :| ;) ;()
+const PROSE_COLON = /(^|[^A-Za-z0-9/])(:\d|:[DPOSX](?![A-Za-z{])|:[)(|]|;[)(])/g
 
 function escapeInProse(text) {
   if (!text) return text
   return text.split('\n').map(line => {
-    if (!line.includes(':')) return line
+    if (!line.includes(':') && !line.includes(';')) return line
     if (INDENTED_CODE.test(line)) return line
-    return line.replace(/(^|[^A-Za-z0-9/])(:\d)/g, '$1\\$2')
+    if (TABLE_DELIM.test(line)) return line
+    return line.replace(PROSE_COLON, '$1\\$2')
   }).join('\n')
 }
 
 export function preprocessPortColons(content) {
   if (typeof content !== 'string') return content
-  if (!content.includes(':')) return content
+  if (!content.includes(':') && !content.includes(';')) return content
 
   let out = ''
   let lastIndex = 0


### PR DESCRIPTION
## Summary

Resolves #1532

Extends the existing `preprocessPortColons()` prose-escape mechanism to also backslash-escape letter-based and punctuation emoticons before comark's MDC parser silently drops them as unresolved component names.

## Changes Made

- Extend `escapeInProse` regex to cover `:D` `:P` `:O` `:S` `:X` (letter emoticons) and `:)` `:(` `:|` `;)` `;(` (paren/semicolon emoticons) — existing `:\d` port-colon branch is unchanged
- Add `TABLE_DELIM` constant and guard to prevent the new `:|` branch from corrupting GFM table alignment rows (`|---:|---|`)
- Widen both fast-path short-circuits to also bail on `!includes(';')` so semicolon-only emoticons aren't skipped by the outer fast-path
- Lift the regex to a module-level `PROSE_COLON` constant for readability
- Add 20 new test cases (positive, negative MDC preservation, code/table exclusions, regression)

## Testing

- `cd frontend && npm run test -- markdownPreprocess` — 47/47 tests pass
- Prose with `:D`, `:)`, `;)` renders the emoticon literally instead of disappearing
- MDC components like `:Alert{type="info"}` still render correctly (negative lookahead `(?![A-Za-z{])`)
- GFM table alignment row `|---:|---|` unchanged (TABLE_DELIM guard)
- Content inside fenced/inline/indented code blocks unaffected (existing walker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)