### PR TITLE
fix: wire CLAUDE_CODE_DISABLE_BACKGROUND_TASKS to allow_background_agent setting

### DIFF
--- a/src/claude_sdk.py
+++ b/src/claude_sdk.py
@@ -1133,7 +1133,8 @@ class ClaudeSDK:
         """Build the env dict for ClaudeAgentOptions.
 
         Merge order (highest priority wins):
-          global BackgroundCallsConfig → per-session opt-back-in → always-set → extra_env
+          global BackgroundCallsConfig → allow_background_agent override → per-session
+          opt-back-in → always-set → extra_env
 
         Note: most categories here are additive/opt-in (a var is only added when a
         flag is true, or removed to opt back in to CC's own default). The
@@ -1157,6 +1158,12 @@ class ClaudeSDK:
         for attr, (var, value) in _BACKGROUND_CALL_ENV_MAP.items():
             if getattr(bg_cfg, attr):
                 env_vars[var] = value
+
+        # Issue #1690: allow_background_agent (#1688) must win over disable_background_tasks —
+        # otherwise the tool-block gate permits Agent(run_in_background=True) but the CLI env
+        # flag still forces it to run synchronously, silently nullifying the toggle.
+        if app_cfg.features.allow_background_agent:
+            env_vars["CLAUDE_CODE_DISABLE_BACKGROUND_TASKS"] = "0"
 
         # Per-session opt-back-in: remove suppression keys when session expresses preference
         # Issues #709, #906: auto-memory

--- a/src/tests/test_claude_sdk_env.py
+++ b/src/tests/test_claude_sdk_env.py
@@ -241,3 +241,47 @@ class TestForwardSubagentText:
         with patch("src.config_manager.load_config", return_value=config):
             env = sdk._resolve_env_vars()
         assert env["CLAUDE_CODE_FORWARD_SUBAGENT_TEXT"] == "0"
+
+
+class TestAllowBackgroundAgentOverridesDisableBackgroundTasks:
+    """Issue #1690 — allow_background_agent must win over disable_background_tasks."""
+
+    def test_default_off_unchanged(self):
+        sdk = _make_sdk()
+        config = AppConfig(
+            background_calls=BackgroundCallsConfig(disable_background_tasks=True),
+            features=FeaturesConfig(allow_background_agent=False),
+        )
+        with patch("src.config_manager.load_config", return_value=config):
+            env = sdk._resolve_env_vars()
+        assert env["CLAUDE_CODE_DISABLE_BACKGROUND_TASKS"] == "1"
+
+    def test_allow_background_agent_overrides_suppression_on(self):
+        sdk = _make_sdk()
+        config = AppConfig(
+            background_calls=BackgroundCallsConfig(disable_background_tasks=True),
+            features=FeaturesConfig(allow_background_agent=True),
+        )
+        with patch("src.config_manager.load_config", return_value=config):
+            env = sdk._resolve_env_vars()
+        assert env["CLAUDE_CODE_DISABLE_BACKGROUND_TASKS"] == "0"
+
+    def test_allow_background_agent_overrides_suppression_off(self):
+        sdk = _make_sdk()
+        config = AppConfig(
+            background_calls=BackgroundCallsConfig(disable_background_tasks=False),
+            features=FeaturesConfig(allow_background_agent=True),
+        )
+        with patch("src.config_manager.load_config", return_value=config):
+            env = sdk._resolve_env_vars()
+        assert env["CLAUDE_CODE_DISABLE_BACKGROUND_TASKS"] == "0"
+
+    def test_extra_env_still_overrides(self):
+        sdk = _make_sdk(extra_env={"CLAUDE_CODE_DISABLE_BACKGROUND_TASKS": "1"})
+        config = AppConfig(
+            background_calls=BackgroundCallsConfig(disable_background_tasks=True),
+            features=FeaturesConfig(allow_background_agent=True),
+        )
+        with patch("src.config_manager.load_config", return_value=config):
+            env = sdk._resolve_env_vars()
+        assert env["CLAUDE_CODE_DISABLE_BACKGROUND_TASKS"] == "1"


### PR DESCRIPTION
## Summary
Resolves #1690

`allow_background_agent` (#1688) only gated the PreToolUse tool-block for `Agent(run_in_background=True)`; it never overrode the `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS` CLI env flag. As a result, enabling the toggle still left background tasks disabled at the SDK process level, silently nullifying the setting.

## Changes Made
- `src/claude_sdk.py`: in `ClaudeSDK._resolve_env_vars()`, force `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS = "0"` when `app_cfg.features.allow_background_agent` is `True`. Applied immediately after the `BackgroundCallsConfig` suppression loop and before the `extra_env` merge, so per-session `extra_env` still takes final precedence.
- `src/tests/test_claude_sdk_env.py`: added `TestAllowBackgroundAgentOverridesDisableBackgroundTasks` with 4 cases — default off unchanged, override applies with suppression on, override applies with suppression off, and `extra_env` precedence preserved.

## Testing
- `uv run ruff check --fix src/claude_sdk.py src/tests/test_claude_sdk_env.py` — clean.
- `uv run pytest src/tests/test_claude_sdk_env.py -v` — 29/29 passed.
- `uv run pytest src/tests/ --tb=short` — 2109 passed, 8 failed (all pre-existing, unrelated to this change — verified identically failing on unmodified `main`), 46 deselected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)