### PR TITLE
fix: resolve send_comm sender attachment chip to correct version

### DIFF
--- a/src/legion/comm_router.py
+++ b/src/legion/comm_router.py
@@ -166,13 +166,19 @@ class CommRouter:
         # Validate comm has proper routing
         comm.validate()
 
+        # Deliver attachments before persisting (issue #1730) so timeline.jsonl
+        # captures the resolved resource_id from the start, instead of null
+        # placeholders mutated in place afterward.
+        if comm.to_minion_id:
+            await self._deliver_attachments(comm, attachment_data)
+
         # Normal routing - persist and route
         await self._persist_comm(comm)
         legion_logger.debug(f"Comm {comm.comm_id} persisted successfully")
 
         # Route to destination
         if comm.to_minion_id:
-            result = await self._send_to_minion(comm, attachment_data=attachment_data)
+            result = await self._send_to_minion(comm)
             legion_logger.info(f"Comm {comm.comm_id} routed to minion {comm.to_minion_id}: {'success' if result else 'failed'}")
             return result
         elif comm.to_user:
@@ -183,18 +189,108 @@ class CommRouter:
         legion_logger.warning(f"Comm {comm.comm_id} has no valid destination")
         return False
 
-    async def _send_to_minion(
+    async def _deliver_attachments(
         self,
         comm: Comm,
         attachment_data: dict[str, bytes] | None = None,
+    ) -> None:
+        """
+        Write and register a Comm's file attachments in the recipient's session.
+
+        Called from route_comm() before _persist_comm() (issue #1730) so that
+        timeline.jsonl captures each attachment's resolved resource_id from the
+        start, instead of a null placeholder mutated in place afterward.
+
+        Files go to the session's attachments/ dir — same location as user
+        uploads via InputArea. To the agent, a comm is just an enhanced user
+        message from another agent, so the file paths should be consistent.
+        For Docker sessions, attachments/ is mounted read-only at its host
+        path (see session_coordinator.py).
+
+        Mutates each dict in comm.attachments in place with resource_id,
+        session_id, and stored_path on success. On failure to locate or
+        deliver a given attachment, it's left with resource_id=None — no
+        worse than before this fix — and logged.
+        """
+        if not (comm.attachments and comm.to_minion_id):
+            return
+
+        # Skip delivery if the target minion doesn't exist — mirrors the check
+        # _send_to_minion() does before it would otherwise have reached the
+        # (now-removed) delivery block. Without this, a comm to a missing/
+        # disposed minion would write files and register orphaned resources
+        # under a session directory that isn't wired into session_manager,
+        # before _send_to_minion() catches the missing target and errors out.
+        target_minion = await self.system.session_coordinator.session_manager.get_session_info(comm.to_minion_id)
+        if not target_minion:
+            legion_logger.warning(f"Skipping attachment delivery: target minion {comm.to_minion_id} not found")
+            return
+
+        attachment_data = attachment_data or {}
+        data_dir = self.system.session_coordinator.data_dir
+        attachments_dir = data_dir / "sessions" / comm.to_minion_id / "attachments"
+        attachments_dir.mkdir(parents=True, exist_ok=True)
+
+        # Sender name for the registered resource's description only
+        from_name = "Minion #user"
+        if comm.from_minion_id:
+            from_minion = await self.system.legion_coordinator.get_minion_info(comm.from_minion_id)
+            if from_minion and from_minion.name:
+                from_name = f"Minion #{from_minion.name}"
+
+        for att in comm.attachments:
+            file_bytes = attachment_data.get(att["name"])
+            if not file_bytes:
+                # Fallback: try reading from source path
+                source = Path(att.get("source_path", ""))
+                if source.exists():
+                    file_bytes = source.read_bytes()
+            if not file_bytes:
+                legion_logger.error(f"Failed to deliver attachment {att['name']}: no data or source found")
+                continue
+
+            try:
+                dest_path = attachments_dir / att["name"]
+                # Avoid name collisions
+                if dest_path.exists():
+                    dest_path = attachments_dir / f"{dest_path.stem}_{uuid.uuid4().hex[:8]}{dest_path.suffix}"
+                dest_path.write_bytes(file_bytes)
+
+                # Register as resource in recipient session (for UI gallery)
+                resource_result = await self.system.session_coordinator.register_uploaded_resource(
+                    session_id=comm.to_minion_id,
+                    file_path=str(dest_path),
+                    title=att["name"],
+                    description=f"File attachment from {from_name}"
+                )
+
+                # Register for auto-approve Read
+                await self.system.session_coordinator.register_uploaded_file(
+                    session_id=comm.to_minion_id,
+                    file_path=str(dest_path)
+                )
+
+                # Update attachment metadata with resource info
+                if resource_result:
+                    att["resource_id"] = resource_result.get("resource_id")
+                    att["session_id"] = comm.to_minion_id
+                    att["stored_path"] = str(dest_path)
+            except Exception as e:
+                legion_logger.error(f"Failed to deliver attachment {att['name']}: {e}")
+
+    async def _send_to_minion(
+        self,
+        comm: Comm,
     ) -> bool:
         """
         Send Comm to a specific minion by injecting message into SDK session.
         Auto-starts the minion session if it's not active.
 
+        Attachments (if any) must already be delivered via _deliver_attachments()
+        before this is called — this only formats comm.attachments for display.
+
         Args:
             comm: Comm with to_minion_id set
-            attachment_data: Optional dict mapping filename -> bytes for file attachments
 
         Returns:
             bool: True if sent successfully
@@ -308,67 +404,25 @@ class CommRouter:
 
             formatted_message = f"**{comm_type_prefix} from {from_name}:** {header_summary}\n\n{comm.content}"
 
-            # Deliver file attachments to recipient session (issue #773)
-            # Files go to the session's attachments/ dir — same location as
-            # user uploads via InputArea. To the agent, a comm is just an
-            # enhanced user message from another agent, so the file paths
-            # should be consistent. For Docker sessions, attachments/ is
-            # mounted read-only at its host path (see session_coordinator.py).
+            # Format file attachments for the recipient message (issue #773).
+            # Delivery (file write + resource registration) already happened in
+            # route_comm() via _deliver_attachments() (issue #1730), before
+            # _persist_comm() ran, so this only builds display lines from the
+            # already-resolved comm.attachments.
             if comm.attachments and comm.to_minion_id:
-                attachment_data = attachment_data or {}
                 attachment_lines = []
-                data_dir = self.system.session_coordinator.data_dir
-                attachments_dir = data_dir / "sessions" / comm.to_minion_id / "attachments"
-                attachments_dir.mkdir(parents=True, exist_ok=True)
-
                 for att in comm.attachments:
-                    file_bytes = attachment_data.get(att["name"])
-                    if not file_bytes:
-                        # Fallback: try reading from source path
-                        source = Path(att.get("source_path", ""))
-                        if source.exists():
-                            file_bytes = source.read_bytes()
-                    if file_bytes:
-                        try:
-                            dest_path = attachments_dir / att["name"]
-                            # Avoid name collisions
-                            if dest_path.exists():
-                                dest_path = attachments_dir / f"{dest_path.stem}_{uuid.uuid4().hex[:8]}{dest_path.suffix}"
-                            dest_path.write_bytes(file_bytes)
-
-                            # Register as resource in recipient session (for UI gallery)
-                            resource_result = await self.system.session_coordinator.register_uploaded_resource(
-                                session_id=comm.to_minion_id,
-                                file_path=str(dest_path),
-                                title=att["name"],
-                                description=f"File attachment from {from_name}"
-                            )
-
-                            # Register for auto-approve Read
-                            await self.system.session_coordinator.register_uploaded_file(
-                                session_id=comm.to_minion_id,
-                                file_path=str(dest_path)
-                            )
-
-                            # Update attachment metadata with resource info
-                            if resource_result:
-                                att["resource_id"] = resource_result.get("resource_id")
-                                att["session_id"] = comm.to_minion_id
-                                att["stored_path"] = str(dest_path)
-
-                            # Format size for display
-                            size_kb = att["size"] / 1024
-                            if size_kb >= 1024:
-                                size_str = f"{size_kb / 1024:.1f} MB"
-                            else:
-                                size_str = f"{size_kb:.1f} KB"
-
-                            attachment_lines.append(
-                                f"- {att['name']} ({size_str}): {dest_path}"
-                            )
-                        except Exception as e:
-                            legion_logger.error(f"Failed to deliver attachment {att['name']}: {e}")
-                            attachment_lines.append(f"- {att['name']}: [delivery failed]")
+                    if att.get("stored_path"):
+                        size_kb = att["size"] / 1024
+                        if size_kb >= 1024:
+                            size_str = f"{size_kb / 1024:.1f} MB"
+                        else:
+                            size_str = f"{size_kb:.1f} KB"
+                        attachment_lines.append(
+                            f"- {att['name']} ({size_str}): {att['stored_path']}"
+                        )
+                    else:
+                        attachment_lines.append(f"- {att['name']}: [delivery failed]")
 
                 if attachment_lines:
                     formatted_message += "\n\n---\nAttached files (use Read tool to access, or embed via markdown URL):\n"

--- a/src/legion/mcp/legion_mcp_tools.py
+++ b/src/legion/mcp/legion_mcp_tools.py
@@ -724,10 +724,23 @@ class LegionMCPTools:
                 comm, attachment_data=attachment_file_data or None
             )
             if success:
+                text = f"Message sent to {to_minion_name}"
+                if attachment_metadata:
+                    import json as _json
+                    footer_payload = [
+                        {
+                            "name": att["name"],
+                            "resource_id": att.get("sender_resource_id"),
+                            "size": att["size"],
+                            "mime_type": att["mime_type"],
+                        }
+                        for att in attachment_metadata
+                    ]
+                    text += f"\n\n<!-- sender_attachments: {_json.dumps(footer_payload)} -->"
                 return {
                     "content": [{
                         "type": "text",
-                        "text": f"Message sent to {to_minion_name}"
+                        "text": text
                     }],
                     "is_error": False
                 }

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -3824,12 +3824,10 @@ class SessionCoordinator:
                                     if matched_tool.display:
                                         matched_tool.display.state = ToolState.COMPLETED
                                         matched_tool.display.style = "success"
-                                    # Issue #1593: resolve sender attachment resource IDs
+                                    # Issue #1593/#1730: resolve sender attachment resource IDs
                                     if matched_tool.name == "mcp__legion__send_comm":
                                         matched_tool.sender_attachments = (
-                                            await self._resolve_send_comm_sender_attachments(
-                                                session_id, matched_tool.input
-                                            )
+                                            self._parse_send_comm_sender_attachments(result_content)
                                         )
                                 tc_data = matched_tool.to_dict()
                                 tc_data["type"] = "tool_call"
@@ -4339,57 +4337,35 @@ class SessionCoordinator:
 
         return tool_call
 
-    async def _resolve_send_comm_sender_attachments(
+    def _parse_send_comm_sender_attachments(
         self,
-        session_id: str,
-        tool_input: dict,
+        result_content: str,
     ) -> list[dict] | None:
-        """Issue #1593: Resolve sender resource IDs for mcp__legion__send_comm attachments.
+        """Issue #1593/#1730: Parse sender resource IDs for mcp__legion__send_comm attachments.
 
-        Looks up each attachment filename in the session's resource storage to find
-        the resource_id registered when send_comm ran. Returns a list of dicts with
-        {name, resource_id, size, mime_type} for use by SendCommToolHandler.
+        Extracts the JSON footer embedded by `_handle_send_comm` in the tool
+        result text (format: `<!-- sender_attachments: [...] -->`). The footer
+        is captured immutably at the moment of that specific send_comm call, so
+        this parser returns the exact version delivered — unlike a filename
+        search against the resource log, which always resolves to the oldest
+        matching version regardless of which send_comm call is being displayed.
         """
         import json as _json
-        from pathlib import Path
+        import re
 
-        raw = tool_input.get("attachments")
-        if not raw:
+        if not isinstance(result_content, str):
+            return None
+
+        match = re.search(r"<!-- sender_attachments: (.*?) -->", result_content, re.DOTALL)
+        if not match:
             return None
 
         try:
-            paths = _json.loads(raw) if isinstance(raw, str) else raw
-            paths = paths if isinstance(paths, list) else [str(raw)]
-        except Exception:
+            parsed = _json.loads(match.group(1))
+        except _json.JSONDecodeError:
             return None
 
-        storage = self._storage_managers.get(session_id)
-        if not storage:
-            return None
-
-        try:
-            resources = await storage.read_resources()
-        except Exception:
-            return None
-
-        result = []
-        for p in paths:
-            filename = Path(p).name
-            resource = next(
-                (
-                    r
-                    for r in resources
-                    if r.get("title") == filename or r.get("original_name") == filename
-                ),
-                None,
-            )
-            result.append({
-                "name": filename,
-                "resource_id": resource["resource_id"] if resource else None,
-                "size": resource.get("size_bytes") if resource else None,
-                "mime_type": resource.get("mime_type") if resource else None,
-            })
-        return result if result else None
+        return parsed if isinstance(parsed, list) and parsed else None
 
     def mark_session_tools_interrupted(self, session_id: str) -> list[ToolCall]:
         """

--- a/src/tests/test_comm_router.py
+++ b/src/tests/test_comm_router.py
@@ -348,6 +348,9 @@ class TestCommRouter:
             ],
         )
 
+        # Attachment delivery now happens in _deliver_attachments(), called by
+        # route_comm() before _send_to_minion() (issue #1730)
+        await comm_router._deliver_attachments(comm)
         result = await comm_router._send_to_minion(comm)
         assert result is True
 
@@ -364,3 +367,90 @@ class TestCommRouter:
         assert attachments[0]["filename"] == "report.txt"
         assert attachments[0]["stored_path"] != "", "stored_path must be set after delivery"
         assert attachments[0]["resource_id"] == "res-abc123"
+
+    @pytest.mark.asyncio
+    async def test_issue_1730_route_comm_persists_non_null_resource_id(self, comm_router, tmp_path):
+        """Regression test: route_comm() delivers attachments (resolving
+        resource_id) before persisting the Comm, so timeline.jsonl carries the
+        correct resource_id from the start instead of a null placeholder that
+        gets mutated in place afterward (append-only log, so the persisted
+        record previously stayed null forever)."""
+        comm_router.system.session_coordinator.data_dir = tmp_path
+
+        source_file = tmp_path / "notes.txt"
+        source_file.write_bytes(b"attachment contents")
+
+        comm_router.system.session_coordinator.register_uploaded_resource = AsyncMock(
+            return_value={"resource_id": "res-persisted-1"}
+        )
+        comm_router.system.session_coordinator.register_uploaded_file = AsyncMock()
+
+        comm = Comm(
+            comm_id=str(uuid.uuid4()),
+            from_user=True,
+            to_minion_id="test-minion-123",
+            content="Here is a file",
+            comm_type=CommType.TASK,
+            attachments=[
+                {
+                    "name": "notes.txt",
+                    "size": 20,
+                    "mime_type": "text/plain",
+                    "source_path": str(source_file),
+                }
+            ],
+        )
+
+        with patch.object(comm_router, '_append_to_timeline', new=AsyncMock()) as mock_append_timeline:
+            result = await comm_router.route_comm(comm)
+
+        assert result is True
+        mock_append_timeline.assert_called_once()
+        persisted_comm = mock_append_timeline.call_args.args[1]
+        assert persisted_comm.attachments[0]["resource_id"] == "res-persisted-1", (
+            "Comm persisted to timeline.jsonl must already carry the resolved "
+            "resource_id, not null"
+        )
+
+    @pytest.mark.asyncio
+    async def test_issue_1730_deliver_attachments_skips_when_target_missing(self, comm_router, tmp_path):
+        """Regression test: _deliver_attachments() must not write files or
+        register resources for a to_minion_id that doesn't exist. Delivery now
+        runs before _send_to_minion()'s own "target minion not found" check
+        (moved there by issue #1730), so it must re-check existence itself —
+        otherwise a comm to a missing/disposed minion would silently create
+        orphaned files/resources under a session directory that was never
+        wired into session_manager."""
+        comm_router.system.session_coordinator.data_dir = tmp_path
+        comm_router.system.session_coordinator.session_manager.get_session_info = AsyncMock(
+            return_value=None
+        )
+        register_resource_mock = AsyncMock(return_value={"resource_id": "should-not-be-called"})
+        comm_router.system.session_coordinator.register_uploaded_resource = register_resource_mock
+
+        source_file = tmp_path / "notes.txt"
+        source_file.write_bytes(b"attachment contents")
+
+        comm = Comm(
+            comm_id=str(uuid.uuid4()),
+            from_user=True,
+            to_minion_id="nonexistent-minion",
+            content="Here is a file",
+            comm_type=CommType.TASK,
+            attachments=[
+                {
+                    "name": "notes.txt",
+                    "size": 20,
+                    "mime_type": "text/plain",
+                    "source_path": str(source_file),
+                }
+            ],
+        )
+
+        await comm_router._deliver_attachments(comm)
+
+        register_resource_mock.assert_not_called()
+        assert comm.attachments[0].get("resource_id") is None
+        assert not (tmp_path / "sessions" / "nonexistent-minion").exists(), (
+            "No attachment directory should be created for a nonexistent target minion"
+        )

--- a/src/tests/test_legion_mcp_tools.py
+++ b/src/tests/test_legion_mcp_tools.py
@@ -473,6 +473,144 @@ async def test_issue_824_non_tmp_path_not_translated(tmp_path):
     assert result.get("is_error") is True
 
 
+# Regression tests for issue #1730: sender-side attachment chip resolves to the
+# wrong (oldest) version when the same filename is sent across multiple send_comm
+# calls. Fix: _handle_send_comm embeds the resolved resource_id as an immutable
+# footer on the tool result, instead of re-searching resources by filename later.
+
+
+def _make_send_comm_system_with_router(session_id: str, data_dir, resource_ids):
+    """Helper: build a mock system for send_comm attachment-footer tests.
+
+    `resource_ids` is consumed in order, one per attachment registered via
+    register_uploaded_resource, so tests can assert distinct resource_ids are
+    embedded per attachment/call.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    mock_system = _make_send_comm_system(session_id, docker_enabled=False, data_dir=data_dir)
+    mock_system.session_coordinator.register_uploaded_resource = AsyncMock(
+        side_effect=[{"resource_id": rid} for rid in resource_ids]
+    )
+    mock_system.comm_router = MagicMock()
+    mock_system.comm_router.route_comm = AsyncMock(return_value=True)
+    return mock_system
+
+
+def _extract_sender_attachments_footer(text):
+    import json
+    import re
+
+    match = re.search(r"<!-- sender_attachments: (.*?) -->", text, re.DOTALL)
+    assert match, f"sender_attachments footer not found in tool result text: {text!r}"
+    return json.loads(match.group(1))
+
+
+@pytest.mark.asyncio
+async def test_issue_1730_send_comm_embeds_resolved_resource_id_per_attachment(tmp_path):
+    """_handle_send_comm embeds the resolved resource_id for each of multiple
+    attachments sent in a single call, not just the first."""
+    from src.legion.mcp.legion_mcp_tools import LegionMCPTools
+
+    session_id = "sender-session-multi"
+    file_a = tmp_path / "a.txt"
+    file_a.write_text("version a")
+    file_b = tmp_path / "b.txt"
+    file_b.write_text("version bb")
+
+    mock_system = _make_send_comm_system_with_router(
+        session_id, tmp_path, resource_ids=["res-a", "res-b"]
+    )
+    mcp_tools = LegionMCPTools(mock_system)
+
+    result = await mcp_tools._handle_send_comm({
+        "_from_minion_id": session_id,
+        "to_minion_name": "user",
+        "summary": "test",
+        "content": "body",
+        "comm_type": "report",
+        "attachments": [str(file_a), str(file_b)],
+    })
+
+    assert result["is_error"] is False
+    footer = _extract_sender_attachments_footer(result["content"][0]["text"])
+    assert footer == [
+        {"name": "a.txt", "resource_id": "res-a", "size": 9, "mime_type": "text/plain"},
+        {"name": "b.txt", "resource_id": "res-b", "size": 10, "mime_type": "text/plain"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_issue_1730_footer_parser_round_trips(tmp_path):
+    """session_coordinator._parse_send_comm_sender_attachments correctly decodes
+    the footer embedded by _handle_send_comm."""
+    from src.legion.mcp.legion_mcp_tools import LegionMCPTools
+    from src.session_coordinator import SessionCoordinator
+
+    session_id = "sender-session-roundtrip"
+    file_a = tmp_path / "report.md"
+    file_a.write_text("contents")
+
+    mock_system = _make_send_comm_system_with_router(
+        session_id, tmp_path, resource_ids=["res-xyz"]
+    )
+    mcp_tools = LegionMCPTools(mock_system)
+
+    result = await mcp_tools._handle_send_comm({
+        "_from_minion_id": session_id,
+        "to_minion_name": "user",
+        "summary": "test",
+        "content": "body",
+        "comm_type": "report",
+        "attachments": [str(file_a)],
+    })
+
+    text = result["content"][0]["text"]
+    parsed = SessionCoordinator._parse_send_comm_sender_attachments(None, text)
+    assert parsed == [
+        {"name": "report.md", "resource_id": "res-xyz", "size": 8, "mime_type": "text/markdown"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_issue_1730_same_filename_resolves_distinct_resource_ids_across_calls(tmp_path):
+    """Sending the same-named file across 3 separate send_comm calls resolves 3
+    distinct resource_ids — not the same (oldest) one each time, which was the
+    bug: the old resolver re-searched the resource log by filename and always
+    matched the first (oldest) registered version."""
+    from src.legion.mcp.legion_mcp_tools import LegionMCPTools
+    from src.session_coordinator import SessionCoordinator
+
+    session_id = "sender-session-versions"
+    mock_system = _make_send_comm_system_with_router(
+        session_id, tmp_path, resource_ids=["res-v1", "res-v2", "res-v3"]
+    )
+    mcp_tools = LegionMCPTools(mock_system)
+
+    resolved_ids = []
+    for version_text in ["v1 contents", "v2 contents", "v3 contents"]:
+        # Same filename each time, overwriting the previous version on disk —
+        # mirrors an agent re-registering an updated version of the same file.
+        shared_path = tmp_path / "same_name.txt"
+        shared_path.write_text(version_text)
+
+        result = await mcp_tools._handle_send_comm({
+            "_from_minion_id": session_id,
+            "to_minion_name": "user",
+            "summary": "test",
+            "content": "body",
+            "comm_type": "report",
+            "attachments": [str(shared_path)],
+        })
+
+        footer = SessionCoordinator._parse_send_comm_sender_attachments(
+            None, result["content"][0]["text"]
+        )
+        resolved_ids.append(footer[0]["resource_id"])
+
+    assert resolved_ids == ["res-v1", "res-v2", "res-v3"]
+
+
 # ── queue_task handler tests (Issue #1114) ──
 
 

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -793,13 +793,13 @@ class ClaudeWebUI:
                     is_error = tool_result.get('is_error', False)
 
                     if tool_use_id:
-                        # Issue #1593: resolve sender attachment resource IDs for send_comm
+                        # Issue #1593/#1730: resolve sender attachment resource IDs for send_comm
                         sender_attachments = None
                         if not is_error:
                             active_tc = self.coordinator._get_active_tool_call(session_id, tool_use_id)
                             if active_tc and active_tc.name == "mcp__legion__send_comm":
-                                sender_attachments = await self.coordinator._resolve_send_comm_sender_attachments(
-                                    session_id, active_tc.input
+                                sender_attachments = self.coordinator._parse_send_comm_sender_attachments(
+                                    result_content
                                 )
 
                         # Update ToolCall with result


### PR DESCRIPTION
## Summary
Resolves #1730

When an agent sent the same-named file across multiple `send_comm` calls (e.g. iterating on a file with a collaborator), the sender-side attachment chip on every historical `send_comm` tool call re-derived its `resource_id` by searching resource storage for the first filename match — always resolving to the oldest version instead of the one actually attached at that specific send. Separately, `timeline.jsonl` always persisted `resource_id: null` for every attachment because the Comm was written to the append-only log before delivery resolved the value.

## Changes Made
- `legion_mcp_tools.py`: `_handle_send_comm` now embeds the resolved `{name, resource_id, size, mime_type}` per attachment as an immutable JSON footer on the tool result text, captured at the exact moment of that specific call.
- `session_coordinator.py`: replaced the async filename-search resolver (`_resolve_send_comm_sender_attachments`) with a synchronous footer parser (`_parse_send_comm_sender_attachments`) that no longer re-queries resource storage. Updated both call sites — the live message-processing path (`web_server.py`) and the history-replay path (`session_coordinator.get_session_messages`).
- `comm_router.py`: extracted attachment delivery (file write + resource registration) into `_deliver_attachments()`, now called before `_persist_comm()` in `route_comm()` so `timeline.jsonl` carries the correct `resource_id` from the start. Added a target-minion-existence check inside `_deliver_attachments()` (found during self-review) so a comm to a missing/disposed minion can't write orphaned files/resources before the existing "target not found" check in `_send_to_minion()` runs.

No frontend changes — `SendCommToolHandler.vue` already renders attachment chips from the parsed `sender_attachments` field, never from raw tool-result text, so the new footer format is invisible to the UI.

## Testing
- `uv run ruff check` — zero violations on all changed files.
- `uv run pytest src/tests/` — full suite passes except 7 pre-existing failures confirmed present on unmodified `main` (unrelated to this change: `test_api_links`, `test_api_schedules`, `test_issue_1598_poll_viewed_timing`, `test_overseer_controller`).
- Added regression tests: footer embeds correct per-attachment `resource_id` for multi-attachment sends, footer round-trips through the parser, three sends of the same filename resolve to three distinct `resource_id`s, `route_comm()` persists a non-null `resource_id` to the timeline, and `_deliver_attachments()` skips delivery (no orphaned files/resources) when the target minion doesn't exist.
- Live manual verification: started the app against a real per-issue backend, created two real minions, and drove the actual `LegionMCPTools`/`CommRouter` production code (not mocked) through 3 sends of the same filename with different content each time. Confirmed 3 distinct non-null `resource_id`s in the tool-result footers and non-null `resource_id` for every attachment in the real `timeline.jsonl` on disk. Test data cleaned up afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)