### PR TITLE
feat: register proxy CA in Chromium NSS store at container startup

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -59,7 +59,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update && apt-get install -y --no-install-recommends \
     chromium \
     chromium-driver \
-    fonts-noto-color-emoji
+    fonts-noto-color-emoji \
+    libnss3-tools
 
 # ---------- Layer 4: gh CLI (GitHub CLI) ----------
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -104,8 +105,11 @@ RUN curl -fsSL https://astral.sh/uv/install.sh | bash
 ARG CLAUDE_CODE_VERSION=2.1.149
 RUN curl -fsSL https://claude.ai/install.sh | bash -s ${CLAUDE_CODE_VERSION}
 
-# ---------- Layer 8: PATH and entrypoint ----------
+# ---------- Layer 8: PATH, environment, and entrypoint ----------
 ENV PATH="/home/claude/.local/bin:${PATH}"
+ENV UV_NATIVE_TLS=1
 
 # Workspace path and working directory set at runtime via docker run -w
-ENTRYPOINT ["claude"]
+COPY --chown=claude:claude entrypoint.sh /home/claude/.local/bin/entrypoint.sh
+RUN chmod +x /home/claude/.local/bin/entrypoint.sh
+ENTRYPOINT ["entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+PROXY_CA="/run/proxy-ca/ca.crt"
+NSS_DB="${HOME}/.pki/nssdb"
+
+if [ -f "${PROXY_CA}" ]; then
+    mkdir -p "${NSS_DB}"
+    certutil -N -d "sql:${NSS_DB}" --empty-password 2>/dev/null || true
+    certutil -A -d "sql:${NSS_DB}" -n "ProxyCA" -t "CT,," -i "${PROXY_CA}" 2>/dev/null && \
+        echo "[entrypoint] Proxy CA registered in Chromium NSS store." || \
+        echo "[entrypoint] Warning: failed to register proxy CA." >&2
+fi
+
+exec claude "$@"


### PR DESCRIPTION
## Summary
Resolves #1547

Add automatic proxy CA registration into Chromium's NSS certificate store at container startup, and enable `UV_NATIVE_TLS=1` so `uv` uses the system's native TLS stack.

## Changes Made
- `docker/Dockerfile.dev`: add `libnss3-tools` to the Chromium apt layer (Layer 3) so `certutil` is available
- `docker/Dockerfile.dev`: add `ENV UV_NATIVE_TLS=1` in Layer 8 for uv native TLS
- `docker/Dockerfile.dev`: replace `ENTRYPOINT ["claude"]` with a COPY + chmod + `ENTRYPOINT ["entrypoint.sh"]` block
- `docker/entrypoint.sh` (new): bash script that imports `/run/proxy-ca/ca.crt` into `~/.pki/nssdb` when the file is present, then `exec claude "$@"`; silent no-op when no CA is mounted

## Testing
- Manual: `docker build -f docker/Dockerfile.dev -t claudecode-webui-dev:local docker/`
- Smoke test — certutil available: `docker run --rm --entrypoint bash claudecode-webui-dev:local -c "command -v certutil"`
- No-op path (no CA mounted): container starts normally with no warnings
- CA registration path: mount a self-signed CA at `/run/proxy-ca/ca.crt`; expect `[entrypoint] Proxy CA registered in Chromium NSS store.` and `certutil -L` listing `ProxyCA`
- UV_NATIVE_TLS: `docker run --rm --entrypoint bash claudecode-webui-dev:local -c 'echo $UV_NATIVE_TLS'` → `1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)