### PR TITLE
fix: video resource preview can't seek (no HTTP range support)

### DIFF
--- a/src/http_range.py
+++ b/src/http_range.py
@@ -1,0 +1,93 @@
+"""RFC 7233 single-range parsing and response building for byte-serving endpoints.
+
+Supports only a single range per request (the first range of a comma-separated
+list is used), matching Starlette's own FileResponse behavior.
+"""
+
+from fastapi import Request
+from fastapi.responses import Response
+
+
+def parse_range_header(range_header: str, file_size: int) -> tuple[int, int]:
+    """Parse a `Range` header value into an inclusive (start, end) byte tuple.
+
+    Supports `bytes=start-end`, `bytes=start-` (open-ended), and `bytes=-suffix`
+    (suffix length) forms. Only the first range of a comma-separated list is
+    parsed. Raises ValueError for malformed or unsatisfiable ranges.
+    """
+    if not range_header.startswith("bytes="):
+        raise ValueError(f"Unsupported range unit: {range_header!r}")
+
+    spec = range_header[len("bytes="):].split(",", 1)[0].strip()
+    if "-" not in spec:
+        raise ValueError(f"Malformed range spec: {spec!r}")
+
+    start_str, end_str = spec.split("-", 1)
+    start_str = start_str.strip()
+    end_str = end_str.strip()
+
+    if start_str == "" and end_str == "":
+        raise ValueError("Malformed range spec: both bounds empty")
+
+    if file_size == 0:
+        raise ValueError("Range not satisfiable for empty file")
+
+    if start_str == "":
+        # Suffix range: last N bytes.
+        suffix_length = int(end_str)
+        if suffix_length <= 0:
+            raise ValueError(f"Invalid suffix length: {suffix_length}")
+        start = max(0, file_size - suffix_length)
+        end = file_size - 1
+    else:
+        start = int(start_str)
+        end = int(end_str) if end_str != "" else file_size - 1
+
+    if start < 0 or end < start or start >= file_size:
+        raise ValueError(f"Range not satisfiable: {spec!r} for file size {file_size}")
+
+    end = min(end, file_size - 1)
+    return start, end
+
+
+def build_resource_response(
+    request: Request,
+    content: bytes,
+    media_type: str,
+    filename: str,
+    disposition: str = "inline",
+) -> Response:
+    """Build a 200/206/416 response for a fully-buffered resource, honoring Range.
+
+    - No `Range` header: 200 with the full body (unchanged existing behavior).
+    - Valid `Range` header: 206 with the sliced body and Content-Range/Content-Length/
+      Accept-Ranges headers.
+    - Invalid/unsatisfiable `Range` header: 416 with `Content-Range: bytes */{size}`.
+    """
+    file_size = len(content)
+    range_header = request.headers.get("range")
+    base_headers = {
+        "Content-Disposition": f'{disposition}; filename="{filename}"',
+        "Accept-Ranges": "bytes",
+    }
+
+    if range_header is None:
+        return Response(content=content, media_type=media_type, headers=base_headers)
+
+    try:
+        start, end = parse_range_header(range_header, file_size)
+    except ValueError:
+        return Response(
+            content=b"",
+            media_type=media_type,
+            status_code=416,
+            headers={"Content-Range": f"bytes */{file_size}"},
+        )
+
+    sliced = content[start : end + 1]
+    headers = {
+        **base_headers,
+        "Content-Range": f"bytes {start}-{end}/{file_size}",
+        "Content-Length": str(len(sliced)),
+    }
+    return Response(content=sliced, media_type=media_type, status_code=206, headers=headers)

--- a/src/routers/archives.py
+++ b/src/routers/archives.py
@@ -1,10 +1,10 @@
 """Archive endpoints: /api/projects/{id}/archives/*, /api/projects/{id}/deleted-agents,
 /api/sessions/{id}/archives, /api/sessions/{id}/history-archives-status"""
 
-from fastapi import APIRouter, HTTPException
-from fastapi.responses import Response
+from fastapi import APIRouter, HTTPException, Request
 
 from ..exception_handlers import handle_exceptions
+from ..http_range import build_resource_response
 
 
 def build_router(webui) -> APIRouter:
@@ -78,7 +78,7 @@ def build_router(webui) -> APIRouter:
     )
     @handle_exceptions("get archive resource file")
     async def get_archive_resource_file(
-        project_id: str, session_id: str, archive_id: str, resource_id: str
+        project_id: str, session_id: str, archive_id: str, resource_id: str, request: Request
     ):
         """Get raw file data for a resource in an archive."""
         if not await webui.service.validate_project_exists(project_id):
@@ -105,12 +105,12 @@ def build_router(webui) -> APIRouter:
             "original_name", f"{resource_id}.bin"
         )
 
-        return Response(
+        return build_resource_response(
+            request,
             content=resource_bytes,
             media_type=content_type,
-            headers={
-                "Content-Disposition": f'inline; filename="{original_name}"'
-            },
+            filename=original_name,
+            disposition="inline",
         )
 
     @router.get("/api/projects/{project_id}/deleted-agents")

--- a/src/routers/files.py
+++ b/src/routers/files.py
@@ -5,10 +5,11 @@ import os
 from pathlib import Path
 from typing import Annotated
 
-from fastapi import APIRouter, File, HTTPException, UploadFile
+from fastapi import APIRouter, File, HTTPException, Request, UploadFile
 
 from ..exception_handlers import handle_exceptions
 from ..file_upload import FileUploadError, FileUploadManager
+from ..http_range import build_resource_response
 
 logger = logging.getLogger(__name__)
 
@@ -149,10 +150,8 @@ def build_router(webui) -> APIRouter:
 
     @router.get("/api/sessions/{session_id}/resources/{resource_id}")
     @handle_exceptions("get session resource")
-    async def get_session_resource(session_id: str, resource_id: str):
+    async def get_session_resource(session_id: str, resource_id: str, request: Request):
         """Get raw file data for a specific resource"""
-        from fastapi.responses import Response
-
         # Get resource metadata to determine content type
         resource_meta = await webui.coordinator.get_session_resource_by_id(session_id, resource_id)
 
@@ -168,20 +167,18 @@ def build_router(webui) -> APIRouter:
         content_type = resource_meta.get("mime_type", "application/octet-stream")
         original_name = resource_meta.get("original_name", f"{resource_id}.bin")
 
-        return Response(
+        return build_resource_response(
+            request,
             content=resource_bytes,
             media_type=content_type,
-            headers={
-                "Content-Disposition": f'inline; filename="{original_name}"'
-            }
+            filename=original_name,
+            disposition="inline",
         )
 
     @router.get("/api/sessions/{session_id}/resources/{resource_id}/download")
     @handle_exceptions("download session resource")
-    async def download_session_resource(session_id: str, resource_id: str):
+    async def download_session_resource(session_id: str, resource_id: str, request: Request):
         """Download a resource file"""
-        from fastapi.responses import Response
-
         # Get resource metadata
         resource_meta = await webui.coordinator.get_session_resource_by_id(session_id, resource_id)
 
@@ -196,12 +193,12 @@ def build_router(webui) -> APIRouter:
         content_type = resource_meta.get("mime_type", "application/octet-stream")
         original_name = resource_meta.get("original_name", f"{resource_id}.bin")
 
-        return Response(
+        return build_resource_response(
+            request,
             content=resource_bytes,
             media_type=content_type,
-            headers={
-                "Content-Disposition": f'attachment; filename="{original_name}"'
-            }
+            filename=original_name,
+            disposition="attachment",
         )
 
     # Issue #820: Serve session /tmp files directly (for containerized agents)

--- a/src/tests/integration/test_api_archives.py
+++ b/src/tests/integration/test_api_archives.py
@@ -129,6 +129,29 @@ class TestArchiveResources:
                 )
                 assert resp.status_code == 200
 
+    async def test_get_archive_resource_file_range_request_returns_206(self, api_integration_env):
+        """GET .../resources/{rid} with a Range header — 206 with correct slice (Issue #1716)."""
+        client = api_integration_env["client"]
+        pid, sid = await _create_and_delete_session(api_integration_env)
+
+        resp = await client.get(f"/api/projects/{pid}/archives/{sid}")
+        archives = resp.json().get("archives", [])
+
+        if archives:
+            archive_id = archives[0]["archive_id"]
+            res_resp = await client.get(
+                f"/api/projects/{pid}/archives/{sid}/{archive_id}/resources"
+            )
+            resources = res_resp.json().get("resources", [])
+            if resources:
+                rid = resources[0]["resource_id"]
+                resp = await client.get(
+                    f"/api/projects/{pid}/archives/{sid}/{archive_id}/resources/{rid}",
+                    headers={"Range": "bytes=0-3"},
+                )
+                assert resp.status_code == 206
+                assert resp.headers.get("content-range", "").startswith("bytes 0-3/")
+
     async def test_get_archive_resource_file_nonexistent(self, api_integration_env):
         client = api_integration_env["client"]
         pid, sid = await _create_and_delete_session(api_integration_env)

--- a/src/tests/integration/test_api_resources.py
+++ b/src/tests/integration/test_api_resources.py
@@ -194,6 +194,158 @@ class TestDownloadResource:
             assert resp.status_code == 200
             assert "attachment" in resp.headers.get("content-disposition", "")
 
+    async def test_download_resource_with_range_returns_206(self, api_integration_env):
+        """Download endpoint shares the Range helper — 206 with correct slice (Issue #1716)."""
+        client = api_integration_env["client"]
+        session = await _create_session_with_project(api_integration_env)
+        sid = session["session_id"]
+
+        await client.post(
+            f"/api/sessions/{sid}/files",
+            files={"file": ("dl-range.txt", b"download content here", "text/plain")},
+        )
+
+        res_resp = await client.get(f"/api/sessions/{sid}/resources")
+        resources = res_resp.json()["resources"]
+        if resources:
+            rid = resources[0]["resource_id"]
+            resp = await client.get(
+                f"/api/sessions/{sid}/resources/{rid}/download",
+                headers={"Range": "bytes=0-3"},
+            )
+            assert resp.status_code == 206
+            assert resp.content == b"down"
+            assert "attachment" in resp.headers.get("content-disposition", "")
+
+
+class TestResourceRangeRequests:
+    """Tests for HTTP Range support on GET /api/sessions/{session_id}/resources/{resource_id} (Issue #1716)."""
+
+    async def _upload_and_get_resource_id(self, env, client, sid, filename, content, content_type):
+        await client.post(
+            f"/api/sessions/{sid}/files",
+            files={"file": (filename, content, content_type)},
+        )
+        res_resp = await client.get(f"/api/sessions/{sid}/resources")
+        resources = res_resp.json()["resources"]
+        assert resources
+        return resources[0]["resource_id"]
+
+    async def test_no_range_header_returns_200_full_body(self, api_integration_env):
+        client = api_integration_env["client"]
+        session = await _create_session_with_project(api_integration_env)
+        sid = session["session_id"]
+        content = b"0123456789" * 10  # 100 bytes
+
+        rid = await self._upload_and_get_resource_id(
+            api_integration_env, client, sid, "range-content.txt", content, "text/plain"
+        )
+
+        resp = await client.get(f"/api/sessions/{sid}/resources/{rid}")
+        assert resp.status_code == 200
+        assert resp.content == content
+        assert resp.headers.get("accept-ranges") == "bytes"
+
+    async def test_mid_range_returns_206_correct_slice(self, api_integration_env):
+        client = api_integration_env["client"]
+        session = await _create_session_with_project(api_integration_env)
+        sid = session["session_id"]
+        content = b"0123456789" * 10  # 100 bytes
+
+        rid = await self._upload_and_get_resource_id(
+            api_integration_env, client, sid, "range-content.txt", content, "text/plain"
+        )
+
+        resp = await client.get(
+            f"/api/sessions/{sid}/resources/{rid}", headers={"Range": "bytes=10-19"}
+        )
+        assert resp.status_code == 206
+        assert resp.content == content[10:20]
+        assert resp.headers.get("content-range") == "bytes 10-19/100"
+        assert resp.headers.get("content-length") == "10"
+        assert resp.headers.get("accept-ranges") == "bytes"
+
+    async def test_open_ended_range_returns_206_to_eof(self, api_integration_env):
+        client = api_integration_env["client"]
+        session = await _create_session_with_project(api_integration_env)
+        sid = session["session_id"]
+        content = b"0123456789" * 10  # 100 bytes
+
+        rid = await self._upload_and_get_resource_id(
+            api_integration_env, client, sid, "range-content.txt", content, "text/plain"
+        )
+
+        resp = await client.get(
+            f"/api/sessions/{sid}/resources/{rid}", headers={"Range": "bytes=90-"}
+        )
+        assert resp.status_code == 206
+        assert resp.content == content[90:]
+        assert resp.headers.get("content-range") == "bytes 90-99/100"
+
+    async def test_suffix_range_returns_206(self, api_integration_env):
+        client = api_integration_env["client"]
+        session = await _create_session_with_project(api_integration_env)
+        sid = session["session_id"]
+        content = b"0123456789" * 10  # 100 bytes
+
+        rid = await self._upload_and_get_resource_id(
+            api_integration_env, client, sid, "range-content.txt", content, "text/plain"
+        )
+
+        resp = await client.get(
+            f"/api/sessions/{sid}/resources/{rid}", headers={"Range": "bytes=-10"}
+        )
+        assert resp.status_code == 206
+        assert resp.content == content[-10:]
+        assert resp.headers.get("content-range") == "bytes 90-99/100"
+
+    async def test_malformed_range_returns_416(self, api_integration_env):
+        client = api_integration_env["client"]
+        session = await _create_session_with_project(api_integration_env)
+        sid = session["session_id"]
+        content = b"0123456789" * 10  # 100 bytes
+
+        rid = await self._upload_and_get_resource_id(
+            api_integration_env, client, sid, "range-content.txt", content, "text/plain"
+        )
+
+        resp = await client.get(
+            f"/api/sessions/{sid}/resources/{rid}", headers={"Range": "bytes=abc-def"}
+        )
+        assert resp.status_code == 416
+        assert resp.headers.get("content-range") == "bytes */100"
+
+    async def test_out_of_bounds_range_returns_416(self, api_integration_env):
+        client = api_integration_env["client"]
+        session = await _create_session_with_project(api_integration_env)
+        sid = session["session_id"]
+        content = b"0123456789" * 10  # 100 bytes
+
+        rid = await self._upload_and_get_resource_id(
+            api_integration_env, client, sid, "range-content.txt", content, "text/plain"
+        )
+
+        resp = await client.get(
+            f"/api/sessions/{sid}/resources/{rid}", headers={"Range": "bytes=200-300"}
+        )
+        assert resp.status_code == 416
+        assert resp.headers.get("content-range") == "bytes */100"
+
+    async def test_non_video_resource_unaffected_without_range_header(self, api_integration_env):
+        """Regression: an image resource still gets a full 200 response when no Range header is sent."""
+        client = api_integration_env["client"]
+        session = await _create_session_with_project(api_integration_env)
+        sid = session["session_id"]
+        png_data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+
+        rid = await self._upload_and_get_resource_id(
+            api_integration_env, client, sid, "image.png", png_data, "image/png"
+        )
+
+        resp = await client.get(f"/api/sessions/{sid}/resources/{rid}")
+        assert resp.status_code == 200
+        assert resp.content == png_data
+
 
 class TestRemoveResource:
     async def test_soft_remove_resource(self, api_integration_env):

--- a/src/tests/test_http_range.py
+++ b/src/tests/test_http_range.py
@@ -1,0 +1,64 @@
+"""Unit tests for RFC 7233 single-range parsing (issue #1716)."""
+
+import pytest
+
+from ..http_range import parse_range_header
+
+
+class TestParseRangeHeader:
+    def test_full_range(self):
+        assert parse_range_header("bytes=0-99", 100) == (0, 99)
+
+    def test_mid_range(self):
+        assert parse_range_header("bytes=10-19", 100) == (10, 19)
+
+    def test_open_ended_range(self):
+        assert parse_range_header("bytes=50-", 100) == (50, 99)
+
+    def test_suffix_range(self):
+        assert parse_range_header("bytes=-10", 100) == (90, 99)
+
+    def test_suffix_range_larger_than_file_clamps_to_start(self):
+        assert parse_range_header("bytes=-1000", 100) == (0, 99)
+
+    def test_single_byte_range(self):
+        assert parse_range_header("bytes=0-0", 100) == (0, 0)
+
+    def test_range_at_eof(self):
+        assert parse_range_header("bytes=99-99", 100) == (99, 99)
+
+    def test_end_beyond_file_size_is_clamped(self):
+        assert parse_range_header("bytes=0-999", 100) == (0, 99)
+
+    def test_first_range_of_multi_range_used(self):
+        assert parse_range_header("bytes=0-9,20-29", 100) == (0, 9)
+
+    @pytest.mark.parametrize(
+        "header",
+        [
+            "bytes=-",
+            "bytes=abc-def",
+            "bytes=10",
+            "items=0-99",
+            "bytes=-0",
+        ],
+    )
+    def test_malformed_spec_raises(self, header):
+        with pytest.raises(ValueError):
+            parse_range_header(header, 100)
+
+    def test_reversed_range_raises(self):
+        with pytest.raises(ValueError):
+            parse_range_header("bytes=50-10", 100)
+
+    def test_negative_start_raises(self):
+        with pytest.raises(ValueError):
+            parse_range_header("bytes=-5-10", 100)
+
+    def test_start_at_or_beyond_file_size_raises(self):
+        with pytest.raises(ValueError):
+            parse_range_header("bytes=100-199", 100)
+
+    def test_empty_file_raises(self):
+        with pytest.raises(ValueError):
+            parse_range_header("bytes=0-0", 0)


### PR DESCRIPTION
## Summary
Resolves #1716

`get_session_resource`, `download_session_resource`, and `get_archive_resource_file` read
the entire resource file into memory and returned it via a plain `Response` — no `Range`
header parsing, no `Accept-Ranges`, no 206 Partial Content path. Browsers require
`Accept-Ranges: bytes` + 206 support to enable `<video>` seeking, so video resource preview
playback was strictly sequential (no scrub-bar seek, no fast-forward/rewind).

## Changes Made
- Add `src/http_range.py`: RFC 7233 single-range parsing (`parse_range_header`) and response
  building (`build_resource_response`) — returns 200 (no Range header, unchanged full body),
  206 (valid Range — `Content-Range`/`Content-Length`/`Accept-Ranges` + sliced body), or 416
  (invalid/unsatisfiable Range — `Content-Range: bytes */{size}`).
- Wire the helper into `get_session_resource` and `download_session_resource`
  (`src/routers/files.py`) and `get_archive_resource_file` (`src/routers/archives.py`), adding
  a `Request` param to each. `disposition="inline"` for the two preview endpoints,
  `"attachment"` for download.
- Continue reading the full file into memory (unchanged from current behavior) — only the
  amount of data *transmitted* is reduced for Range requests. Disk-offset streaming is
  explicitly out of scope.
- Only single-range requests are supported (first range of a comma-separated list is used),
  matching Starlette's own `FileResponse` behavior.
- Add `src/tests/test_http_range.py` (18 unit tests covering full/mid/open-ended/suffix
  ranges, malformed specs, out-of-bounds, empty file) and extend
  `src/tests/integration/test_api_resources.py` / `test_api_archives.py` with Range-header
  integration tests against the real endpoints (200/206/416, byte-exact slices, and a
  regression check that non-Range requests — including image resources — are unaffected).

## Testing
- `uv run ruff check` — zero violations on all changed/new files.
- `uv run pytest src/tests/` — 2157 passed, 8 pre-existing failures unrelated to this change
  (verified identical on `main` without these changes — Mock/await issues in
  `test_overseer_controller.py`, `test_api_links.py`, `test_api_schedules.py`,
  `test_issue_1598_poll_viewed_timing.py`).
- Regression guard confirmed unchanged: `test_download_resource`, `test_get_nonexistent_resource`,
  and all of `test_resource_versioning_integration.py` pass.
- Independent second-opinion code review (subagent) focused on off-by-one range math and 416
  edge cases — no correctness bugs found; one test-coverage gap identified (download/archive
  endpoints lacked Range-specific integration tests) and closed.
- Manual verification against a live dev server (backend :8716, frontend :5716):
  - Uploaded a real 60s/3MB MP4 test video, opened the resource preview, and seeked both
    forward (0:00 → 0:48) and backward (0:48 → 0:11) via the native scrub bar — confirmed via
    `currentTime` and screenshots.
  - Captured real browser network traffic: distinct `Range: bytes=N-` requests fired during
    seeking (e.g. `bytes=2129920-`, `bytes=2359296-`, `bytes=458752-`), each served as 206 with
    correct `Content-Range`.
  - `curl` proof against the live endpoint: no-Range → 200 full body; mid-range
    (`bytes=1000000-1000099`) → 206 with exactly 100 bytes; out-of-bounds range → 416 with
    `Content-Range: bytes */3126325`.
  - Uploaded a PNG image resource and confirmed it still returns a plain 200 with no Range
    header (no regression to non-video resource previews).

🤖 Generated with [Claude Code](https://claude.com/claude-code)