### PR TITLE
fix: PERMISSION CALLBACK logs in permission_service.py are silently dropped

### DIFF
--- a/src/permission_service.py
+++ b/src/permission_service.py
@@ -19,6 +19,7 @@ from claude_agent_sdk import PermissionUpdate
 from claude_agent_sdk.types import PermissionRuleValue
 
 from .event_queue import EventQueue
+from .logging_config import get_logger
 from .models.messages import (
     PermissionInfo,
     PermissionRequestMessage,
@@ -32,6 +33,7 @@ if TYPE_CHECKING:
     from .session_coordinator import SessionCoordinator
 
 logger = logging.getLogger(__name__)
+debug_logger = get_logger('sdk_debug', category='PERMISSION_CALLBACK')
 
 
 class PermissionService:
@@ -64,17 +66,17 @@ class PermissionService:
             display_name    = getattr(context, 'display_name', None) if context else None
             description     = getattr(context, 'description', None) if context else None
 
-            logger.info(
+            debug_logger.info(
                 f"PERMISSION CALLBACK TRIGGERED: tool={tool_name}, session={session_id}, "
                 f"request_id={request_id}, tool_use_id={tool_use_id}, agent_id={agent_id}"
             )
-            logger.info(f"Permission requested for tool: {tool_name} (request_id: {request_id})")
+            debug_logger.info(f"Permission requested for tool: {tool_name} (request_id: {request_id})")
 
             # Issue #403: Auto-approve Read tool for user-uploaded files
             if tool_name == 'Read':
                 file_path = input_params.get('file_path', '')
                 if file_path and self.coordinator.is_uploaded_file(session_id, file_path):
-                    logger.info(f"Auto-approving Read for uploaded file: {file_path}")
+                    debug_logger.info(f"Auto-approving Read for uploaded file: {file_path}")
                     return {"behavior": "allow"}
 
             # Extract suggestions from context
@@ -85,7 +87,7 @@ class PermissionService:
                         suggestions.append(s.to_dict())
                     else:
                         suggestions.append(s)
-                logger.info(f"Permission context has {len(suggestions)} suggestions")
+                debug_logger.info(f"Permission context has {len(suggestions)} suggestions")
 
             # Store permission request message using dataclass (Phase 0, Issue #310)
             try:
@@ -168,7 +170,7 @@ class PermissionService:
                                 if tool_call:
                                     break
                         if not tool_call:
-                            logger.warning(
+                            debug_logger.warning(
                                 f"[PERMISSIONS] Race condition NOT resolved after 5.0s "
                                 f"for {tool_name} in session {session_id}. "
                                 f"Auto-denying permission to prevent deadlock."
@@ -214,7 +216,7 @@ class PermissionService:
                             if not self.coordinator.is_assistant_message_emitted(
                                 session_id, tool_call.message_id
                             ):
-                                logger.warning(
+                                debug_logger.warning(
                                     f"[PERMISSIONS] Assistant message envelope for "
                                     f"message_id {tool_call.message_id} not emitted after "
                                     f"2.0s in session {session_id}. Proceeding anyway "
@@ -255,10 +257,10 @@ class PermissionService:
                             }
                             if session_id in self.session_queues:
                                 self.session_queues[session_id].append(websocket_message)
-                            logger.info(f"Appended tool_call awaiting_permission for {tool_name} in session {session_id}")
+                            debug_logger.info(f"Appended tool_call awaiting_permission for {tool_name} in session {session_id}")
                     else:
                         # Issue #616: No ToolCall found after retries — auto-deny to prevent deadlock
-                        logger.warning(
+                        debug_logger.warning(
                             f"Could not find matching ToolCall for permission request: "
                             f"{tool_name} in session {session_id}. Auto-denying."
                         )
@@ -283,12 +285,12 @@ class PermissionService:
             # This provides visual feedback that the session is blocked on user input
             try:
                 await self.coordinator.session_manager.pause_session(session_id)
-                logger.info(f"Set session {session_id} to PAUSED state while waiting for permission")
+                debug_logger.info(f"Set session {session_id} to PAUSED state while waiting for permission")
             except Exception:
                 logger.exception(f"Failed to pause session {session_id} for permission wait")
 
             # Wait for user permission decision via WebSocket
-            logger.info(f"PERMISSION CALLBACK: Creating Future for request_id {request_id}")
+            debug_logger.info(f"PERMISSION CALLBACK: Creating Future for request_id {request_id}")
 
             # Create a Future to wait for user response
             permission_future = asyncio.Future()
@@ -296,9 +298,9 @@ class PermissionService:
 
             try:
                 # Wait for user decision (no timeout - wait indefinitely)
-                logger.info(f"PERMISSION CALLBACK: Waiting for user decision on request_id {request_id}")
+                debug_logger.info(f"PERMISSION CALLBACK: Waiting for user decision on request_id {request_id}")
                 response = await permission_future
-                logger.info(f"PERMISSION CALLBACK: Received user decision for request_id {request_id}: {response}")
+                debug_logger.info(f"PERMISSION CALLBACK: Received user decision for request_id {request_id}: {response}")
 
                 # Restore session to ACTIVE state after permission decision
                 # The session will continue processing, which will show as ACTIVE+processing (purple)
@@ -307,7 +309,7 @@ class PermissionService:
                     if session_info and session_info.state == SessionState.PAUSED:
                         # Use update_session_state instead of start_session to avoid re-initializing SDK
                         await self.coordinator.session_manager.update_session_state(session_id, SessionState.ACTIVE)
-                        logger.info(f"Restored session {session_id} to ACTIVE state after permission decision")
+                        debug_logger.info(f"Restored session {session_id} to ACTIVE state after permission decision")
                 except Exception:
                     logger.exception(f"Failed to restore session {session_id} to ACTIVE after permission")
 
@@ -357,7 +359,7 @@ class PermissionService:
                                 await self.coordinator.session_manager.update_additional_directories(
                                     session_id, suggestion_dict['directories']
                                 )
-                                logger.info(
+                                debug_logger.info(
                                     f"Updated session {session_id} additional_directories "
                                     f"with {len(suggestion_dict['directories'])} dirs"
                                 )
@@ -366,7 +368,7 @@ class PermissionService:
 
                     response['updated_permissions'] = updated_permissions
                     response['applied_updates_for_storage'] = applied_updates_for_storage
-                    logger.info(f"Built {len(updated_permissions)} permission updates from suggestions")
+                    debug_logger.info(f"Built {len(updated_permissions)} permission updates from suggestions")
 
                     # Issue #631: Audit log when user edits permission suggestion text
                     if response.get("selected_suggestions"):
@@ -392,7 +394,7 @@ class PermissionService:
                                             if orig_content else orig_tool
                                         )
                                         if orig_tool == tool_name_applied and orig_text != applied_text:
-                                            logger.info(
+                                            debug_logger.info(
                                                 f"Permission edited by user: "
                                                 f"original='{orig_text}' → edited='{applied_text}' "
                                                 f"in session {session_id}"
@@ -422,7 +424,7 @@ class PermissionService:
                             await self.coordinator.session_manager.update_allowed_tools(
                                 session_id, list(tools_to_persist)
                             )
-                            logger.info(
+                            debug_logger.info(
                                 f"Persisted {len(tools_to_persist)} approved tools to session "
                                 f"{session_id} allowed_tools: {tools_to_persist}"
                             )
@@ -519,7 +521,7 @@ class PermissionService:
                             }
                             if session_id in self.session_queues:
                                 self.session_queues[session_id].append(websocket_message)
-                            logger.info(
+                            debug_logger.info(
                                 f"Appended tool_call {'running' if granted else 'denied'} "
                                 f"for {tool_name} in session {session_id}"
                             )
@@ -532,7 +534,7 @@ class PermissionService:
             except Exception:
                 logger.exception("Failed to store permission response message")
 
-            logger.info(f"Permission {decision} for tool: {tool_name} (request_id: {request_id})")
+            debug_logger.info(f"Permission {decision} for tool: {tool_name} (request_id: {request_id})")
             return response
 
         return permission_callback
@@ -559,10 +561,10 @@ class PermissionService:
                         "message": f"Session {session_id} terminated - auto-denying pending permission"
                     }
                     future.set_result(response)
-                    logger.info(f"Auto-denied pending permission {request_id} due to session {session_id} termination")
+                    debug_logger.info(f"Auto-denied pending permission {request_id} due to session {session_id} termination")
 
             if permissions_to_cleanup:
-                logger.info(f"Cleaned up {len(permissions_to_cleanup)} pending permissions for session {session_id}")
+                debug_logger.info(f"Cleaned up {len(permissions_to_cleanup)} pending permissions for session {session_id}")
 
         except Exception:
             logger.exception(f"Error cleaning up pending permissions for session {session_id}")

--- a/src/tests/test_issue_1694_permission_ordering.py
+++ b/src/tests/test_issue_1694_permission_ordering.py
@@ -20,6 +20,7 @@ Covers:
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -392,7 +393,12 @@ async def test_permission_barrier_fails_open_on_timeout(caplog):
         patch("src.permission_service.PermissionInfo"),
         # Make wait_for immediately time out so the test runs in well under 2s
         patch("src.permission_service.asyncio.wait_for", side_effect=asyncio.TimeoutError),
-        caplog.at_level("WARNING", logger="src.permission_service"),
+        # configure_logging() (run by other test modules earlier in the same session)
+        # unconditionally sets propagate=False on every category logger it manages,
+        # including 'sdk_debug' — caplog's handler is only attached to the root
+        # logger, so propagation must be forced on for it to see these records.
+        patch.object(logging.getLogger("sdk_debug"), "propagate", True),
+        caplog.at_level("WARNING", logger="sdk_debug"),
     ):
         mock_pr.return_value = MagicMock()
         mock_sm.from_permission_request.return_value = MagicMock(to_dict=lambda: {})


### PR DESCRIPTION
## Summary
Resolves #1710

`permission_service.py` used a bare `logging.getLogger(__name__)`, never registered in `logging_config.py`, so it fell back to the root logger (WARNING threshold, error-only handlers). All `logger.info`/`logger.warning` calls were silently dropped — enabling `--debug-permissions` had no effect on this module, only `claude_sdk.py`'s SDK-facing half of the permission lifecycle was ever visible.

## Changes Made
- Add `debug_logger = get_logger('sdk_debug', category='PERMISSION_CALLBACK')`, reusing the existing `sdk_debug.log` / `--debug-permissions` wiring (already enabled by either `debug_sdk` or `debug_permissions`) that `claude_sdk.py` relies on for its `PERMISSIONS` category.
- Redirect all `logger.info`/`logger.warning` call sites in the file to `debug_logger` (covers the full permission callback lifecycle, not just the 5 lines named in the issue — the same root cause silently dropped every info/warning line in the file).
- Leave every `logger.exception` call site on the original module `logger` unchanged, so failure paths keep reaching `error.log` exactly as before.
- No changes to `logging_config.py` or `main.py` — the flag and category already exist and already work correctly.

## Testing
- `uv run ruff check --fix src/permission_service.py`: zero violations.
- `uv run pytest src/tests/ -q`: 2131 passed, 9 pre-existing failures unrelated to this change (verified identical on unmodified `main` — links/schedules/poll-timing/overseer-controller tests, none touching `permission_service.py`).
- Manual verification via a throwaway script exercising `PermissionService.create_permission_callback()` and `cleanup_pending_for_session()` directly:
  - With `--debug-permissions` (i.e. `configure_logging(debug_permissions=True)`): `sdk_debug.log` shows `[PERMISSION_CALLBACK]`-tagged lifecycle lines (triggered → requested → auto-approved).
  - Without the flag: no `sdk_debug.log` is even created — zero new log volume.
  - Forced error path (`cleanup_pending_for_session` exception): `error.log` still receives the full exception traceback unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)