### PR TITLE
fix: use get_all_descendants for reparent membership checks

### DIFF
--- a/src/legion/mcp/legion_mcp_tools.py
+++ b/src/legion/mcp/legion_mcp_tools.py
@@ -795,10 +795,10 @@ class LegionMCPTools:
 
             # Validate: named minion must be a descendant of the caller (or caller themselves)
             if named_minion.session_id != parent_overseer_id:
-                _desc_page = await self.system.session_coordinator.get_descendants(
-                    parent_overseer_id
-                )
-                descendant_ids = {d["session_id"] for d in _desc_page["descendants"]}
+                descendant_ids = {
+                    d["session_id"]
+                    for d in await self.system.session_coordinator.get_all_descendants(parent_overseer_id)
+                }
 
                 if named_minion.session_id not in descendant_ids:
                     return self._err(
@@ -1129,11 +1129,8 @@ class LegionMCPTools:
 
             if not is_direct_child:
                 # Search full descendant subtree for the target
-                _desc_page = await self.system.session_coordinator.get_descendants(
-                    parent_overseer_id
-                )
                 target_desc = None
-                for d in _desc_page["descendants"]:
+                for d in await self.system.session_coordinator.get_all_descendants(parent_overseer_id):
                     d_slug = _slugify(d["name"])
                     if d_slug == target_slug:
                         target_desc = d

--- a/src/legion/mcp/legion_mcp_tools.py
+++ b/src/legion/mcp/legion_mcp_tools.py
@@ -1228,9 +1228,7 @@ class LegionMCPTools:
             subject_slug = _slugify(subject_name)
             new_parent_slug = _slugify(new_parent_name)
 
-            # get_descendants returns a paginated dict; extract the list from ["descendants"]
-            _desc_page = await self.system.session_coordinator.get_descendants(caller_id)
-            caller_descendants = _desc_page["descendants"]
+            caller_descendants = await self.system.session_coordinator.get_all_descendants(caller_id)
 
             subject_id = None
             new_parent_id = None

--- a/src/legion/overseer_controller.py
+++ b/src/legion/overseer_controller.py
@@ -506,8 +506,10 @@ class OverseerController:
             if new_parent.project_id != legion_id:
                 raise ValueError("Cannot reparent to a minion in a different legion")
 
-        _desc_page = await self.system.session_coordinator.get_descendants(subject_id)
-        subject_descendant_ids = {d["session_id"] for d in _desc_page["descendants"]}
+        subject_descendant_ids = {
+            d["session_id"]
+            for d in await self.system.session_coordinator.get_all_descendants(subject_id)
+        }
         if new_parent_id is not None and new_parent_id in subject_descendant_ids:
             raise ValueError(
                 "Cannot reparent: the new parent is a descendant of the subject (would create a cycle)"
@@ -518,8 +520,10 @@ class OverseerController:
             if not caller:
                 raise ValueError(f"Caller {caller_id} not found")
 
-            _caller_desc_page = await self.system.session_coordinator.get_descendants(caller_id)
-            caller_descendant_ids = {d["session_id"] for d in _caller_desc_page["descendants"]}
+            caller_descendant_ids = {
+                d["session_id"]
+                for d in await self.system.session_coordinator.get_all_descendants(caller_id)
+            }
 
             # Subject must be in caller's descendant closure
             if subject_id not in caller_descendant_ids:

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -2253,6 +2253,11 @@ class SessionCoordinator:
         """Public wrapper: find the project containing the given session."""
         return await self._find_project_for_session(session_id)
 
+    async def get_all_descendants(self, session_id: str) -> list[dict]:
+        """Return the complete descendant list (unpaginated). Use for
+        membership/cycle checks where truncation produces incorrect results."""
+        return await self._get_all_descendants(session_id)
+
     async def _get_all_descendants(self, session_id: str) -> list[dict]:
         """
         Get all descendant sessions (children, grandchildren, etc.) of a session.

--- a/src/tests/test_legion_mcp_tools.py
+++ b/src/tests/test_legion_mcp_tools.py
@@ -1082,8 +1082,9 @@ async def test_issue_1419_update_schedule_handler_rejects_non_empty_prompt_on_sc
 @pytest.mark.asyncio
 async def test_issue_1433_reparent_extracts_descendants_from_dict():
     """
-    Issue #1433 regression: _handle_reparent_minion must extract ["descendants"]
-    from the paginated dict returned by get_descendants, not iterate the dict itself.
+    Issue #1433 regression: _handle_reparent_minion now uses get_all_descendants
+    which returns a plain list (not a paginated dict). Verify it resolves names
+    correctly and calls overseer_controller.reparent_minion.
     """
     from unittest.mock import AsyncMock, MagicMock
 
@@ -1097,24 +1098,18 @@ async def test_issue_1433_reparent_extracts_descendants_from_dict():
     caller_session.name = "CallerMinion"
     caller_session.state = SessionState.ACTIVE
 
-    # Simulate the real paginated return shape from get_descendants
-    paginated_result = {
-        "descendants": [
-            {"name": "ChildA", "session_id": "child-a-id"},
-            {"name": "NewParent", "session_id": "new-parent-id"},
-        ],
-        "total": 2,
-        "limit": 50,
-        "offset": 0,
-        "has_more": False,
-    }
+    # get_all_descendants returns a plain list
+    all_descendants = [
+        {"name": "ChildA", "session_id": "child-a-id"},
+        {"name": "NewParent", "session_id": "new-parent-id"},
+    ]
 
     session_manager = MagicMock()
     session_manager.get_session_info = AsyncMock(return_value=caller_session)
 
     session_coordinator = MagicMock()
     session_coordinator.session_manager = session_manager
-    session_coordinator.get_descendants = AsyncMock(return_value=paginated_result)
+    session_coordinator.get_all_descendants = AsyncMock(return_value=all_descendants)
 
     overseer_controller = MagicMock()
     overseer_controller.reparent_minion = AsyncMock(
@@ -1136,6 +1131,61 @@ async def test_issue_1433_reparent_extracts_descendants_from_dict():
     assert result.get("is_error") is False, f"Expected success, got: {result}"
     overseer_controller.reparent_minion.assert_awaited_once_with(
         subject_id="child-a-id",
+        new_parent_id="new-parent-id",
+        caller_id=caller_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_issue_1581_reparent_with_large_subtree():
+    """
+    Issue #1581 regression: _handle_reparent_minion must succeed when the caller
+    has >50 descendants and the subject/new_parent are beyond position 50.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from src.legion.mcp.legion_mcp_tools import LegionMCPTools
+    from src.session_manager import SessionState
+
+    caller_id = "caller-session-id"
+
+    caller_session = MagicMock()
+    caller_session.session_id = caller_id
+    caller_session.name = "CallerMinion"
+    caller_session.state = SessionState.ACTIVE
+
+    # 60 descendants; subject at index 54, new_parent at index 58
+    all_descendants = [{"name": f"Desc{i}", "session_id": f"desc-{i}-id"} for i in range(60)]
+    all_descendants[54] = {"name": "SubjectMinion", "session_id": "subject-id"}
+    all_descendants[58] = {"name": "NewParentMinion", "session_id": "new-parent-id"}
+
+    session_manager = MagicMock()
+    session_manager.get_session_info = AsyncMock(return_value=caller_session)
+
+    session_coordinator = MagicMock()
+    session_coordinator.session_manager = session_manager
+    session_coordinator.get_all_descendants = AsyncMock(return_value=all_descendants)
+
+    overseer_controller = MagicMock()
+    overseer_controller.reparent_minion = AsyncMock(
+        return_value={"descendants_moved": 0}
+    )
+
+    mock_system = MagicMock()
+    mock_system.session_coordinator = session_coordinator
+    mock_system.overseer_controller = overseer_controller
+
+    mcp_tools = LegionMCPTools(mock_system)
+
+    result = await mcp_tools._handle_reparent_minion({
+        "_caller_id": caller_id,
+        "subject_name": "SubjectMinion",
+        "new_parent_name": "NewParentMinion",
+    })
+
+    assert result.get("is_error") is False, f"Expected success, got: {result}"
+    overseer_controller.reparent_minion.assert_awaited_once_with(
+        subject_id="subject-id",
         new_parent_id="new-parent-id",
         caller_id=caller_id,
     )

--- a/src/tests/test_legion_mcp_tools.py
+++ b/src/tests/test_legion_mcp_tools.py
@@ -1192,6 +1192,134 @@ async def test_issue_1581_reparent_with_large_subtree():
 
 
 @pytest.mark.asyncio
+async def test_issue_1581_spawn_parent_name_large_subtree():
+    """
+    Issue #1581 regression: _handle_spawn_minion must succeed when the caller has
+    >50 descendants and the named parent_name is beyond position 50.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from src.legion.mcp.legion_mcp_tools import LegionMCPTools
+    from src.session_manager import SessionState
+
+    caller_id = "caller-id"
+
+    caller_session = MagicMock()
+    caller_session.session_id = caller_id
+    caller_session.project_id = "legion-1"
+    caller_session.state = SessionState.ACTIVE
+    caller_session.current_permission_mode = "default"
+    caller_session.working_directory = "/tmp/test"
+    caller_session.config = {}
+
+    # named_minion lives at position 54 in the descendants list
+    named_minion = MagicMock()
+    named_minion.session_id = "named-parent-id"
+    named_minion.name = "NamedParent"
+    named_minion.config = {}
+    named_minion.current_permission_mode = "default"
+    named_minion.working_directory = "/tmp/test"
+
+    # 60 descendants; named_minion at index 54
+    all_descendants = [{"name": f"Desc{i}", "session_id": f"desc-{i}-id"} for i in range(60)]
+    all_descendants[54] = {"name": "NamedParent", "session_id": "named-parent-id"}
+
+    session_manager = MagicMock()
+    session_manager.get_session_info = AsyncMock(return_value=caller_session)
+
+    session_coordinator = MagicMock()
+    session_coordinator.session_manager = session_manager
+    session_coordinator.get_all_descendants = AsyncMock(return_value=all_descendants)
+
+    legion_coordinator = MagicMock()
+    legion_coordinator.get_minion_by_name_in_legion = AsyncMock(return_value=named_minion)
+
+    overseer_controller = MagicMock()
+    overseer_controller.spawn_minion = AsyncMock(return_value={
+        "session_id": "new-child-id",
+        "name": "NewChild",
+        "slug": "newchild",
+    })
+
+    mock_system = MagicMock()
+    mock_system.session_coordinator = session_coordinator
+    mock_system.legion_coordinator = legion_coordinator
+    mock_system.overseer_controller = overseer_controller
+
+    mcp_tools = LegionMCPTools(mock_system)
+
+    result = await mcp_tools._handle_spawn_minion({
+        "_parent_overseer_id": caller_id,
+        "name": "NewChild",
+        "role": "Worker",
+        "system_prompt": "Do work.",
+        "parent_name": "NamedParent",
+    })
+
+    # Must NOT fail with the pagination-truncation error
+    assert result.get("is_error") is not True or "descendant" not in result.get("content", [{}])[0].get("text", ""), \
+        f"Spurious descendant error: {result}"
+    # parent_name at position 54 must have been resolved and spawn called
+    overseer_controller.spawn_minion.assert_awaited_once()
+    call_kwargs = overseer_controller.spawn_minion.call_args
+    assert call_kwargs.kwargs.get("parent_overseer_id") == "named-parent-id"
+
+
+@pytest.mark.asyncio
+async def test_issue_1581_dispose_minion_large_subtree():
+    """
+    Issue #1581 regression: _handle_dispose_minion must succeed when the caller has
+    >50 descendants and the target minion is beyond position 50.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from src.legion.mcp.legion_mcp_tools import LegionMCPTools
+    from src.session_manager import SessionState
+
+    caller_id = "caller-id"
+
+    caller_session = MagicMock()
+    caller_session.session_id = caller_id
+    caller_session.state = SessionState.ACTIVE
+    caller_session.child_minion_ids = []  # no direct children → forces subtree search
+
+    # Target at position 54 with a distinct parent
+    all_descendants = [
+        {"name": f"Desc{i}", "session_id": f"desc-{i}-id", "parent_id": caller_id}
+        for i in range(60)
+    ]
+    all_descendants[54] = {"name": "TargetMinion", "session_id": "target-id", "parent_id": "mid-parent-id"}
+
+    session_manager = MagicMock()
+    session_manager.get_session_info = AsyncMock(return_value=caller_session)
+
+    session_coordinator = MagicMock()
+    session_coordinator.session_manager = session_manager
+    session_coordinator.get_all_descendants = AsyncMock(return_value=all_descendants)
+
+    overseer_controller = MagicMock()
+    overseer_controller.dispose_minion = AsyncMock(return_value={"descendants_count": 0})
+
+    mock_system = MagicMock()
+    mock_system.session_coordinator = session_coordinator
+    mock_system.overseer_controller = overseer_controller
+
+    mcp_tools = LegionMCPTools(mock_system)
+
+    result = await mcp_tools._handle_dispose_minion({
+        "_parent_overseer_id": caller_id,
+        "minion_name": "TargetMinion",
+    })
+
+    assert result.get("is_error") is False, f"Expected success, got: {result}"
+    overseer_controller.dispose_minion.assert_awaited_once_with(
+        parent_overseer_id="mid-parent-id",
+        child_minion_name="TargetMinion",
+        delete_after_archive=False,
+    )
+
+
+@pytest.mark.asyncio
 async def test_issue_1433_list_minions_includes_parent_field():
     """
     Issue #1433: list_minions must include a Parent: line for each minion.

--- a/src/tests/test_overseer_reparent.py
+++ b/src/tests/test_overseer_reparent.py
@@ -82,6 +82,17 @@ def _build_system(session_map):
                 queue.extend(s.child_minion_ids or [])
         return {"descendants": result, "total": len(result), "limit": limit, "offset": offset, "has_more": False}
 
+    async def _get_all_descendants_mock(session_id):
+        result = []
+        queue = list(session_map[session_id].child_minion_ids) if session_map.get(session_id) else []
+        while queue:
+            sid = queue.pop(0)
+            s = session_map.get(sid)
+            if s:
+                result.append({"session_id": sid})
+                queue.extend(s.child_minion_ids or [])
+        return result
+
     project = Mock()
     project.to_dict = Mock(return_value={"project_id": "legion-1"})
 
@@ -90,6 +101,7 @@ def _build_system(session_map):
 
     coord = Mock()
     coord.get_descendants = AsyncMock(side_effect=_get_descendants_mock)
+    coord.get_all_descendants = AsyncMock(side_effect=_get_all_descendants_mock)
     coord.session_manager = sm
     coord.project_manager = pm
 
@@ -430,3 +442,62 @@ class TestEdgeMcpNewParentOutsideSubtree:
 
         with pytest.raises(ValueError, match="Authority violation"):
             await oc.reparent_minion(subject_id="b-id", new_parent_id="x-id", caller_id="a-id")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Issue #1581 regression: large subtrees (>50 descendants)
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestIssue1581LargeSubtree:
+    @pytest.mark.asyncio
+    async def test_issue_1581_cycle_detection_beyond_page(self):
+        """
+        Cycle detection must catch a proposed new_parent that lives beyond
+        position 50 in the subject's descendant list.
+        """
+        # Build subject with 60 linear descendants: s → d1 → d2 → … → d60
+        subject = _make_session("s-id", "Subject", parent_id=None, children=["d1"], is_overseer=True, overseer_level=0)
+        sessions = {"s-id": subject}
+        prev = subject
+        for i in range(1, 61):
+            sid = f"d{i}"
+            next_id = f"d{i + 1}" if i < 60 else None
+            children = [next_id] if next_id else []
+            s = _make_session(sid, f"Desc{i}", parent_id=prev.session_id, children=children, is_overseer=bool(children), overseer_level=i)
+            sessions[sid] = s
+            prev = s
+
+        system = _build_system(sessions)
+        oc = OverseerController(system)
+
+        # d55 is beyond page limit 50; using it as new_parent would create a cycle
+        with pytest.raises(ValueError, match="cycle"):
+            await oc.reparent_minion(subject_id="s-id", new_parent_id="d55", caller_id=None)
+
+    @pytest.mark.asyncio
+    async def test_issue_1581_authority_check_still_rejects_outsider(self):
+        """
+        Authority check must still reject a subject that is genuinely outside
+        the caller's subtree, even when the caller has >50 descendants.
+        """
+        # Caller has 60 linear descendants
+        caller = _make_session("caller-id", "Caller", parent_id=None, children=["d1"], is_overseer=True, overseer_level=0)
+        sessions = {"caller-id": caller}
+        prev = caller
+        for i in range(1, 61):
+            sid = f"d{i}"
+            next_id = f"d{i + 1}" if i < 60 else None
+            children = [next_id] if next_id else []
+            s = _make_session(sid, f"Desc{i}", parent_id=prev.session_id, children=children, is_overseer=bool(children), overseer_level=i)
+            sessions[sid] = s
+            prev = s
+
+        # outsider is NOT in caller's subtree
+        outsider = _make_session("out-id", "Outsider", parent_id=None, children=[], is_overseer=False, overseer_level=0)
+        sessions["out-id"] = outsider
+
+        system = _build_system(sessions)
+        oc = OverseerController(system)
+
+        with pytest.raises(ValueError, match="Authority violation"):
+            await oc.reparent_minion(subject_id="out-id", new_parent_id="d1", caller_id="caller-id")


### PR DESCRIPTION
## Summary
Resolves #1581

Five callsites in the reparent/spawn/dispose flow used the paginated `get_descendants()` (limit=50) for set-membership and name-resolution checks, causing spurious failures when a minion had >50 descendants.

## Changes Made
- `src/session_coordinator.py`: add public `get_all_descendants()` wrapper around existing private `_get_all_descendants()` (~3 LOC)
- `src/legion/mcp/legion_mcp_tools.py`: replace paginated `get_descendants` calls in `_handle_reparent_minion`, `_handle_spawn_minion`, and `_handle_dispose_minion` with `get_all_descendants`
- `src/legion/overseer_controller.py`: replace two paginated calls (cycle detection + authority check) with `get_all_descendants`
- `src/tests/test_legion_mcp_tools.py`: add 3 regression tests (reparent, spawn, dispose large-subtree); migrate existing #1433 test to mock `get_all_descendants`
- `src/tests/test_overseer_reparent.py`: add 2 regression tests (cycle detection beyond page, authority check still rejects genuine outsider); extend `_build_system` mock helper

## Testing
- `pytest src/tests/test_legion_mcp_tools.py src/tests/test_overseer_reparent.py -v` — 57/57 passed
- `ruff check` — zero violations on all modified files
- No UI changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)