### PR TITLE
fix: serve root-level public files (favicons) from dist/ in production

### DIFF
--- a/src/web_server.py
+++ b/src/web_server.py
@@ -285,6 +285,9 @@ class ClaudeWebUI:
                 "Run 'cd frontend && npm run build' to create production build."
             )
         self.app.mount("/assets", StaticFiles(directory=str(static_dir / "assets")), name="assets")
+        # Serve root-level public files (favicons, robots.txt, etc.) from dist/ root.
+        # Registered after all API routes so it only handles paths that don't match any route.
+        self.app.mount("/", StaticFiles(directory=str(static_dir)), name="static-root")
 
     def _get_permission_callback_factory(self):
         """


### PR DESCRIPTION
## Summary
- `Vite` copies `frontend/public/` to `dist/` root, but only `/assets/` was mounted as `StaticFiles`
- `/favicon-32x32.png` and other root-level assets returned 404 in production
- Adds a `StaticFiles(directory=dist/)` mount at `/`, registered after all API routes so it only handles unmatched paths — API routes are unaffected

## Test plan
- [ ] `GET /favicon-32x32.png` returns 200 (not 404)
- [ ] `GET /favicon.ico` returns 200
- [ ] `GET /api/sessions` still routes correctly to the API
- [ ] `GET /` still serves index.html (explicit route takes precedence over the mount)

🤖 Generated with [Claude Code](https://claude.com/claude-code)