### PR TITLE
[fix]: per-session permission grouping and background-agent task tracking (stage: backend, part of #1746)

### DIFF
--- a/src/message_parser.py
+++ b/src/message_parser.py
@@ -17,6 +17,7 @@ from claude_agent_sdk import (
     TaskNotificationMessage,
     TaskProgressMessage,
     TaskStartedMessage,
+    TaskUpdatedMessage,
     TextBlock,
     ThinkingBlock,
     ToolResultBlock,
@@ -266,6 +267,65 @@ class TaskNotificationHandler(MessageHandler):
                 "usage": stored_meta.get("usage"),
             })
             content = message_data.get("content", "Task notification")
+
+        return {"content": content, "metadata": metadata}
+
+    def parse(self, message_data: dict[str, Any]) -> ParsedMessage:
+        business_data = self._extract_business_data(message_data)
+        return ParsedMessage(
+            type=MessageType.SYSTEM,
+            timestamp=message_data.get("timestamp", time.time()),
+            session_id=message_data.get("session_id"),
+            content=business_data["content"],
+            raw_data=message_data,
+            metadata=self._standardize_metadata_fields(business_data["metadata"], message_data),
+        )
+
+
+class TaskUpdatedHandler(MessageHandler):
+    """Handler for SDK TaskUpdatedMessage (SystemMessage subclass).
+
+    Issue #1746: a task stopped via TaskStop reports status="killed" *only*
+    via this message type — the matching TaskNotificationMessage is
+    sometimes suppressed entirely. Without this handler, TaskUpdatedMessage
+    falls through to SystemMessageHandler in the live path and its
+    task_id/status/patch fields are lost from the live event stream (the
+    storage-replay path already handled this correctly, per issue #1657).
+    Note TaskUpdatedMessage carries no tool_use_id field (unlike the other
+    three Task* messages) — the SDK does not expose one for this frame type.
+    """
+
+    def can_handle(self, message_data: dict[str, Any]) -> bool:
+        if "sdk_message" in message_data:
+            return isinstance(message_data["sdk_message"], TaskUpdatedMessage)
+        return (message_data.get("type") == "system"
+                and (message_data.get("metadata") or {}).get("subtype") == "task_updated")
+
+    def _extract_business_data(self, message_data: dict[str, Any]) -> dict[str, Any]:
+        metadata = {
+            "subtype": "task_updated",
+            "session_id": message_data.get("session_id"),
+        }
+        content = ""
+
+        if "sdk_message" in message_data and isinstance(message_data["sdk_message"], TaskUpdatedMessage):
+            sdk_msg = message_data["sdk_message"]
+            metadata["task_id"] = sdk_msg.task_id
+            metadata["patch"] = sdk_msg.patch
+            metadata["status"] = sdk_msg.status
+            metadata["task_session_id"] = sdk_msg.session_id
+            metadata["uuid"] = sdk_msg.uuid
+            content = "Agent task updated"
+        else:
+            stored_meta = message_data.get("metadata") or {}
+            metadata.update({
+                "task_id": stored_meta.get("task_id"),
+                "patch": stored_meta.get("patch"),
+                "status": stored_meta.get("status"),
+                "task_session_id": stored_meta.get("task_session_id"),
+                "uuid": stored_meta.get("uuid"),
+            })
+            content = message_data.get("content", "Task updated")
 
         return {"content": content, "metadata": metadata}
 
@@ -1578,6 +1638,7 @@ class MessageParser:
             TaskStartedHandler(),
             TaskProgressHandler(),
             TaskNotificationHandler(),
+            TaskUpdatedHandler(),
             # SDK specific handlers
             SystemMessageHandler(),
             AssistantMessageHandler(),

--- a/src/permission_service.py
+++ b/src/permission_service.py
@@ -47,6 +47,10 @@ class PermissionService:
         self.coordinator = coordinator
         self.session_queues = session_queues
         self.pending_permissions: dict[str, asyncio.Future] = {}
+        # Issue #1746: request_ids currently open per session, so resolving one
+        # agent's permission doesn't clear another still-open agent's PAUSED
+        # state on the same session.
+        self.pending_by_session: dict[str, set[str]] = {}
 
     def create_permission_callback(self, session_id: str) -> Callable:
         """Create permission callback for tool usage"""
@@ -281,11 +285,20 @@ class PermissionService:
             # successful tool_call path. We only reach here if the permission prompt was
             # successfully broadcast to the frontend.
 
+            # Issue #1746: Track this request in the per-session open set before
+            # pausing, so concurrent requests on the same session only pause
+            # once and only resume the session once every sibling request has
+            # resolved.
+            session_pending = self.pending_by_session.setdefault(session_id, set())
+            is_first_pending_for_session = not session_pending
+            session_pending.add(request_id)
+
             # Set session state to PAUSED while waiting for permission response
             # This provides visual feedback that the session is blocked on user input
             try:
-                await self.coordinator.session_manager.pause_session(session_id)
-                debug_logger.info(f"Set session {session_id} to PAUSED state while waiting for permission")
+                if is_first_pending_for_session:
+                    await self.coordinator.session_manager.pause_session(session_id)
+                    debug_logger.info(f"Set session {session_id} to PAUSED state while waiting for permission")
             except Exception:
                 logger.exception(f"Failed to pause session {session_id} for permission wait")
 
@@ -302,16 +315,11 @@ class PermissionService:
                 response = await permission_future
                 debug_logger.info(f"PERMISSION CALLBACK: Received user decision for request_id {request_id}: {response}")
 
-                # Restore session to ACTIVE state after permission decision
-                # The session will continue processing, which will show as ACTIVE+processing (purple)
-                try:
-                    session_info = await self.coordinator.session_manager.get_session_info(session_id)
-                    if session_info and session_info.state == SessionState.PAUSED:
-                        # Use update_session_state instead of start_session to avoid re-initializing SDK
-                        await self.coordinator.session_manager.update_session_state(session_id, SessionState.ACTIVE)
-                        debug_logger.info(f"Restored session {session_id} to ACTIVE state after permission decision")
-                except Exception:
-                    logger.exception(f"Failed to restore session {session_id} to ACTIVE after permission")
+                # Issue #1746: Only restore ACTIVE once no sibling request is
+                # still open for this session — resolving one agent's request
+                # must not clear another agent's still-open PAUSED state.
+                self._discard_pending(session_id, request_id)
+                await self._maybe_resume_session(session_id)
 
                 decision = response.get("behavior")
                 reasoning = f"User {decision}ed permission"
@@ -443,6 +451,21 @@ class PermissionService:
 
                 # Clean up the pending permission
                 self.pending_permissions.pop(request_id, None)
+                # Issue #1746: This path bypasses resolve() entirely (e.g. session
+                # termination while awaiting), so the per-session open set must be
+                # cleaned up here too — otherwise a session can be left stuck PAUSED
+                # forever if this was its last outstanding request.
+                self._discard_pending(session_id, request_id)
+                await self._maybe_resume_session(session_id)
+
+            finally:
+                # Issue #1746: asyncio.CancelledError is a BaseException, not caught
+                # by `except Exception` above — without this, a coroutine cancelled
+                # while awaiting permission_future (e.g. abrupt shutdown) would leak
+                # its entry in pending_by_session and could leave the session stuck
+                # PAUSED forever. Idempotent with the explicit calls above.
+                self._discard_pending(session_id, request_id)
+                await self._maybe_resume_session(session_id)
 
             # Store permission response message using dataclass (Phase 0, Issue #310)
             decision_time = time.time()
@@ -539,6 +562,37 @@ class PermissionService:
 
         return permission_callback
 
+    def _discard_pending(self, session_id: str, request_id: str) -> None:
+        """Remove request_id from the per-session open-request set (issue #1746)."""
+        session_pending = self.pending_by_session.get(session_id)
+        if session_pending is None:
+            return
+        session_pending.discard(request_id)
+        if not session_pending:
+            self.pending_by_session.pop(session_id, None)
+
+    def open_permission_count(self, session_id: str) -> int:
+        """Number of currently-open permission requests for a session (issue #1746)."""
+        return len(self.pending_by_session.get(session_id, ()))
+
+    async def _maybe_resume_session(self, session_id: str) -> None:
+        """Restore session to ACTIVE only if no permission requests remain open.
+
+        Issue #1746: previously this ran unconditionally whenever *any* request
+        resolved, so resolving one agent's permission could clear another
+        agent's still-open "needs attention" PAUSED state on the same session.
+        """
+        if self.open_permission_count(session_id) != 0:
+            return
+        try:
+            session_info = await self.coordinator.session_manager.get_session_info(session_id)
+            if session_info and session_info.state == SessionState.PAUSED:
+                # Use update_session_state instead of start_session to avoid re-initializing SDK
+                await self.coordinator.session_manager.update_session_state(session_id, SessionState.ACTIVE)
+                debug_logger.info(f"Restored session {session_id} to ACTIVE state after permission decision")
+        except Exception:
+            logger.exception(f"Failed to restore session {session_id} to ACTIVE after permission")
+
     def cleanup_pending_for_session(self, session_id: str) -> None:
         """Clean up pending permissions for a specific session by auto-denying them"""
         try:
@@ -566,6 +620,11 @@ class PermissionService:
             if permissions_to_cleanup:
                 debug_logger.info(f"Cleaned up {len(permissions_to_cleanup)} pending permissions for session {session_id}")
 
+            # Issue #1746: This session's own pending-request bookkeeping is
+            # fully retired here regardless of the (pre-existing, unchanged)
+            # cross-session sweep above — every request it held is now denied.
+            self.pending_by_session.pop(session_id, None)
+
         except Exception:
             logger.exception(f"Error cleaning up pending permissions for session {session_id}")
 
@@ -579,6 +638,9 @@ class PermissionService:
                     "interrupt": True
                 })
                 self.pending_permissions.pop(request_id, None)
+        # Issue #1746: This denies every pending request service-wide, so
+        # every session's open-request set is now empty.
+        self.pending_by_session.clear()
 
     def resolve(self, request_id: str, response: dict) -> bool:
         """Resolve a pending permission request.

--- a/src/routers/sessions.py
+++ b/src/routers/sessions.py
@@ -414,4 +414,12 @@ def build_router(webui) -> APIRouter:
             result["event_cursor"] = queue.current_cursor
         return result
 
+    @router.get("/api/sessions/{session_id}/background_agents")
+    @handle_exceptions("get background agents")
+    async def get_background_agents(session_id: str):
+        """Snapshot of background-agent (Task) leg history, for reload/reconnect (issue #1746)."""
+        if not await webui.service.get_session_exists(session_id):
+            raise HTTPException(status_code=404, detail="Session not found")
+        return await webui.coordinator.get_background_agents(session_id)
+
     return router

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -46,6 +46,7 @@ from .queue_manager import QueueManager
 from .queue_processor import QueueProcessor
 from .session_config import SessionConfig
 from .session_manager import STOPPED_STATES, VALID_MODELS, SessionManager, SessionState
+from .task_registry import TASK_LIFECYCLE_SUBTYPES, TaskLegRegistry
 from .task_utils import task_done_log_exception
 from .timestamp_utils import get_unix_timestamp
 
@@ -60,6 +61,14 @@ _DOCKER_ERROR_KEYWORDS = ('exited with code', 'was killed', 'crashed')
 
 # Issue #1375: Regex for ${secret:<name>} references in MCP server header values.
 _SECRET_REF_RE = re.compile(r"\$\{secret:([^}]+)\}")
+
+# Issue #1746: stored "_type" discriminator (reload path, via StoredMessage)
+# for the four SDK Task lifecycle frame types — feeding TaskLegRegistry.
+# The parsed-"subtype" form (live path) is TASK_LIFECYCLE_SUBTYPES, imported
+# from task_registry so the two modules share one definition.
+_TASK_LIFECYCLE_STORED_TYPES = frozenset(
+    {"TaskStartedMessage", "TaskProgressMessage", "TaskNotificationMessage", "TaskUpdatedMessage"}
+)
 
 # Resource format groups for filtering
 _TEXT_RESOURCE_FORMATS = {
@@ -407,6 +416,11 @@ class SessionCoordinator:
         # Issue #324: Active tool calls per session for unified ToolCall lifecycle
         # Maps session_id -> {tool_use_id: ToolCall}
         self._active_tool_calls: dict[str, dict[str, ToolCall]] = {}
+
+        # Issue #1746: Per-session background-agent (Task) leg registry.
+        # Lazily hydrated from stored messages on first access, then kept live
+        # via the four Task lifecycle frames as they stream in.
+        self._task_leg_registries: dict[str, TaskLegRegistry] = {}
 
         # Issue #858: Per-session event notified on every create_tool_call(), allowing
         # permission callbacks to wait efficiently instead of polling.
@@ -2120,6 +2134,9 @@ class SessionCoordinator:
 
             # Reset display projection state
             self._reset_display_projection(session_id)
+            # Issue #1746: Drop cached task leg registry — it would otherwise
+            # keep serving stale legs from before the message history wipe.
+            self._task_leg_registries.pop(session_id, None)
 
             # Notify frontend to clear messages
             await self._notify_session_reset(session_id)
@@ -2861,6 +2878,9 @@ class SessionCoordinator:
                 coord_logger.info(f"Cleared queue for session {session_id}")
                 await storage.clear_attachments()
                 coord_logger.info(f"Cleared attachments for session {session_id}")
+                # Issue #1746: Drop cached task leg registry along with the
+                # cleared message history it was built from.
+                self._task_leg_registries.pop(session_id, None)
 
             # Issue #1244: rotate proxy logs then clear non-proxy docker_claude_data and tmp
             await self._rotate_proxy_logs(session_id)
@@ -3355,6 +3375,10 @@ class SessionCoordinator:
                     metadata["subtype"] = "task_updated"
                     metadata["task_id"] = data.get("task_id")
                     metadata["status"] = data.get("status")
+                    # Issue #1746: patch carries the changed fields (e.g. status,
+                    # end_time) — status is sometimes only reported inside patch,
+                    # not the top-level field.
+                    metadata["patch"] = data.get("patch")
                     metadata["tool_use_id"] = data.get("tool_use_id")
                     metadata["uuid"] = data.get("uuid")
                     content = "Agent task updated"
@@ -3451,6 +3475,46 @@ class SessionCoordinator:
         except Exception as e:
             coord_logger.warning(f"Failed to convert StoredMessage to WebSocket format: {e}")
             return None
+
+    # ==================== TASK LEG REGISTRY (Issue #1746) ====================
+
+    async def _get_task_leg_registry(self, session_id: str) -> TaskLegRegistry:
+        """Get (lazily hydrating) the per-session TaskLegRegistry.
+
+        Hydration replays every stored Task lifecycle message once via
+        _convert_stored_message_to_websocket — the same reconstruction the
+        reload/history path already uses — so a page refresh and a
+        live-streamed session converge on identical state. Only cached once
+        a storage manager is available; if the session hasn't been started
+        yet in this process, an ephemeral empty registry is returned so a
+        later call (once storage exists) can still hydrate properly.
+        """
+        registry = self._task_leg_registries.get(session_id)
+        if registry is not None:
+            return registry
+
+        registry = TaskLegRegistry()
+        storage = self._storage_managers.get(session_id)
+        if storage:
+            raw_messages = await storage.read_messages()
+            for raw_message in raw_messages:
+                if raw_message.get("_type") not in _TASK_LIFECYCLE_STORED_TYPES:
+                    continue
+                ws_data = self._convert_stored_message_to_websocket(raw_message)
+                if not ws_data:
+                    continue
+                metadata = ws_data.get("metadata") or {}
+                subtype = metadata.get("subtype")
+                if subtype:
+                    registry.apply_frame(subtype, metadata, ws_data.get("timestamp"))
+            self._task_leg_registries[session_id] = registry
+
+        return registry
+
+    async def get_background_agents(self, session_id: str) -> dict[str, Any]:
+        """Snapshot of background-agent (Task) leg history for reload/reconnect."""
+        registry = await self._get_task_leg_registry(session_id)
+        return {"session_id": session_id, "agents": registry.snapshot()}
 
     # ==================== ARCHIVE METHODS ====================
 
@@ -4663,6 +4727,27 @@ class SessionCoordinator:
                                 coord_logger.info(f"Permission mode updated to '{new_mode}' for session {session_id} via SDK status event")
                             except Exception:
                                 logger.exception(f"Failed to update permission mode from SDK status event for session {session_id}")
+
+                    # Issue #1746: Feed Task lifecycle frames into the per-session
+                    # TaskLegRegistry — a task_id-keyed source of truth for
+                    # background-agent status, independent of the Agent tool
+                    # call's own dispatch-ack status.
+                    task_subtype = parsed_message.metadata.get('subtype')
+                    if task_subtype in TASK_LIFECYCLE_SUBTYPES:
+                        try:
+                            # Storage always persists this message before this
+                            # callback fires (see ClaudeSDK._process_sdk_message),
+                            # so a *cold* hydration below already replays this
+                            # exact frame from messages.jsonl. Only apply it here
+                            # when the registry was already warm — otherwise this
+                            # frame would be double-counted (e.g. two legs for one
+                            # task_started).
+                            registry_already_cached = session_id in self._task_leg_registries
+                            registry = await self._get_task_leg_registry(session_id)
+                            if registry_already_cached:
+                                registry.apply_frame(task_subtype, parsed_message.metadata, parsed_message.timestamp)
+                        except Exception:
+                            logger.exception(f"Failed to update task leg registry for session {session_id}")
 
                 # Track permission responses with applied updates (for historical/display purposes)
                 if parsed_message.type.value == 'permission_response' and parsed_message.metadata:

--- a/src/task_registry.py
+++ b/src/task_registry.py
@@ -1,0 +1,178 @@
+"""Per-session registry of background-agent (SDK Task) lifecycle legs.
+
+Tracks the four SDK Task lifecycle frame types — task_started, task_progress,
+task_notification, task_updated — keyed by task_id, giving reload/reconnect a
+task_id-first source of truth for "is this background agent actually done"
+that is independent of the Agent tool call's own dispatch-ack status.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+# Task statuses that mean a leg has finished. Mirrors claude_agent_sdk's own
+# TERMINAL_TASK_STATUSES — task_notification never reports "killed" (it maps
+# that to "stopped" itself), but task_updated can, so both are accepted here.
+TERMINAL_TASK_STATUSES = frozenset({"completed", "failed", "stopped", "killed"})
+
+# task_updated (and, in principle, any future terminal source) may report the
+# raw SDK status "killed" for a TaskStop-terminated task. Normalized to
+# "stopped" for display consistency with task_notification's own vocabulary —
+# per the SDK's docs, consumers should treat the two the same way.
+_STATUS_DISPLAY_MAP = {"killed": "stopped"}
+
+TASK_LIFECYCLE_SUBTYPES = frozenset(
+    {"task_started", "task_progress", "task_notification", "task_updated"}
+)
+
+
+def _normalize_status(status: str | None) -> str | None:
+    if not status:
+        return None
+    return _STATUS_DISPLAY_MAP.get(status, status)
+
+
+@dataclass
+class TaskLeg:
+    """A single launch-to-terminal-state run of a background agent task."""
+
+    tool_use_id: str | None
+    description: str | None
+    started_at: float | None
+    last_progress_at: float | None = None
+    ended_at: float | None = None
+    status: str = "running"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "tool_use_id": self.tool_use_id,
+            "description": self.description,
+            "started_at": self.started_at,
+            "last_progress_at": self.last_progress_at,
+            "ended_at": self.ended_at,
+            "status": self.status,
+        }
+
+
+@dataclass
+class TaskLegEntry:
+    """All known legs for a single task_id, in arrival order."""
+
+    task_id: str
+    legs: list[TaskLeg] = field(default_factory=list)
+
+    @property
+    def latest_leg(self) -> TaskLeg | None:
+        return self.legs[-1] if self.legs else None
+
+    @property
+    def current_status(self) -> str | None:
+        latest = self.latest_leg
+        return latest.status if latest else None
+
+    @property
+    def description(self) -> str | None:
+        latest = self.latest_leg
+        return latest.description if latest else None
+
+    def to_dict(self) -> dict[str, Any]:
+        latest = self.latest_leg
+        return {
+            "task_id": self.task_id,
+            "description": self.description,
+            "legs": [leg.to_dict() for leg in self.legs],
+            "latest_leg": latest.to_dict() if latest else None,
+            "current_status": self.current_status,
+        }
+
+
+class TaskLegRegistry:
+    """Per-session, in-memory index of background-agent (Task) lifecycle legs.
+
+    Keyed by task_id — the one field the SDK guarantees stable across a
+    resumed agent's legs (a stopped-and-resumed agent reuses task_id across
+    two separate task_started frames). tool_use_id is per-leg: the tool call
+    that triggered *that* leg's start, and must never be used as the
+    cross-leg key.
+
+    Fed live from the four SDK lifecycle frame types as they stream in, and
+    rebuilt identically by replaying the same four frame types from stored
+    messages on session reload — the two code paths must agree so a page
+    refresh reconstructs the same state a live-streamed session would have
+    reached.
+    """
+
+    def __init__(self) -> None:
+        self._entries: dict[str, TaskLegEntry] = {}
+
+    def apply_frame(
+        self, subtype: str, metadata: dict[str, Any], timestamp: float | None = None
+    ) -> None:
+        """Apply one lifecycle frame's parsed metadata to the registry.
+
+        `metadata` is the same shape message_parser's Task*Handler classes
+        produce (and the reload path's _convert_stored_message_to_websocket
+        reconstructs) — task_id, tool_use_id, description, status, patch.
+        """
+        task_id = metadata.get("task_id")
+        if not task_id or subtype not in TASK_LIFECYCLE_SUBTYPES:
+            return
+
+        if subtype == "task_started":
+            entry = self._entries.setdefault(task_id, TaskLegEntry(task_id=task_id))
+            entry.legs.append(TaskLeg(
+                tool_use_id=metadata.get("tool_use_id"),
+                description=metadata.get("description"),
+                started_at=timestamp,
+                last_progress_at=timestamp,
+            ))
+            return
+
+        # No task_started on record for this task_id — malformed/incomplete
+        # frame sequence. Nothing to attach this frame to; do not create a
+        # leg-less entry as a side effect of merely looking one up.
+        entry = self._entries.get(task_id)
+        if entry is None:
+            return
+        leg = entry.latest_leg
+        if leg is None:
+            return
+
+        if subtype == "task_progress":
+            # No-op once a leg has reached a terminal status: progress arriving
+            # after termination must not resurrect it.
+            if leg.status != "running":
+                return
+            leg.last_progress_at = timestamp
+            if metadata.get("description") and not leg.description:
+                leg.description = metadata["description"]
+            return
+
+        # task_notification / task_updated: terminal status carrier.
+        # First-terminal-wins: a leg that's already terminal must not be
+        # overwritten by a later/duplicate terminal frame (the SDK's own docs
+        # note task_notification is only "sometimes" suppressed after a
+        # task_updated has already closed a leg out, or vice versa).
+        if leg.status != "running":
+            return
+
+        if subtype == "task_notification":
+            raw_status = metadata.get("status")
+        else:  # task_updated
+            patch = metadata.get("patch") or {}
+            raw_status = metadata.get("status") or patch.get("status")
+
+        if raw_status not in TERMINAL_TASK_STATUSES:
+            return
+
+        leg.status = _normalize_status(raw_status)
+        leg.ended_at = timestamp
+
+    def snapshot(self) -> list[dict[str, Any]]:
+        """Ordered snapshot of every known task_id's leg history."""
+        return [entry.to_dict() for entry in self._entries.values()]
+
+    def current_status(self, task_id: str) -> str | None:
+        entry = self._entries.get(task_id)
+        return entry.current_status if entry else None

--- a/src/tests/integration/test_issue_1746_background_agents_endpoint.py
+++ b/src/tests/integration/test_issue_1746_background_agents_endpoint.py
@@ -1,0 +1,94 @@
+"""
+Integration test for issue #1746 (stage: backend) — GET /api/sessions/{id}/background_agents.
+
+Uses the shared api_integration_env fixture (full FastAPI app + real
+SessionCoordinator) to verify the endpoint hydrates a TaskLegRegistry from
+stored messages and returns the expected response shape.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _stored_task_started(task_id, tool_use_id, session_id, ts):
+    return {
+        "_type": "TaskStartedMessage",
+        "timestamp": ts,
+        "session_id": session_id,
+        "data": {
+            "subtype": "task_started",
+            "data": {},
+            "task_id": task_id,
+            "description": "alpha: hydrated",
+            "uuid": f"uuid-{task_id}-started",
+            "session_id": "sub-" + session_id,
+            "tool_use_id": tool_use_id,
+            "task_type": "local_agent",
+        },
+    }
+
+
+def _stored_task_notification(task_id, tool_use_id, session_id, status, ts):
+    return {
+        "_type": "TaskNotificationMessage",
+        "timestamp": ts,
+        "session_id": session_id,
+        "data": {
+            "subtype": "task_notification",
+            "data": {},
+            "task_id": task_id,
+            "status": status,
+            "output_file": "",
+            "summary": "done",
+            "uuid": f"uuid-{task_id}-notif",
+            "session_id": "sub-" + session_id,
+            "tool_use_id": tool_use_id,
+            "usage": None,
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_background_agents_endpoint_returns_hydrated_snapshot(api_integration_env):
+    """GET /api/sessions/{id}/background_agents hydrates from stored messages
+    and returns the expected response shape."""
+    env = api_integration_env
+    client = env["client"]
+    coordinator = env["coordinator"]
+
+    project = await env["create_test_project"]()
+    session = await env["create_test_session"](project["project_id"])
+    session_id = session["session_id"]
+
+    session_dir = await coordinator.session_manager.get_session_directory(session_id)
+    storage = coordinator._storage_managers.get(session_id)
+    if storage is None:
+        from src.data_storage import DataStorageManager
+        storage = DataStorageManager(session_dir)
+        await storage.initialize()
+        coordinator._storage_managers[session_id] = storage
+
+    for msg in (
+        _stored_task_started("t1", "tu-1", session_id, 1.0),
+        _stored_task_notification("t1", "tu-1", session_id, "completed", 2.0),
+    ):
+        await storage.append_message(msg)
+
+    resp = await client.get(f"/api/sessions/{session_id}/background_agents")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["session_id"] == session_id
+    assert len(body["agents"]) == 1
+    agent = body["agents"][0]
+    assert agent["task_id"] == "t1"
+    assert agent["current_status"] == "completed"
+    assert len(agent["legs"]) == 1
+    assert agent["legs"][0]["tool_use_id"] == "tu-1"
+
+
+@pytest.mark.asyncio
+async def test_background_agents_endpoint_404_for_unknown_session(api_integration_env):
+    client = api_integration_env["client"]
+    resp = await client.get("/api/sessions/does-not-exist/background_agents")
+    assert resp.status_code == 404

--- a/src/tests/test_message_parser.py
+++ b/src/tests/test_message_parser.py
@@ -3,6 +3,7 @@
 import time
 
 import pytest
+from claude_agent_sdk import TaskUpdatedMessage
 
 from ..message_parser import (
     AssistantMessageHandler,
@@ -12,6 +13,7 @@ from ..message_parser import (
     ParsedMessage,
     ResultMessageHandler,
     SystemMessageHandler,
+    TaskUpdatedHandler,
     ToolUseHandler,
     UnknownMessageHandler,
     UserMessageHandler,
@@ -292,6 +294,95 @@ class TestMessageHandlers:
         assert parsed.type == MessageType.UNKNOWN
         assert parsed.metadata["original_type"] == "custom_type"
         assert parsed.metadata["unknown_format"] is True
+
+
+class TestIssue1746TaskUpdatedHandler:
+    """Live-path coverage for TaskUpdatedHandler (issue #1746).
+
+    Before this handler existed, TaskUpdatedMessage fell through to
+    SystemMessageHandler in the live message-parsing path — its subtype
+    defaulted to "init" and task_id/status/patch were silently dropped from
+    the live event stream, even though the storage-replay path (issue #1657)
+    already handled it correctly.
+    """
+
+    def test_can_handle_sdk_message(self):
+        handler = TaskUpdatedHandler()
+        sdk_msg = TaskUpdatedMessage(
+            subtype="task_updated", data={}, task_id="t1",
+            patch={"status": "killed"}, status="killed",
+            session_id="sub-sess", uuid="u1",
+        )
+        message_data = {"type": "system", "sdk_message": sdk_msg, "session_id": "sess-1"}
+        assert handler.can_handle(message_data) is True
+
+    def test_does_not_handle_other_task_messages(self):
+        handler = TaskUpdatedHandler()
+        message_data = {"type": "system", "metadata": {"subtype": "task_started"}}
+        assert handler.can_handle(message_data) is False
+
+    def test_extracts_fields_from_sdk_message(self):
+        handler = TaskUpdatedHandler()
+        sdk_msg = TaskUpdatedMessage(
+            subtype="task_updated", data={}, task_id="task-abc",
+            patch={"status": "completed", "end_time": 123}, status="completed",
+            session_id="sub-sess-1", uuid="uuid-1",
+        )
+        message_data = {"type": "system", "sdk_message": sdk_msg, "session_id": "sess-1",
+                         "timestamp": time.time()}
+
+        assert handler.can_handle(message_data) is True
+        parsed = handler.parse(message_data)
+
+        assert parsed.type == MessageType.SYSTEM
+        assert parsed.metadata["subtype"] == "task_updated"
+        assert parsed.metadata["task_id"] == "task-abc"
+        assert parsed.metadata["status"] == "completed"
+        assert parsed.metadata["patch"] == {"status": "completed", "end_time": 123}
+        assert parsed.metadata["uuid"] == "uuid-1"
+        assert parsed.metadata["task_session_id"] == "sub-sess-1"
+
+    def test_extracts_fields_from_stored_dict_fallback(self):
+        """The reload/websocket-replay dict shape (no live sdk_message object)."""
+        handler = TaskUpdatedHandler()
+        message_data = {
+            "type": "system",
+            "session_id": "sess-1",
+            "timestamp": time.time(),
+            "metadata": {
+                "subtype": "task_updated",
+                "task_id": "task-xyz",
+                "status": "failed",
+                "patch": {"status": "failed"},
+                "uuid": "uuid-2",
+                "task_session_id": "sub-sess-2",
+            },
+        }
+        assert handler.can_handle(message_data) is True
+        parsed = handler.parse(message_data)
+        assert parsed.metadata["task_id"] == "task-xyz"
+        assert parsed.metadata["status"] == "failed"
+        assert parsed.metadata["patch"] == {"status": "failed"}
+
+    def test_full_parser_routes_to_task_updated_handler_not_system_default(self):
+        """Regression guard: without this handler, MessageParser would route a
+        TaskUpdatedMessage to SystemMessageHandler and lose task_id/status,
+        defaulting subtype to "init"."""
+        parser = MessageParser()
+        sdk_msg = TaskUpdatedMessage(
+            subtype="task_updated", data={}, task_id="task-live",
+            patch={"status": "killed"}, status="killed",
+            session_id="sub-sess", uuid="u1",
+        )
+        message_data = {"type": "system", "sdk_message": sdk_msg, "session_id": "sess-1",
+                         "timestamp": time.time()}
+
+        parsed = parser.parse_message(message_data)
+
+        assert parsed.metadata["subtype"] == "task_updated"
+        assert parsed.metadata["subtype"] != "init"
+        assert parsed.metadata["task_id"] == "task-live"
+        assert parsed.metadata["status"] == "killed"
 
 
 class TestMessageParser:

--- a/src/tests/test_permission_service_session_grouping.py
+++ b/src/tests/test_permission_service_session_grouping.py
@@ -1,0 +1,314 @@
+"""
+Regression tests for issue #1746 (stage: backend) — per-session permission grouping.
+
+Resolving one agent's permission request must not clear another agent's
+still-open "needs attention" PAUSED state on the same session. Session
+PAUSED->ACTIVE must be driven by "are zero requests still open for this
+session," not "did *a* request resolve."
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.models.messages import ToolCall, ToolDisplayInfo, ToolState
+from src.session_manager import SessionState
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_tool_call(session_id: str, name: str, input_params: dict) -> ToolCall:
+    return ToolCall(
+        tool_use_id=f"tu_{name}",
+        session_id=session_id,
+        name=name,
+        input=input_params,
+        status=ToolState.PENDING,
+        created_at=time.time(),
+        requires_permission=True,
+        parent_tool_use_id=None,
+        display=ToolDisplayInfo(
+            state=ToolState.PENDING,
+            visible=True,
+            collapsed=False,
+            style="default",
+        ),
+    )
+
+
+def _make_coordinator() -> MagicMock:
+    """Minimal mock SessionCoordinator: tool calls resolve immediately (no event.wait())."""
+    coord = MagicMock()
+    tool_calls: dict[str, ToolCall] = {}
+
+    coord.find_tool_call_by_signature.side_effect = (
+        lambda sid, name, params: tool_calls.get(name)
+    )
+    coord.is_uploaded_file.side_effect = lambda sid, path: False
+    coord.update_tool_call_permission_request = MagicMock(return_value=None)
+    coord._tool_calls = tool_calls
+
+    # Track per-session state so update_session_state's effect is visible to
+    # a later get_session_info call — mirrors the real SessionManager closely
+    # enough that _maybe_resume_session's "already ACTIVE" guard behaves the
+    # same as in production (a redundant resume attempt is a real no-op, not
+    # just an unasserted mock call).
+    session_states: dict[str, SessionState] = {}
+
+    async def _get_session_info(sid):
+        return MagicMock(state=session_states.get(sid, SessionState.PAUSED))
+
+    async def _update_session_state(sid, state):
+        session_states[sid] = state
+
+    coord.session_manager = MagicMock()
+    coord.session_manager.pause_session = AsyncMock()
+    coord.session_manager.update_session_state = AsyncMock(side_effect=_update_session_state)
+    coord.session_manager.get_session_info = AsyncMock(side_effect=_get_session_info)
+    coord._session_states = session_states
+    return coord
+
+
+# ---------------------------------------------------------------------------
+# Test 1: two concurrent requests on the same session
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_two_concurrent_requests_same_session_only_resumes_after_both_resolve():
+    """Resolving the first of two concurrent requests must leave the session
+    PAUSED; only resolving the second flips it to ACTIVE."""
+    session_id = "sess-concurrent-grouping"
+    coord = _make_coordinator()
+    coord._tool_calls["Read"] = _make_tool_call(session_id, "Read", {"file_path": "/a.txt"})
+    coord._tool_calls["Edit"] = _make_tool_call(session_id, "Edit", {"file_path": "/b.py"})
+
+    with (
+        patch("src.permission_service.PermissionRequestMessage"),
+        patch("src.permission_service.StoredMessage") as mock_sm,
+        patch("src.permission_service.PermissionInfo"),
+    ):
+        mock_sm.from_permission_request.return_value = MagicMock(to_dict=lambda: {})
+        mock_sm.from_permission_response.return_value = MagicMock(to_dict=lambda: {})
+
+        from src.permission_service import PermissionService
+
+        svc = PermissionService(coordinator=coord, session_queues={})
+        cb = svc.create_permission_callback(session_id)
+
+        task1 = asyncio.create_task(cb("Read", {"file_path": "/a.txt"}, None))
+        task2 = asyncio.create_task(cb("Edit", {"file_path": "/b.py"}, None))
+
+        # Let both callbacks reach the "await permission_future" point.
+        for _ in range(20):
+            await asyncio.sleep(0.01)
+            if svc.open_permission_count(session_id) == 2:
+                break
+
+        assert svc.open_permission_count(session_id) == 2
+        # Only one pause_session call for two concurrent requests on the same session.
+        coord.session_manager.pause_session.assert_awaited_once_with(session_id)
+
+        request_ids = list(svc.pending_by_session[session_id])
+        assert len(request_ids) == 2
+
+        # Resolve the first — session must still show as needing the second's decision.
+        svc.resolve(request_ids[0], {"behavior": "allow"})
+        for _ in range(20):
+            await asyncio.sleep(0.01)
+            if svc.open_permission_count(session_id) == 1:
+                break
+
+        assert svc.open_permission_count(session_id) == 1
+        coord.session_manager.update_session_state.assert_not_called()
+
+        # Resolve the second — now the session should resume.
+        svc.resolve(request_ids[1], {"behavior": "allow"})
+        await task1
+        await task2
+
+        assert svc.open_permission_count(session_id) == 0
+        coord.session_manager.update_session_state.assert_awaited_once_with(
+            session_id, SessionState.ACTIVE
+        )
+        assert session_id not in svc.pending_by_session
+
+
+# ---------------------------------------------------------------------------
+# Test 2: single request — unchanged regression behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_single_request_still_resumes_session_on_resolve():
+    """Single permission request must still flip the session back to ACTIVE."""
+    session_id = "sess-single-grouping"
+    coord = _make_coordinator()
+    coord._tool_calls["Bash"] = _make_tool_call(session_id, "Bash", {"command": "ls"})
+
+    with (
+        patch("src.permission_service.PermissionRequestMessage"),
+        patch("src.permission_service.StoredMessage") as mock_sm,
+        patch("src.permission_service.PermissionInfo"),
+    ):
+        mock_sm.from_permission_request.return_value = MagicMock(to_dict=lambda: {})
+        mock_sm.from_permission_response.return_value = MagicMock(to_dict=lambda: {})
+
+        from src.permission_service import PermissionService
+
+        svc = PermissionService(coordinator=coord, session_queues={})
+        cb = svc.create_permission_callback(session_id)
+
+        task = asyncio.create_task(cb("Bash", {"command": "ls"}, None))
+        for _ in range(20):
+            await asyncio.sleep(0.01)
+            if svc.open_permission_count(session_id) == 1:
+                break
+
+        coord.session_manager.pause_session.assert_awaited_once_with(session_id)
+        request_id = next(iter(svc.pending_by_session[session_id]))
+
+        svc.resolve(request_id, {"behavior": "allow"})
+        await task
+
+        coord.session_manager.update_session_state.assert_awaited_once_with(
+            session_id, SessionState.ACTIVE
+        )
+        assert session_id not in svc.pending_by_session
+
+
+# ---------------------------------------------------------------------------
+# Test 3: cleanup_pending_for_session clears the per-session set
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cleanup_pending_for_session_clears_session_set():
+    """cleanup_pending_for_session must clear pending_by_session along with the futures."""
+    coord = _make_coordinator()
+    from src.permission_service import PermissionService
+
+    svc = PermissionService(coordinator=coord, session_queues={})
+
+    future = asyncio.get_running_loop().create_future()
+    svc.pending_permissions["req-1"] = future
+    svc.pending_by_session["sess-a"] = {"req-1"}
+
+    svc.cleanup_pending_for_session("sess-a")
+
+    assert "sess-a" not in svc.pending_by_session
+    assert svc.open_permission_count("sess-a") == 0
+    assert future.done()
+    assert future.result()["behavior"] == "deny"
+
+
+# ---------------------------------------------------------------------------
+# Test 4: two different sessions never interact
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_two_different_sessions_do_not_interact():
+    """Resolving session A's request must not touch session B's open set,
+    even on one shared PermissionService instance (the real deployment shape:
+    one PermissionService serving every session)."""
+    coord = _make_coordinator()
+    session_a, session_b = "sess-a-isolated", "sess-b-isolated"
+    coord._tool_calls["Read"] = _make_tool_call(session_a, "Read", {"file_path": "/a.txt"})
+    coord._tool_calls["Write"] = _make_tool_call(session_b, "Write", {"file_path": "/b.txt"})
+
+    with (
+        patch("src.permission_service.PermissionRequestMessage"),
+        patch("src.permission_service.StoredMessage") as mock_sm,
+        patch("src.permission_service.PermissionInfo"),
+    ):
+        mock_sm.from_permission_request.return_value = MagicMock(to_dict=lambda: {})
+        mock_sm.from_permission_response.return_value = MagicMock(to_dict=lambda: {})
+
+        from src.permission_service import PermissionService
+
+        svc = PermissionService(coordinator=coord, session_queues={})
+        cb_a = svc.create_permission_callback(session_a)
+        cb_b = svc.create_permission_callback(session_b)
+
+        task_a = asyncio.create_task(cb_a("Read", {"file_path": "/a.txt"}, None))
+        task_b = asyncio.create_task(cb_b("Write", {"file_path": "/b.txt"}, None))
+
+        for _ in range(20):
+            await asyncio.sleep(0.01)
+            if svc.open_permission_count(session_a) == 1 and svc.open_permission_count(session_b) == 1:
+                break
+
+        req_id_a = next(iter(svc.pending_by_session[session_a]))
+        svc.resolve(req_id_a, {"behavior": "allow"})
+        await task_a
+
+        # Session A resumes on its own resolution; session B's open set (and
+        # state) is untouched by it.
+        coord.session_manager.update_session_state.assert_awaited_once_with(
+            session_a, SessionState.ACTIVE
+        )
+        assert session_b in svc.pending_by_session
+        assert svc.open_permission_count(session_b) == 1
+
+        req_id_b = next(iter(svc.pending_by_session[session_b]))
+        svc.resolve(req_id_b, {"behavior": "allow"})
+        await task_b
+
+        assert coord.session_manager.update_session_state.await_count == 2
+        coord.session_manager.update_session_state.assert_any_await(
+            session_b, SessionState.ACTIVE
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 5: cancellation while awaiting still releases the per-session open set
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancelled_await_still_releases_pending_by_session():
+    """asyncio.CancelledError during `await permission_future` is a BaseException,
+    not caught by `except Exception` — without a `finally`, cancellation (e.g.
+    abrupt shutdown while a request is outstanding) would leak the request's
+    entry in pending_by_session and could leave the session stuck PAUSED forever."""
+    session_id = "sess-cancelled"
+    coord = _make_coordinator()
+    coord._tool_calls["Read"] = _make_tool_call(session_id, "Read", {"file_path": "/a.txt"})
+
+    with (
+        patch("src.permission_service.PermissionRequestMessage"),
+        patch("src.permission_service.StoredMessage") as mock_sm,
+        patch("src.permission_service.PermissionInfo"),
+    ):
+        mock_sm.from_permission_request.return_value = MagicMock(to_dict=lambda: {})
+
+        from src.permission_service import PermissionService
+
+        svc = PermissionService(coordinator=coord, session_queues={})
+        cb = svc.create_permission_callback(session_id)
+
+        task = asyncio.create_task(cb("Read", {"file_path": "/a.txt"}, None))
+        for _ in range(20):
+            await asyncio.sleep(0.01)
+            if svc.open_permission_count(session_id) == 1:
+                break
+
+        assert svc.open_permission_count(session_id) == 1
+        coord.session_manager.pause_session.assert_awaited_once_with(session_id)
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert svc.open_permission_count(session_id) == 0
+        assert session_id not in svc.pending_by_session
+        coord.session_manager.update_session_state.assert_awaited_once_with(
+            session_id, SessionState.ACTIVE
+        )

--- a/src/tests/test_route_inventory.py
+++ b/src/tests/test_route_inventory.py
@@ -5,7 +5,7 @@ def test_route_count_unchanged():
     from src.web_server import create_app
     app = create_app()
     api_routes = [r for r in app.routes if hasattr(r, "methods")]
-    assert len(api_routes) == 150, (
-        f"Expected 150 routes (+1 usage from #1125, +1 edit-history from #1128, +3 audit from #1127, +1 analytics from #1132, -2 legacy images from #1261, +1 oauth import-as-secret from #1381, -1 cancel-schedule from #1416, +1 reparent-minion from #1422, +1 session-routing from #1427-phase3, +6 provider-catalog from #1427-phase4, +1 queue-history from #1502, +1 session-links from #1530, +1 mark-unread from #1597, +1 unaccounted pre-existing delta, +1 model live-switch from #1673, +1 add-directory from #1675, +5 kanban-groups from #1722), got {len(api_routes)}. "
+    assert len(api_routes) == 151, (
+        f"Expected 151 routes (+1 usage from #1125, +1 edit-history from #1128, +3 audit from #1127, +1 analytics from #1132, -2 legacy images from #1261, +1 oauth import-as-secret from #1381, -1 cancel-schedule from #1416, +1 reparent-minion from #1422, +1 session-routing from #1427-phase3, +6 provider-catalog from #1427-phase4, +1 queue-history from #1502, +1 session-links from #1530, +1 mark-unread from #1597, +1 unaccounted pre-existing delta, +1 model live-switch from #1673, +1 add-directory from #1675, +5 kanban-groups from #1722, +1 background-agents from #1746), got {len(api_routes)}. "
         "A route was added or removed."
     )

--- a/src/tests/test_session_coordinator.py
+++ b/src/tests/test_session_coordinator.py
@@ -2186,6 +2186,27 @@ class TestConvertStoredMessageToWebsocket:
         assert result["metadata"]["subtype"] == "task_started"
         assert result["metadata"]["task_id"] == "task-start"
 
+    def test_issue_1746_task_updated_copies_patch(self, coordinator):
+        """Issue #1746: patch carries the changed fields (e.g. status, end_time) —
+        status is sometimes only reported inside patch, not the top-level field."""
+        stored = {
+            "_type": "TaskUpdatedMessage",
+            "timestamp": 1700000000.0,
+            "data": {
+                "subtype": "task_updated",
+                "task_id": "task-patch-only",
+                "status": None,
+                "patch": {"status": "failed", "end_time": 1700000001.0},
+                "tool_use_id": None,
+                "uuid": "uuid-patch",
+            },
+        }
+        result = coordinator._convert_stored_message_to_websocket(stored)
+        assert result is not None
+        meta = result["metadata"]
+        assert meta["patch"] == {"status": "failed", "end_time": 1700000001.0}
+        assert meta["status"] is None
+
     def test_issue_1657_task_notification_unchanged(self, coordinator):
         stored = {
             "_type": "TaskNotificationMessage",

--- a/src/tests/test_task_registry.py
+++ b/src/tests/test_task_registry.py
@@ -1,0 +1,434 @@
+"""
+Regression tests for issue #1746 (stage: backend) — TaskLegRegistry.
+
+Covers:
+- §4 TaskLegRegistry mechanics: single-leg, multi-leg resume, concurrent
+  agents, TaskStop-only termination, progress-after-terminal no-op.
+- §3 task_id stability: a live-pipeline test (message_parser -> registry)
+  driving two full launch/resume legs sharing one task_id through real SDK
+  dataclasses, proving the fix holds through the actual parsing path, not
+  just the registry's own bookkeeping.
+- §4 reload/live parity: a hand-built messages.jsonl fixture reconstructs an
+  identical registry to the equivalent live-streamed sequence.
+- §4 new endpoint: GET /api/sessions/{id}/background_agents integration test.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from claude_agent_sdk import (
+    TaskNotificationMessage,
+    TaskProgressMessage,
+    TaskStartedMessage,
+    TaskUpdatedMessage,
+)
+
+from src.message_parser import MessageParser, MessageProcessor
+from src.task_registry import TaskLegRegistry
+
+# ---------------------------------------------------------------------------
+# §4: TaskLegRegistry mechanics (pure unit tests, no I/O)
+# ---------------------------------------------------------------------------
+
+
+def _started(task_id, tool_use_id, description="alpha: do work"):
+    return {
+        "task_id": task_id,
+        "tool_use_id": tool_use_id,
+        "description": description,
+    }
+
+
+def _progress(task_id):
+    return {"task_id": task_id}
+
+
+def _notification(task_id, status):
+    return {"task_id": task_id, "status": status}
+
+
+def _updated(task_id, status=None, patch=None):
+    return {"task_id": task_id, "status": status, "patch": patch or {}}
+
+
+def test_single_leg_lifecycle_reaches_completed():
+    registry = TaskLegRegistry()
+    registry.apply_frame("task_started", _started("t1", "tu-1"), timestamp=1.0)
+    registry.apply_frame("task_progress", _progress("t1"), timestamp=2.0)
+    registry.apply_frame("task_notification", _notification("t1", "completed"), timestamp=3.0)
+
+    snapshot = registry.snapshot()
+    assert len(snapshot) == 1
+    entry = snapshot[0]
+    assert entry["task_id"] == "t1"
+    assert entry["current_status"] == "completed"
+    assert len(entry["legs"]) == 1
+    assert entry["legs"][0]["tool_use_id"] == "tu-1"
+    assert entry["legs"][0]["ended_at"] == 3.0
+    assert registry.current_status("t1") == "completed"
+
+
+def test_multi_leg_resume_shares_task_id_distinct_tool_use_ids():
+    """§3: task_id is stable across a resumed agent's legs; tool_use_id is per-leg."""
+    registry = TaskLegRegistry()
+
+    # Leg 1
+    registry.apply_frame("task_started", _started("t-resume", "tu-A"), timestamp=1.0)
+    registry.apply_frame("task_progress", _progress("t-resume"), timestamp=2.0)
+    registry.apply_frame("task_notification", _notification("t-resume", "completed"), timestamp=3.0)
+
+    # Leg 2 (resumed agent, same task_id, new tool_use_id)
+    registry.apply_frame("task_started", _started("t-resume", "tu-B"), timestamp=4.0)
+    registry.apply_frame("task_progress", _progress("t-resume"), timestamp=5.0)
+    registry.apply_frame("task_notification", _notification("t-resume", "completed"), timestamp=6.0)
+
+    snapshot = registry.snapshot()
+    assert len(snapshot) == 1, "both legs must collapse under the one stable task_id"
+    entry = snapshot[0]
+    assert len(entry["legs"]) == 2
+    assert entry["legs"][0]["tool_use_id"] == "tu-A"
+    assert entry["legs"][1]["tool_use_id"] == "tu-B"
+    assert entry["latest_leg"]["tool_use_id"] == "tu-B"
+    assert entry["current_status"] == "completed"
+
+
+def test_concurrent_different_task_ids_no_cross_contamination():
+    registry = TaskLegRegistry()
+    registry.apply_frame("task_started", _started("t1", "tu-1"), timestamp=1.0)
+    registry.apply_frame("task_started", _started("t2", "tu-2"), timestamp=1.0)
+    registry.apply_frame("task_notification", _notification("t1", "completed"), timestamp=2.0)
+
+    assert registry.current_status("t1") == "completed"
+    assert registry.current_status("t2") == "running"
+    snapshot = {e["task_id"]: e for e in registry.snapshot()}
+    assert set(snapshot) == {"t1", "t2"}
+
+
+def test_task_stop_only_termination_reaches_stopped_via_task_updated():
+    """A TaskStop-terminated task reports status="killed" only via task_updated,
+    with no task_notification at all — must still close out the leg as "stopped"."""
+    registry = TaskLegRegistry()
+    registry.apply_frame("task_started", _started("t1", "tu-1"), timestamp=1.0)
+    registry.apply_frame("task_updated", _updated("t1", status="killed"), timestamp=2.0)
+
+    assert registry.current_status("t1") == "stopped"
+    leg = registry.snapshot()[0]["legs"][0]
+    assert leg["ended_at"] == 2.0
+
+
+def test_task_updated_status_only_in_patch_still_detected():
+    """task_updated may report status only inside patch, not the top-level field."""
+    registry = TaskLegRegistry()
+    registry.apply_frame("task_started", _started("t1", "tu-1"), timestamp=1.0)
+    registry.apply_frame(
+        "task_updated", _updated("t1", status=None, patch={"status": "failed"}), timestamp=2.0
+    )
+    assert registry.current_status("t1") == "failed"
+
+
+def test_duplicate_terminal_frame_does_not_overwrite_first_terminal_status():
+    """First-terminal-wins: task_notification is only "sometimes" suppressed
+    after task_updated (or vice versa) already closed a leg out — a later,
+    duplicate/conflicting terminal frame must not overwrite the first."""
+    registry = TaskLegRegistry()
+    registry.apply_frame("task_started", _started("t1", "tu-1"), timestamp=1.0)
+    registry.apply_frame("task_notification", _notification("t1", "completed"), timestamp=2.0)
+    # A late task_updated for the same already-terminal leg reports a
+    # different status — must not clobber the first terminal result.
+    registry.apply_frame("task_updated", _updated("t1", status="killed"), timestamp=3.0)
+
+    leg = registry.snapshot()[0]["legs"][0]
+    assert leg["status"] == "completed"
+    assert leg["ended_at"] == 2.0, "the first terminal frame's timestamp must be preserved"
+
+
+def test_progress_after_terminal_is_noop():
+    """Ordering: progress arriving after a terminal notification must not resurrect the leg."""
+    registry = TaskLegRegistry()
+    registry.apply_frame("task_started", _started("t1", "tu-1"), timestamp=1.0)
+    registry.apply_frame("task_notification", _notification("t1", "completed"), timestamp=2.0)
+    registry.apply_frame("task_progress", _progress("t1"), timestamp=3.0)
+
+    leg = registry.snapshot()[0]["legs"][0]
+    assert leg["status"] == "completed"
+    assert leg["last_progress_at"] == 1.0, "stale progress must not overwrite last_progress_at"
+
+
+def test_frame_with_no_task_id_is_ignored():
+    registry = TaskLegRegistry()
+    registry.apply_frame("task_started", {"tool_use_id": "tu-1"}, timestamp=1.0)
+    assert registry.snapshot() == []
+
+
+def test_progress_or_terminal_with_no_started_leg_is_dropped():
+    registry = TaskLegRegistry()
+    registry.apply_frame("task_notification", _notification("ghost", "completed"), timestamp=1.0)
+    assert registry.snapshot() == []
+
+
+# ---------------------------------------------------------------------------
+# §3: live-pipeline stability test (message_parser -> registry), real SDK dataclasses
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_live_pipeline_two_leg_resume_preserves_task_id_stability():
+    """Drives real TaskStartedMessage/TaskProgressMessage/TaskNotificationMessage
+    SDK objects through MessageProcessor (the live path, now with the §2a fix)
+    for two separate legs sharing one task_id, then feeds each parsed frame's
+    metadata into TaskLegRegistry — exercising the full live pipeline, not just
+    the registry's own bookkeeping."""
+    processor = MessageProcessor(MessageParser())
+    registry = TaskLegRegistry()
+
+    def _drive(sdk_msg, timestamp):
+        message_data = {
+            "type": "system",
+            "sdk_message": sdk_msg,
+            "session_id": "sess-1",
+            "timestamp": timestamp,
+        }
+        parsed = processor.process_message(message_data, source="sdk")
+        assert parsed.metadata.get("subtype") in (
+            "task_started", "task_progress", "task_notification", "task_updated",
+        )
+        registry.apply_frame(parsed.metadata["subtype"], parsed.metadata, timestamp)
+
+    # Leg 1
+    _drive(TaskStartedMessage(
+        subtype="task_started", data={}, task_id="shared-task-id",
+        description="alpha: leg one", uuid="u1", session_id="sub-sess-1", tool_use_id="tu-A",
+    ), 1.0)
+    _drive(TaskProgressMessage(
+        subtype="task_progress", data={}, task_id="shared-task-id",
+        description="alpha: leg one", usage=None, uuid="u2", session_id="sub-sess-1", tool_use_id="tu-A",
+    ), 2.0)
+    _drive(TaskNotificationMessage(
+        subtype="task_notification", data={}, task_id="shared-task-id",
+        status="completed", output_file="", summary="done", uuid="u3",
+        session_id="sub-sess-1", tool_use_id="tu-A",
+    ), 3.0)
+
+    # Simulated resume trigger — leg 2, same task_id, new tool_use_id
+    _drive(TaskStartedMessage(
+        subtype="task_started", data={}, task_id="shared-task-id",
+        description="alpha: leg two", uuid="u4", session_id="sub-sess-1", tool_use_id="tu-B",
+    ), 4.0)
+    _drive(TaskProgressMessage(
+        subtype="task_progress", data={}, task_id="shared-task-id",
+        description="alpha: leg two", usage=None, uuid="u5", session_id="sub-sess-1", tool_use_id="tu-B",
+    ), 5.0)
+    _drive(TaskNotificationMessage(
+        subtype="task_notification", data={}, task_id="shared-task-id",
+        status="completed", output_file="", summary="done again", uuid="u6",
+        session_id="sub-sess-1", tool_use_id="tu-B",
+    ), 6.0)
+
+    snapshot = registry.snapshot()
+    assert len(snapshot) == 1
+    entry = snapshot[0]
+    assert entry["task_id"] == "shared-task-id"
+    assert len(entry["legs"]) == 2
+    assert entry["legs"][0]["tool_use_id"] == "tu-A"
+    assert entry["legs"][1]["tool_use_id"] == "tu-B"
+    assert entry["latest_leg"]["tool_use_id"] == "tu-B"
+    assert entry["current_status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_live_pipeline_task_updated_killed_no_notification():
+    """§2a regression guard: TaskUpdatedMessage must be extracted with its own
+    handler in the live path, not fall through to the generic system handler."""
+    processor = MessageProcessor(MessageParser())
+    registry = TaskLegRegistry()
+
+    message_data = {
+        "type": "system",
+        "sdk_message": TaskStartedMessage(
+            subtype="task_started", data={}, task_id="stopped-task",
+            description="beta: stoppable", uuid="u1", session_id="sub-sess-2", tool_use_id="tu-X",
+        ),
+        "session_id": "sess-2",
+        "timestamp": 1.0,
+    }
+    parsed = processor.process_message(message_data, source="sdk")
+    registry.apply_frame(parsed.metadata["subtype"], parsed.metadata, 1.0)
+
+    updated_data = {
+        "type": "system",
+        "sdk_message": TaskUpdatedMessage(
+            subtype="task_updated", data={}, task_id="stopped-task",
+            patch={"status": "killed"}, status="killed", session_id="sub-sess-2", uuid="u2",
+        ),
+        "session_id": "sess-2",
+        "timestamp": 2.0,
+    }
+    parsed = processor.process_message(updated_data, source="sdk")
+    # This is exactly the bug §2a fixes: without TaskUpdatedHandler this would
+    # be subtype="init" (SystemMessageHandler's default) and task_id would be lost.
+    assert parsed.metadata.get("subtype") == "task_updated"
+    assert parsed.metadata.get("task_id") == "stopped-task"
+    registry.apply_frame(parsed.metadata["subtype"], parsed.metadata, 2.0)
+
+    assert registry.current_status("stopped-task") == "stopped"
+
+
+# ---------------------------------------------------------------------------
+# §4: reload/live parity
+# ---------------------------------------------------------------------------
+
+
+def _stored_task_started(task_id, tool_use_id, session_id, ts):
+    return {
+        "_type": "TaskStartedMessage",
+        "timestamp": ts,
+        "session_id": session_id,
+        "data": {
+            "subtype": "task_started",
+            "data": {},
+            "task_id": task_id,
+            "description": "alpha: hydrated",
+            "uuid": f"uuid-{task_id}-started",
+            "session_id": "sub-" + session_id,
+            "tool_use_id": tool_use_id,
+            "task_type": "local_agent",
+        },
+    }
+
+
+def _stored_task_progress(task_id, tool_use_id, session_id, ts):
+    return {
+        "_type": "TaskProgressMessage",
+        "timestamp": ts,
+        "session_id": session_id,
+        "data": {
+            "subtype": "task_progress",
+            "data": {},
+            "task_id": task_id,
+            "description": "alpha: hydrated",
+            "usage": None,
+            "uuid": f"uuid-{task_id}-progress",
+            "session_id": "sub-" + session_id,
+            "tool_use_id": tool_use_id,
+            "last_tool_name": "Read",
+        },
+    }
+
+
+def _stored_task_notification(task_id, tool_use_id, session_id, status, ts):
+    return {
+        "_type": "TaskNotificationMessage",
+        "timestamp": ts,
+        "session_id": session_id,
+        "data": {
+            "subtype": "task_notification",
+            "data": {},
+            "task_id": task_id,
+            "status": status,
+            "output_file": "",
+            "summary": "done",
+            "uuid": f"uuid-{task_id}-notif",
+            "session_id": "sub-" + session_id,
+            "tool_use_id": tool_use_id,
+            "usage": None,
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_reload_reconstruction_matches_live_streamed_sequence(tmp_path):
+    """A hand-built messages.jsonl fixture must reconstruct an identical
+    registry to the equivalent live-streamed sequence."""
+    import src.session_coordinator as sc_module
+    from src.session_coordinator import SessionCoordinator
+
+    session_id = "sess-parity"
+
+    # Build the "live" registry directly via apply_frame, using the same
+    # metadata shape _convert_stored_message_to_websocket would produce.
+    live_registry = TaskLegRegistry()
+    live_registry.apply_frame(
+        "task_started",
+        {"task_id": "t1", "tool_use_id": "tu-1", "description": "alpha: hydrated"},
+        1.0,
+    )
+    live_registry.apply_frame(
+        "task_progress", {"task_id": "t1", "description": "alpha: hydrated"}, 2.0
+    )
+    live_registry.apply_frame(
+        "task_notification", {"task_id": "t1", "status": "completed"}, 3.0
+    )
+
+    coordinator = SessionCoordinator(data_dir=tmp_path)
+    session_dir = tmp_path / "sessions" / session_id
+    session_dir.mkdir(parents=True)
+
+    messages_path = session_dir / "messages.jsonl"
+    with messages_path.open("w", encoding="utf-8") as f:
+        for msg in (
+            _stored_task_started("t1", "tu-1", session_id, 1.0),
+            _stored_task_progress("t1", "tu-1", session_id, 2.0),
+            _stored_task_notification("t1", "tu-1", session_id, "completed", 3.0),
+        ):
+            f.write(json.dumps(msg) + "\n")
+
+    storage = sc_module.DataStorageManager(session_dir)
+    await storage.initialize()
+    coordinator._storage_managers[session_id] = storage
+
+    reloaded_registry = await coordinator._get_task_leg_registry(session_id)
+
+    assert reloaded_registry.snapshot() == live_registry.snapshot()
+
+
+# ---------------------------------------------------------------------------
+# §4: cold-cache live callback must not double-apply the triggering frame
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_live_callback_cold_cache_does_not_double_apply_triggering_frame(tmp_path):
+    """ClaudeSDK always persists a message (storage_manager.append_message) before
+    invoking message_callback — so the very first Task frame seen by a session
+    with no cached TaskLegRegistry yet is *already* in messages.jsonl by the
+    time the live callback runs. Hydration therefore already includes it; the
+    live callback must not apply it a second time (which would append two legs
+    for one real launch)."""
+    import src.session_coordinator as sc_module
+    from src.session_coordinator import SessionCoordinator
+
+    session_id = "sess-cold-cache"
+    coordinator = SessionCoordinator(data_dir=tmp_path)
+    session_dir = tmp_path / "sessions" / session_id
+    session_dir.mkdir(parents=True)
+
+    storage = sc_module.DataStorageManager(session_dir)
+    await storage.initialize()
+    coordinator._storage_managers[session_id] = storage
+
+    # Simulate ClaudeSDK._store_sdk_message() having already persisted this
+    # exact frame before message_callback fires.
+    await storage.append_message(_stored_task_started("t1", "tu-1", session_id, 1.0))
+
+    assert session_id not in coordinator._task_leg_registries, "cache must start cold"
+
+    sdk_msg = TaskStartedMessage(
+        subtype="task_started", data={}, task_id="t1",
+        description="alpha: cold cache", uuid="u1", session_id="sub-sess", tool_use_id="tu-1",
+    )
+    converted_message = {
+        "type": "system",
+        "sdk_message": sdk_msg,
+        "session_id": session_id,
+        "timestamp": 1.0,
+    }
+
+    callback = coordinator._create_message_callback(session_id)
+    await callback(converted_message)
+
+    registry = coordinator._task_leg_registries[session_id]
+    snapshot = registry.snapshot()
+    assert len(snapshot) == 1
+    assert len(snapshot[0]["legs"]) == 1, "the triggering frame must not be applied twice"


### PR DESCRIPTION
## Summary

Backend stage of #1746 (session floating "needs attention" state and reload/reconnect support for background subagents). Pure backend — no Vue/frontend changes. Running in parallel with the "layout" stage (different files, no overlap expected).

Relates to #1746 (stage: backend)

## Changes Made

- **`src/permission_service.py`** — Fixes per-session permission tracking. Adds `pending_by_session: dict[str, set[str]]` so resolving one agent's permission request no longer clears another agent's still-open PAUSED state on the same session. Session PAUSED→ACTIVE is now gated on "zero requests open for this session," not "did *any* request resolve." The `await permission_future` wait is wrapped with `try/finally` so `asyncio.CancelledError` (a `BaseException`, not caught by `except Exception`) can no longer leak the per-session bookkeeping — found and fixed during the code-review pass.

- **`src/message_parser.py`** — Adds `TaskUpdatedHandler` to the live message-parsing handler chain (mirrors the existing `TaskStartedHandler`/`TaskProgressHandler`/`TaskNotificationHandler`). Previously `TaskUpdatedMessage` fell through to the generic `SystemMessageHandler` in the *live* path — a real gap: a `TaskStop`-terminated background agent got no structured live event at all (its `task_id`/`status`/`patch` were silently dropped), even though the storage-replay path (#1657) already handled this message type correctly.

- **`src/task_registry.py`** (new) — `TaskLegRegistry`: per-session, in-memory index of background-agent (SDK `Task`) lifecycle legs, keyed by the stable `task_id` (a resumed agent reuses `task_id` across separate `task_started` frames; `tool_use_id` is per-leg only). Fed by the four lifecycle frame types (`task_started`/`task_progress`/`task_notification`/`task_updated`) — the same four frames the SDK's own internal tracker uses, never `background_tasks_changed` (which the SDK's own source explicitly says is not meant to be consumed). First-terminal-wins: a leg's terminal status is never overwritten by a later/duplicate terminal frame — found and fixed during the code-review pass.

- **`src/session_coordinator.py`** — Wires the registry into the live message callback (`_create_message_callback`) and adds a lazy per-session hydration path (`_get_task_leg_registry`) that replays `messages.jsonl` once via the existing `_convert_stored_message_to_websocket` reconstruction, so live-streamed and reload-reconstructed state agree. Guards against double-applying a session's very first Task frame: storage always persists a message before the live callback fires, so a cold-cache hydration already includes the triggering frame — found and fixed during the code-review pass. Also fixes a related gap in `_convert_stored_message_to_websocket`: the `TaskUpdatedMessage` branch wasn't copying `patch`, which can be the only place a terminal status is reported.

- **`src/routers/sessions.py`** — New `GET /api/sessions/{session_id}/background_agents` endpoint returning the registry snapshot: `{session_id, agents: [{task_id, description, legs: [...], latest_leg, current_status}]}`.

## Testing

- Full `uv run pytest src/tests/ -v` — 2237 passed, 8 pre-existing/unrelated failures (confirmed identical on clean `main`, unrelated to this diff — `test_api_links`, `test_api_schedules`, `test_issue_1598_poll_viewed_timing`, `test_overseer_controller`).
- `uv run ruff check src/` — zero violations on all touched files.
- New/extended coverage:
  - `src/tests/test_permission_service_session_grouping.py` (new) — concurrent-request grouping, single-request regression, cross-session isolation, `cleanup_pending_for_session` cleanup, and a cancellation regression test that fails without the `try/finally` fix.
  - `src/tests/test_message_parser.py` — live-path `TaskUpdatedHandler` coverage, including a regression guard proving the message would otherwise be misrouted to `subtype="init"`.
  - `src/tests/test_session_coordinator.py` — `patch` field extraction regression for `_convert_stored_message_to_websocket`.
  - `src/tests/test_task_registry.py` (new) — registry mechanics (single-leg, multi-leg resume, concurrent agents, `TaskStop`-only termination, progress-after-terminal no-op, duplicate-terminal no-op), a full live-pipeline test driving real SDK dataclasses through `message_parser` → `TaskLegRegistry` for a two-leg resume (task_id stability, §3), reload/live parity, and a regression test for the cold-cache double-apply bug (fails without the fix).
  - `src/tests/integration/test_issue_1746_background_agents_endpoint.py` (new) — endpoint integration test via the real FastAPI app + `SessionCoordinator`.
- Code review: `/simplify` (4 parallel cleanup agents) found and fixed a duplicated lifecycle-subtype constant and two genuine test-helper duplications within the new files; `/code-review medium` was substituted with a dedicated review subagent (the skill returned `disable-model-invocation` when invoked directly) — it found and I fixed the two real issues above (CancelledError leak, terminal-status overwrite), both now covered by regression tests that fail without their respective fixes.

### Manual verification (backend-only, no UI to click through)

This awaits a review/testing period before merge — not requesting immediate approval.

Against a running session with a real `Agent`-tool subagent call, cross-checked against `data/logs/sdk_debug.log` (`--debug-sdk`):

```bash
# 1. Hit the new endpoint for a session that has run at least one Agent tool call
curl -s http://localhost:8001/api/sessions/<session_id>/background_agents | jq

# Expected shape:
# {
#   "session_id": "...",
#   "agents": [
#     {
#       "task_id": "...",
#       "description": "...",
#       "legs": [{"tool_use_id": "...", "description": "...", "started_at": ..., "last_progress_at": ..., "ended_at": ..., "status": "running|completed|failed|stopped"}],
#       "latest_leg": {...},
#       "current_status": "..."
#     }
#   ]
# }

# 2. Cross-check task_id/status against sdk_debug.log's TaskStartedMessage/
#    TaskProgressMessage/TaskNotificationMessage/TaskUpdatedMessage frames for
#    the same session — task_id should match across legs; status should match
#    the last terminal frame seen.

# 3. Exercise the permission-grouping fix: trigger two concurrent Agent-tool
#    subagents that both need permission on the SAME parent session (e.g. two
#    Bash calls from two spawned agents). Resolve the first one's permission
#    prompt via the UI/API and confirm the session is still shown PAUSED
#    (session state, not the per-agent chip) until the second is resolved too:
curl -s http://localhost:8001/api/sessions/<session_id> | jq '.session.state'
# then resolve the second permission and re-check — should now be "active".

# 4. TaskStop scenario: stop a running background agent via the SDK's TaskStop
#    (or let one get interrupted) and confirm background_agents shows
#    current_status: "stopped" for that leg even with no task_notification in
#    sdk_debug.log for it (only task_updated with status="killed").
```

Note: item 3 (task_id stability across resumed-agent legs) is confirmed against the SDK's documented/typed contract and a scripted fixture test driving real SDK dataclasses through the full parsing pipeline, but the *original* observed trace behind this issue is the only real-world (non-fixture) data point — worth a live resumed-agent trace check during the manual pass above if practical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)