### PR TITLE
feat: integrate Playwright CLI into dev Dockerfile

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -72,6 +72,16 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
     && apt-get update && apt-get install -y --no-install-recommends gh
 
+# ---------- Layer 4b: Playwright CLI (global, run as root before user switch) ----------
+RUN --mount=type=cache,target=/root/.npm,sharing=locked \
+    npm install -g @playwright/cli@latest
+
+# ---------- Layer 4c: ffmpeg for playwright-cli video recording ----------
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
+    apt-get update && apt-get install -y --no-install-recommends ffmpeg
+
 # ssh 7.3+ silently ignores an Include of a non-existent path — safe when no SSH secrets are configured.
 RUN echo "Include /run/ssh/config" >> /etc/ssh/ssh_config
 
@@ -79,6 +89,12 @@ RUN echo "Include /run/ssh/config" >> /etc/ssh/ssh_config
 RUN useradd -m -s /bin/bash claude
 
 USER claude
+
+# ---------- Layer 5b: Playwright CLI — install global skills + config ----------
+RUN playwright-cli install --skills 2>/dev/null || true
+RUN mkdir -p /home/claude/.playwright && \
+    printf '{\n  "browser": {\n    "browserName": "chromium",\n    "launchOptions": {\n      "executablePath": "/usr/bin/chromium",\n      "chromiumSandbox": false,\n      "args": ["--no-sandbox", "--disable-setuid-sandbox"]\n    }\n  }\n}\n' \
+    > /home/claude/.playwright/cli.config.json
 
 # ---------- Layer 6: UV Python package manager ----------
 RUN curl -fsSL https://astral.sh/uv/install.sh | bash


### PR DESCRIPTION
## Summary
Resolves #1542

Add `@playwright/cli` (Playwright MCP browser automation tool), `ffmpeg`, and a pre-configured `cli.config.json` to the dev Docker image so `playwright-cli` is available out of the box without any per-session setup.

## Changes Made
- **Layer 4b**: `npm install -g @playwright/cli@latest` (as root, with BuildKit npm cache mount)
- **Layer 4c**: `apt-get install ffmpeg` for `playwright-cli` video recording support
- **Layer 5b**: `playwright-cli install --skills` (optional, guarded with `|| true`) + write `/home/claude/.playwright/cli.config.json` pointing at the system Chromium binary (`/usr/bin/chromium`) with `--no-sandbox` / `--disable-setuid-sandbox` flags for containerised environments

Layer ordering places the new layers before UV/Claude Code CLI so bumping `CLAUDE_CODE_VERSION` does not invalidate the Playwright cache layers.

## Testing
- Build: `docker build -f docker/Dockerfile.dev -t claudecode-webui-dev:local docker/`
- Smoke checks inside container:
  - `playwright-cli --version` → exit 0
  - `which playwright-cli` → `/usr/local/bin/playwright-cli`
  - `cat /home/claude/.playwright/cli.config.json` → correct JSON with Chromium path + sandbox flags
  - `ffmpeg -version` → exit 0
  - `chromium --version` → exit 0 (sanity check Layer 3 not perturbed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)