### PR TITLE
fix: prune stale MCP snapshots from session.config after template spawn

### DIFF
--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -69,6 +69,23 @@ _TEXT_RESOURCE_FORMATS = {
     "php", "sql", "r", "swift", "kt",
 }
 
+# Issue #1660: MCP config fields that the spawn path snapshots into session.config.
+# These are the only fields subject to stale-snapshot pruning.
+_MCP_INHERITABLE_FIELDS = ("mcp_server_ids", "enable_claudeai_mcp_servers", "strict_mcp_config")
+
+
+def _mcp_field_equal(field: str, a, b) -> bool:
+    """Compare an MCP config field value, treating mcp_server_ids order-insensitively.
+
+    None and [] are treated as distinct: None means "inherit from chain", [] means
+    "explicitly no servers". Only a list-vs-list comparison uses set equality.
+    """
+    if field == "mcp_server_ids":
+        if (a is None) != (b is None):
+            return False
+        return set(a or []) == set(b or [])
+    return a == b
+
 
 def _apply_resource_filters(
     resources: list[dict],
@@ -620,6 +637,7 @@ class SessionCoordinator:
             # Load configuration profiles from disk (issue #1062)
             await self.profile_manager.load_profiles()
             coord_logger.info("Loaded configuration profiles")
+            await self._migrate_stale_mcp_snapshots()  # issue #1660
 
             # Load global MCP server configs (issue #676)
             await self.mcp_config_manager.load_configs()
@@ -870,6 +888,9 @@ class SessionCoordinator:
             # and store non-matching fields as initial session_overrides (#1079).
             if config.template_id:
                 await self._init_session_overrides(session_id, config)
+                sinfo = await self.session_manager.get_session_info(session_id)
+                if sinfo:
+                    await self._prune_inherited_mcp_snapshot(sinfo)  # issue #1660
 
             # Add session to project
             await self.project_manager.add_session_to_project(project_id, session_id)
@@ -5323,3 +5344,54 @@ class SessionCoordinator:
                 )
         except Exception:
             logger.exception(f"Failed to compute initial session_overrides for {session_id}")
+
+    async def _prune_inherited_mcp_snapshot(self, session_info) -> bool:
+        """Remove MCP config fields from session.config that merely mirror the current
+        template/profile resolution (inherited snapshots, not real overrides).
+
+        Returns True if the session was modified. Issue #1660.
+        """
+        if not session_info.template_id:
+            return False
+        try:
+            from src.config_resolution import resolve_template_config
+
+            template = await self.template_manager.get_template(session_info.template_id)
+            if template is None:
+                return False
+            resolved = await resolve_template_config(template, self.profile_manager)
+            cfg = dict(session_info.config or {})
+            changed = False
+            for field in _MCP_INHERITABLE_FIELDS:
+                if field not in cfg:
+                    continue
+                if _mcp_field_equal(field, cfg[field], resolved.get(field)):
+                    del cfg[field]
+                    changed = True
+            if changed:
+                await self.session_manager.update_session(
+                    session_info.session_id, _replace_config=cfg
+                )
+            return changed
+        except Exception:
+            logger.exception(
+                f"Failed to prune MCP snapshot for session {session_info.session_id}"
+            )
+            return False
+
+    async def _migrate_stale_mcp_snapshots(self) -> None:
+        """Issue #1660: one-time cleanup of inherited MCP snapshots persisted into
+        session.config by the spawn path. Conservative — only clears fields that still
+        equal the current template/profile resolution. Never blocks startup."""
+        try:
+            sessions = await self.session_manager.list_sessions()
+            cleared = 0
+            for s in sessions:
+                if await self._prune_inherited_mcp_snapshot(s):
+                    cleared += 1
+            if cleared:
+                coord_logger.info(
+                    f"#1660 migration: cleared stale MCP snapshots on {cleared} session(s)"
+                )
+        except Exception:
+            logger.exception("Failed MCP snapshot migration (#1660)")

--- a/src/tests/test_session_coordinator.py
+++ b/src/tests/test_session_coordinator.py
@@ -2082,3 +2082,258 @@ class TestConvertStoredMessageToWebsocket:
         assert result is not None
         assert result["type"] == "system"
         assert result["metadata"]["subtype"] == "task_notification"
+
+
+# ---------------------------------------------------------------------------
+# Issue #1660 — MCP snapshot pruning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestIssue1660McpSnapshotPrune:
+    """Tests for issue #1660 — _prune_inherited_mcp_snapshot removes MCP config fields
+    that merely mirror the current template/profile resolution (inherited snapshots,
+    not real overrides)."""
+
+    async def _make_project(self, coordinator, suffix=""):
+        return await coordinator.project_manager.create_project(
+            name=f"Test Project {suffix}", working_directory="/tmp/test_1660"
+        )
+
+    async def test_spawn_prune_removes_mcp_server_ids_equal_to_chain(self, temp_coordinator):
+        """After create_session, an mcp_server_ids snapshot equal to the template/profile
+        chain is pruned from session.config so that subsequent profile changes propagate."""
+        import uuid
+
+        coordinator = temp_coordinator
+        profile = await coordinator.profile_manager.create_profile(
+            name="MCP Profile", area="mcp", config={"mcp_server_ids": ["srv-a"]}
+        )
+        template = await coordinator.template_manager.create_template(
+            name="MCP Template",
+            config={},
+            profile_ids={"mcp": profile.profile_id},
+        )
+        project = await self._make_project(coordinator, "spawn-prune")
+        session_id = str(uuid.uuid4())
+
+        # Simulate spawn path: pass same mcp_server_ids as the profile defines
+        await coordinator.create_session(
+            session_id=session_id,
+            project_id=project.project_id,
+            config=SessionConfig(template_id=template.template_id, mcp_server_ids=["srv-a"]),
+        )
+
+        sinfo = await coordinator.session_manager.get_session_info(session_id)
+        assert "mcp_server_ids" not in sinfo.config, (
+            "mcp_server_ids equal to template/profile chain must be pruned at create time"
+        )
+
+    async def test_profile_update_propagates_after_prune(self, temp_coordinator):
+        """After spawn prune clears mcp_server_ids, a profile update is reflected by
+        resolve_effective_config without any session.config change."""
+        import uuid
+
+        from ..config_resolution import resolve_effective_config
+
+        coordinator = temp_coordinator
+        profile = await coordinator.profile_manager.create_profile(
+            name="MCP Profile 2", area="mcp", config={"mcp_server_ids": ["srv-old"]}
+        )
+        template = await coordinator.template_manager.create_template(
+            name="MCP Template 2",
+            config={},
+            profile_ids={"mcp": profile.profile_id},
+        )
+        project = await self._make_project(coordinator, "profile-update")
+        session_id = str(uuid.uuid4())
+        await coordinator.create_session(
+            session_id=session_id,
+            project_id=project.project_id,
+            config=SessionConfig(template_id=template.template_id, mcp_server_ids=["srv-old"]),
+        )
+
+        sinfo = await coordinator.session_manager.get_session_info(session_id)
+        assert "mcp_server_ids" not in sinfo.config  # prune worked at create time
+
+        # Update the profile to a new server list
+        await coordinator.profile_manager.update_profile(
+            profile.profile_id, config={"mcp_server_ids": ["srv-new"]}
+        )
+
+        sinfo2 = await coordinator.session_manager.get_session_info(session_id)
+        resolved = await resolve_effective_config(
+            sinfo2, coordinator.template_manager, profile_manager=coordinator.profile_manager
+        )
+        assert resolved.mcp_server_ids == ["srv-new"], (
+            "Profile update must propagate to session that has no mcp_server_ids in config"
+        )
+
+    async def test_genuine_override_preserved(self, temp_coordinator):
+        """_prune_inherited_mcp_snapshot must NOT prune a field that differs from the chain."""
+        import uuid
+
+        coordinator = temp_coordinator
+        profile = await coordinator.profile_manager.create_profile(
+            name="MCP Profile 3", area="mcp", config={"mcp_server_ids": ["profile-srv"]}
+        )
+        template = await coordinator.template_manager.create_template(
+            name="MCP Template 3",
+            config={},
+            profile_ids={"mcp": profile.profile_id},
+        )
+        project = await self._make_project(coordinator, "override")
+        session_id = str(uuid.uuid4())
+
+        # Pass a DIFFERENT value than the profile → genuine session override
+        await coordinator.create_session(
+            session_id=session_id,
+            project_id=project.project_id,
+            config=SessionConfig(
+                template_id=template.template_id,
+                mcp_server_ids=["user-override-srv"],
+            ),
+        )
+
+        sinfo = await coordinator.session_manager.get_session_info(session_id)
+        assert sinfo.config.get("mcp_server_ids") == ["user-override-srv"], (
+            "mcp_server_ids that differs from chain must be preserved as a genuine override"
+        )
+
+    async def test_prune_helper_directly_clears_order_insensitive(self, temp_coordinator):
+        """Direct _prune_inherited_mcp_snapshot call returns True and clears a snapshot
+        that equals the chain modulo ordering."""
+        import uuid
+
+        coordinator = temp_coordinator
+        profile = await coordinator.profile_manager.create_profile(
+            name="MCP Profile 4", area="mcp", config={"mcp_server_ids": ["x", "y"]}
+        )
+        template = await coordinator.template_manager.create_template(
+            name="MCP Template 4",
+            config={},
+            profile_ids={"mcp": profile.profile_id},
+        )
+        project = await self._make_project(coordinator, "direct-prune")
+        session_id = str(uuid.uuid4())
+        await coordinator.create_session(
+            session_id=session_id,
+            project_id=project.project_id,
+            config=SessionConfig(template_id=template.template_id),
+        )
+
+        # Manually inject a reversed-order snapshot (should be treated as equal)
+        await coordinator.session_manager.update_session(
+            session_id, mcp_server_ids=["y", "x"]
+        )
+        sinfo = await coordinator.session_manager.get_session_info(session_id)
+        assert "mcp_server_ids" in sinfo.config
+
+        pruned = await coordinator._prune_inherited_mcp_snapshot(sinfo)
+        assert pruned is True
+
+        sinfo2 = await coordinator.session_manager.get_session_info(session_id)
+        assert "mcp_server_ids" not in sinfo2.config
+
+    async def test_no_template_link_untouched(self, temp_coordinator):
+        """Sessions without a template_id must not be modified by the prune helper."""
+        import uuid
+
+        coordinator = temp_coordinator
+        project = await self._make_project(coordinator, "no-template")
+        session_id = str(uuid.uuid4())
+        await coordinator.create_session(
+            session_id=session_id,
+            project_id=project.project_id,
+            config=SessionConfig(),
+        )
+
+        # Manually put something in config
+        await coordinator.session_manager.update_session(
+            session_id, mcp_server_ids=["keep-me"]
+        )
+        sinfo = await coordinator.session_manager.get_session_info(session_id)
+        assert sinfo.template_id is None
+
+        pruned = await coordinator._prune_inherited_mcp_snapshot(sinfo)
+        assert pruned is False
+
+        sinfo2 = await coordinator.session_manager.get_session_info(session_id)
+        assert sinfo2.config.get("mcp_server_ids") == ["keep-me"]
+
+    async def test_boolean_mcp_fields_pruned_when_equal(self, temp_coordinator):
+        """strict_mcp_config and enable_claudeai_mcp_servers are pruned when equal to chain."""
+        import uuid
+
+        coordinator = temp_coordinator
+        profile = await coordinator.profile_manager.create_profile(
+            name="MCP Bool Profile", area="mcp",
+            config={"strict_mcp_config": True, "enable_claudeai_mcp_servers": False},
+        )
+        template = await coordinator.template_manager.create_template(
+            name="MCP Bool Template",
+            config={},
+            profile_ids={"mcp": profile.profile_id},
+        )
+        project = await self._make_project(coordinator, "bool-fields")
+        session_id = str(uuid.uuid4())
+        await coordinator.create_session(
+            session_id=session_id,
+            project_id=project.project_id,
+            config=SessionConfig(template_id=template.template_id),
+        )
+
+        # Inject equal snapshots
+        await coordinator.session_manager.update_session(
+            session_id,
+            strict_mcp_config=True,
+            enable_claudeai_mcp_servers=False,
+        )
+        sinfo = await coordinator.session_manager.get_session_info(session_id)
+        assert "strict_mcp_config" in sinfo.config
+        assert "enable_claudeai_mcp_servers" in sinfo.config
+
+        pruned = await coordinator._prune_inherited_mcp_snapshot(sinfo)
+        assert pruned is True
+
+        sinfo2 = await coordinator.session_manager.get_session_info(session_id)
+        assert "strict_mcp_config" not in sinfo2.config
+        assert "enable_claudeai_mcp_servers" not in sinfo2.config
+
+    async def test_migrate_stale_mcp_snapshots_idempotency(self, temp_coordinator):
+        """_migrate_stale_mcp_snapshots clears equal snapshots once; second run is a no-op."""
+        import uuid
+
+        coordinator = temp_coordinator
+        profile = await coordinator.profile_manager.create_profile(
+            name="MCP Mig Profile", area="mcp", config={"mcp_server_ids": ["mig-srv"]}
+        )
+        template = await coordinator.template_manager.create_template(
+            name="MCP Mig Template",
+            config={},
+            profile_ids={"mcp": profile.profile_id},
+        )
+        project = await self._make_project(coordinator, "migration")
+        session_id = str(uuid.uuid4())
+        await coordinator.create_session(
+            session_id=session_id,
+            project_id=project.project_id,
+            config=SessionConfig(template_id=template.template_id),
+        )
+
+        # Simulate a pre-fix spawned session by injecting a stale snapshot
+        await coordinator.session_manager.update_session(
+            session_id, mcp_server_ids=["mig-srv"]
+        )
+        sinfo = await coordinator.session_manager.get_session_info(session_id)
+        assert "mcp_server_ids" in sinfo.config
+
+        # First run — clears the stale snapshot
+        await coordinator._migrate_stale_mcp_snapshots()
+        sinfo2 = await coordinator.session_manager.get_session_info(session_id)
+        assert "mcp_server_ids" not in sinfo2.config
+
+        # Second run — no-op, nothing to clear
+        await coordinator._migrate_stale_mcp_snapshots()
+        sinfo3 = await coordinator.session_manager.get_session_info(session_id)
+        assert "mcp_server_ids" not in sinfo3.config


### PR DESCRIPTION
## Summary
Resolves #1660

MCP config values resolved from a template/profile chain at minion spawn time were being frozen into `session.config`, causing the frontend to show stale `(S)` (session override) markers instead of `(P)` (profile) markers after a profile update.

## Root Cause

`legion_mcp_tools.py` resolves `mcp_server_ids` (and related MCP fields) from the template→profile chain at spawn time and passes it into `create_session`. `session_manager.create_session` stores any non-default `CONFIG_FIELDS` value in `session.config`. Once stored, the frontend cannot distinguish this inherited snapshot from a deliberate user override — so it always shows `(S)`.

## Changes Made

- **`_mcp_field_equal(field, a, b)`** — module-level comparator that treats `mcp_server_ids` order-insensitively (as sets) and keeps `None` and `[]` distinct (an explicit empty-list override is not pruned when the chain resolves to `None`)
- **`_MCP_INHERITABLE_FIELDS`** — tuple of the three MCP config fields subject to pruning
- **`_prune_inherited_mcp_snapshot(session_info)`** — removes MCP fields from `session.config` that equal the current template/profile resolution; genuine overrides (values that differ) are preserved
- **`_migrate_stale_mcp_snapshots()`** — startup migration that runs once after profiles load; idempotent, guarded by `try/except` so it never blocks initialization
- **`create_session`** — calls `_prune_inherited_mcp_snapshot` immediately after `_init_session_overrides` for new sessions
- **`initialize()`** — calls `_migrate_stale_mcp_snapshots()` to clean up existing sessions

No frontend changes: the existing `(S)`/`(P)` marker logic is correct once `session.config` no longer holds inherited snapshots.

## Testing

- 7 new unit tests in `TestIssue1660McpSnapshotPrune` covering:
  - Spawn prune removes equal snapshot at create time
  - Profile update propagates after prune (live resolution works)
  - Genuine session override preserved when value differs from chain
  - Order-insensitive set comparison for `mcp_server_ids`
  - Sessions without a template link are untouched
  - Boolean MCP fields (`strict_mcp_config`, `enable_claudeai_mcp_servers`) pruned when equal
  - Migration idempotency: second run is a no-op
- 2009 pre-existing tests pass; 9 pre-existing failures confirmed unchanged on baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)