### PR TITLE
fix: exempt favicon and public static assets from token auth

### DIFF
--- a/src/web_server.py
+++ b/src/web_server.py
@@ -56,7 +56,14 @@ class AuthMiddleware(BaseHTTPMiddleware):
     WebSocket auth is handled separately in each WS endpoint handler.
     """
 
-    EXEMPT_PATHS = {'/', '/health', '/api/auth/check', '/oauth/callback'}
+    EXEMPT_PATHS = {
+        '/', '/health', '/api/auth/check', '/oauth/callback',
+        # Public static assets from frontend/public/ — served at root without hashing,
+        # must be accessible without a token (browsers fetch favicons unauthenticated).
+        '/favicon.ico', '/favicon-16x16.png', '/favicon-32x32.png',
+        '/apple-touch-icon.png', '/android-chrome-192x192.png', '/android-chrome-512x512.png',
+        '/site.webmanifest', '/robots.txt',
+    }
     EXEMPT_PREFIXES = ('/assets/',)
     # Issue #827: The per-session secrets resolve endpoint uses its own Bearer token auth,
     # not the global operator token. Exempt it from global AuthMiddleware.


### PR DESCRIPTION
## Summary
- Browsers fetch favicons and the header logo `<img src="/favicon-32x32.png">` without any auth context, returning 401 when token auth is enabled
- Adds all 6 `frontend/public/` icon paths to `EXEMPT_PATHS` alongside the existing `/assets/` prefix exemption for Vite's hashed bundles
- Pre-exempts `/site.webmanifest` and `/robots.txt` for future use

## Test plan
- [ ] With token auth enabled, reload the app — browser tab shows favicon (no 401 in Network tab for favicon requests)
- [ ] Header logo image loads without token in the URL
- [ ] All other `/api/` endpoints still require the token

🤖 Generated with [Claude Code](https://claude.com/claude-code)