### PR TITLE
fix: propagate task_updated subtype on session reload

### DIFF
--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -3065,7 +3065,7 @@ class SessionCoordinator:
                 )
 
             # Handle SystemMessage subtypes (including Task* subclasses)
-            if _type in ("SystemMessage", "HookEventMessage", "TaskStartedMessage", "TaskProgressMessage", "TaskNotificationMessage"):
+            if _type in ("SystemMessage", "HookEventMessage", "TaskStartedMessage", "TaskProgressMessage", "TaskNotificationMessage", "TaskUpdatedMessage"):
                 subtype = data.get("subtype")
                 if subtype:
                     metadata["subtype"] = subtype
@@ -3111,6 +3111,13 @@ class SessionCoordinator:
                     status = data.get("status", "unknown")
                     summary = data.get("summary") or ""
                     content = f"Agent {status}: {summary}" if summary else f"Agent {status}"
+                elif _type == "TaskUpdatedMessage":
+                    metadata["subtype"] = "task_updated"
+                    metadata["task_id"] = data.get("task_id")
+                    metadata["status"] = data.get("status")
+                    metadata["tool_use_id"] = data.get("tool_use_id")
+                    metadata["uuid"] = data.get("uuid")
+                    content = "Agent task updated"
 
                 # Issue #571: Synthesize content for hook messages from stored format
                 elif subtype in ("hook_started", "hook_response"):

--- a/src/tests/test_session_coordinator.py
+++ b/src/tests/test_session_coordinator.py
@@ -1997,3 +1997,88 @@ class TestIssue1628CompactBoundaryDistillation:
             description_arg = mock_register.call_args.kwargs.get('description')
             assert title_arg is not None and "Compaction Summary" in title_arg
             assert description_arg == f"compaction:{int(boundary_ts)}"
+
+
+class TestConvertStoredMessageToWebsocket:
+    """Tests for _convert_stored_message_to_websocket (issue #1657 regression)."""
+
+    @pytest.fixture
+    def coordinator(self, tmp_path):
+        return SessionCoordinator(tmp_path)
+
+    def test_issue_1657_task_updated_message_sets_subtype(self, coordinator):
+        stored = {
+            "_type": "TaskUpdatedMessage",
+            "timestamp": 1700000000.0,
+            "data": {
+                "subtype": "task_updated",
+                "task_id": "task-abc",
+                "status": "in_progress",
+                "tool_use_id": "toolu_xyz",
+                "uuid": "uuid-123",
+                "patch": {"description": "updated"},
+            },
+        }
+        result = coordinator._convert_stored_message_to_websocket(stored)
+        assert result is not None
+        assert result["type"] == "system"
+        assert result["metadata"]["subtype"] == "task_updated"
+
+    def test_issue_1657_task_updated_copies_fields(self, coordinator):
+        stored = {
+            "_type": "TaskUpdatedMessage",
+            "timestamp": 1700000000.0,
+            "data": {
+                "subtype": "task_updated",
+                "task_id": "task-xyz",
+                "status": "completed",
+                "tool_use_id": "toolu_aaa",
+                "uuid": "uuid-456",
+            },
+        }
+        result = coordinator._convert_stored_message_to_websocket(stored)
+        assert result is not None
+        meta = result["metadata"]
+        assert meta["task_id"] == "task-xyz"
+        assert meta["status"] == "completed"
+        assert meta["tool_use_id"] == "toolu_aaa"
+        assert meta["uuid"] == "uuid-456"
+
+    def test_issue_1657_task_started_unchanged(self, coordinator):
+        stored = {
+            "_type": "TaskStartedMessage",
+            "timestamp": 1700000000.0,
+            "data": {
+                "subtype": "task_started",
+                "task_id": "task-start",
+                "description": "Do something",
+                "session_id": "sess-1",
+                "task_type": "agent",
+                "uuid": "uuid-s",
+                "tool_use_id": "toolu_s",
+            },
+        }
+        result = coordinator._convert_stored_message_to_websocket(stored)
+        assert result is not None
+        assert result["type"] == "system"
+        assert result["metadata"]["subtype"] == "task_started"
+        assert result["metadata"]["task_id"] == "task-start"
+
+    def test_issue_1657_task_notification_unchanged(self, coordinator):
+        stored = {
+            "_type": "TaskNotificationMessage",
+            "timestamp": 1700000000.0,
+            "data": {
+                "subtype": "task_notification",
+                "task_id": "task-notif",
+                "status": "done",
+                "summary": "All done",
+                "session_id": "sess-2",
+                "uuid": "uuid-n",
+                "tool_use_id": "toolu_n",
+            },
+        }
+        result = coordinator._convert_stored_message_to_websocket(stored)
+        assert result is not None
+        assert result["type"] == "system"
+        assert result["metadata"]["subtype"] == "task_notification"


### PR DESCRIPTION
## Summary
Resolves #1657

`task_updated` blank pills were suppressed during live sessions (#1656) but reappeared on session reload. The history reload path (`_convert_stored_message_to_websocket`) was missing `"TaskUpdatedMessage"` from its `_type` dispatch tuple, so `metadata.subtype` was never set, leaving the existing frontend filter in `shouldDisplayMessage()` with nothing to match.

## Changes Made
- `src/session_coordinator.py`: Add `"TaskUpdatedMessage"` to the `_type in (...)` guard tuple in `_convert_stored_message_to_websocket`
- `src/session_coordinator.py`: Add `elif _type == "TaskUpdatedMessage":` branch setting `metadata["subtype"] = "task_updated"` plus `task_id`, `status`, `tool_use_id`, `uuid` (mirrors the sibling Task* pattern)
- `src/tests/test_session_coordinator.py`: Add `TestConvertStoredMessageToWebsocket` with four regression tests covering `TaskUpdatedMessage` conversion and confirming `TaskStartedMessage`/`TaskNotificationMessage` are unchanged

## Testing
- `uv run pytest src/tests/test_session_coordinator.py -v` — 78/78 passed
- `uv run ruff check --fix src/session_coordinator.py src/tests/test_session_coordinator.py` — no violations
- Manual: reopen a session that ran subagents → no blank pills in chat list; task panel unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)