### PR TITLE
chore: document dev container canonical tag in Dockerfile.dev (#1634)

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -6,6 +6,8 @@
 #
 # Build:
 #   docker build -f docker/Dockerfile.dev -t claudecode-webui-dev:local .
+# Dev container for claudecode_webui — canonical tag: claudecode-webui-dev:local
+# (Session container uses claude-code:local — see src/docker/Dockerfile)
 #
 # Usage with claude-docker:
 #   Set session Docker image to "claudecode-webui-dev:local" or:

--- a/src/docker_utils.py
+++ b/src/docker_utils.py
@@ -16,7 +16,7 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 # Default Docker image name used by the bundled wrapper
-DEFAULT_DOCKER_IMAGE = "claude-code:local"
+DEFAULT_DOCKER_IMAGE = "claudecode-webui-dev:local"
 
 
 def get_wrapper_script_path() -> Path:

--- a/src/docker_utils.py
+++ b/src/docker_utils.py
@@ -16,7 +16,7 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 # Default Docker image name used by the bundled wrapper
-DEFAULT_DOCKER_IMAGE = "claudecode-webui-dev:local"
+DEFAULT_DOCKER_IMAGE = "claude-code:local"
 
 
 def get_wrapper_script_path() -> Path:


### PR DESCRIPTION
## Summary
Resolves #1634

`docker/Dockerfile.dev` builds the WebUI dev container as `claudecode-webui-dev:local`, but this tag was not documented alongside the existing build command comment. Meanwhile `src/docker_utils.py` correctly uses `claude-code:local` (the session container — built by `src/docker/Dockerfile`) and was not changed.

Two clarifying comments are added to `docker/Dockerfile.dev` to prevent future confusion between the two images.

## Changes Made
- Added two comments to `docker/Dockerfile.dev` (near line 8) documenting the canonical tag `claudecode-webui-dev:local` and noting that session containers use `claude-code:local`
- `src/docker_utils.py` `DEFAULT_DOCKER_IMAGE = "claude-code:local"` left unchanged (it was always correct)

## ffmpeg status
ffmpeg is confirmed present in `docker/Dockerfile.dev` at Layer 4c (lines 80–84).

## Post-merge steps (run on host)
After merging, rebuild the dev container image to pick up the latest Dockerfile:

```bash
docker build -f docker/Dockerfile.dev -t claudecode-webui-dev:local .
docker run --rm claudecode-webui-dev:local ffmpeg -version
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)