### PR TITLE
feat: pre-warm uv cache in Dockerfile.dev (#1548)

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -5,7 +5,7 @@
 # and GitHub CLI (gh) for GitHub operations.
 #
 # Build:
-#   docker build -f docker/Dockerfile.dev -t claudecode-webui-dev:local docker/
+#   docker build -f docker/Dockerfile.dev -t claudecode-webui-dev:local .
 #
 # Usage with claude-docker:
 #   Set session Docker image to "claudecode-webui-dev:local" or:
@@ -99,17 +99,43 @@ RUN mkdir -p /home/claude/.playwright && \
 
 # ---------- Layer 6: UV Python package manager ----------
 RUN curl -fsSL https://astral.sh/uv/install.sh | bash
+ENV PATH="/home/claude/.local/bin:${PATH}"
+
+# ---------- Layer 6b: Pre-warm uv cache (Issue #1548) ----------
+# Approach A (bake-into-image): copy the project's lock + manifest and run
+# `uv sync` at build time so all wheels — including native packages like
+# uvloop, cryptography, pydantic-core, watchfiles — are downloaded and
+# compiled once and cached at /home/claude/.cache/uv. At runtime, `uv sync`
+# in the mounted workspace reads the cache and assembles .venv from copies,
+# bypassing source compilation.
+#
+# Placement: this layer MUST sit ABOVE the Claude Code CLI layer below.
+# CLAUDE_CODE_VERSION is bumped every few days in lockstep with
+# claude-agent-sdk; anything beneath that layer is rebuilt on every bump,
+# which would re-compile all native wheels and defeat the cache. Project
+# deps (pyproject.toml / uv.lock) change much less often than the Claude
+# Code CLI version, so this is the correct layer ordering.
+#
+# Drift caveat: when pyproject.toml/uv.lock change, the runtime `uv sync`
+# will pull/build the delta online; rebuild the image to refresh the
+# baseline.
+COPY --chown=claude:claude pyproject.toml uv.lock /tmp/prewarm/
+RUN cd /tmp/prewarm \
+    && uv python install 3.13 \
+    && uv sync --frozen --no-install-project \
+    && rm -rf /tmp/prewarm
 
 # ---------- Layer 7: Claude Code CLI ----------
 # Bump in lockstep with claude-agent-sdk in pyproject.toml/uv.lock.
 ARG CLAUDE_CODE_VERSION=2.1.149
 RUN curl -fsSL https://claude.ai/install.sh | bash -s ${CLAUDE_CODE_VERSION}
 
-# ---------- Layer 8: PATH, environment, and entrypoint ----------
-ENV PATH="/home/claude/.local/bin:${PATH}"
+# ---------- Layer 8: Environment and entrypoint ----------
 ENV UV_NATIVE_TLS=1
+ENV UV_CACHE_DIR=/home/claude/.cache/uv
+ENV UV_LINK_MODE=copy
 
 # Workspace path and working directory set at runtime via docker run -w
-COPY --chown=claude:claude entrypoint.sh /home/claude/.local/bin/entrypoint.sh
+COPY --chown=claude:claude docker/entrypoint.sh /home/claude/.local/bin/entrypoint.sh
 RUN chmod +x /home/claude/.local/bin/entrypoint.sh
 ENTRYPOINT ["entrypoint.sh"]


### PR DESCRIPTION
## Summary
- Adds Layer 6b to `docker/Dockerfile.dev` that runs `uv sync --frozen --no-install-project` at build time, baking all locked wheels into `~/.cache/uv` so native packages (uvloop, cryptography, pydantic-core, watchfiles) are never compiled at container startup
- Switches build context from `docker/` to repo root (`.`) to access `pyproject.toml`/`uv.lock`; updates `COPY entrypoint.sh` path to `docker/entrypoint.sh` accordingly
- Moves `ENV PATH` after Layer 6 (uv install) so `uv` is on PATH when Layer 6b runs
- Adds `UV_CACHE_DIR` and `UV_LINK_MODE=copy` env vars for explicit runtime consistency

## Testing
Manual verification per plan acceptance gates:
\`\`\`bash
# Cold-container first-run latency (≤30s target)
docker run --rm -v "$(pwd)":/workspace -w /workspace claudecode-webui-dev:local bash -lc 'time uv sync'

# Confirm no native compilation at runtime
uv run python -c "import uvloop, cryptography, pydantic_core; print('ok')"

# Confirm CPython 3.13 pre-fetched
docker run --rm claudecode-webui-dev:local bash -lc 'uv python list --only-installed'
\`\`\`

Resolves #1548

🤖 Generated with [Claude Code](https://claude.com/claude-code)