### PR TITLE
fix: scope permission cleanup to terminating session only

### DIFF
--- a/src/permission_service.py
+++ b/src/permission_service.py
@@ -596,17 +596,13 @@ class PermissionService:
     def cleanup_pending_for_session(self, session_id: str) -> None:
         """Clean up pending permissions for a specific session by auto-denying them"""
         try:
-            # Find all pending permissions for this session and auto-deny them
-            permissions_to_cleanup = []
-            for request_id, future in self.pending_permissions.items():
-                if not future.done():
-                    # We need to identify which permissions belong to this session
-                    # Since the permission callback stores the session_id in its closure,
-                    # we'll auto-deny all pending permissions when a session terminates
-                    # This is safe because if a session is terminated, no tools should execute
-                    permissions_to_cleanup.append(request_id)
+            # Issue #1754: Scope to this session's own open requests via
+            # pending_by_session (added in #1746) instead of walking every
+            # session's pending_permissions — otherwise terminating one session
+            # auto-denies every other active session's in-flight permission prompts.
+            request_ids = list(self.pending_by_session.get(session_id, ()))
 
-            for request_id in permissions_to_cleanup:
+            for request_id in request_ids:
                 future = self.pending_permissions.pop(request_id, None)
                 if future and not future.done():
                     # Auto-deny the permission
@@ -617,12 +613,9 @@ class PermissionService:
                     future.set_result(response)
                     debug_logger.info(f"Auto-denied pending permission {request_id} due to session {session_id} termination")
 
-            if permissions_to_cleanup:
-                debug_logger.info(f"Cleaned up {len(permissions_to_cleanup)} pending permissions for session {session_id}")
+            if request_ids:
+                debug_logger.info(f"Cleaned up {len(request_ids)} pending permissions for session {session_id}")
 
-            # Issue #1746: This session's own pending-request bookkeeping is
-            # fully retired here regardless of the (pre-existing, unchanged)
-            # cross-session sweep above — every request it held is now denied.
             self.pending_by_session.pop(session_id, None)
 
         except Exception:

--- a/src/tests/test_permission_service_session_grouping.py
+++ b/src/tests/test_permission_service_session_grouping.py
@@ -209,6 +209,87 @@ async def test_cleanup_pending_for_session_clears_session_set():
 
 
 # ---------------------------------------------------------------------------
+# Test 3b: cleanup_pending_for_session is scoped to the terminating session
+# (issue #1754 — was iterating the global pending_permissions dict and
+# auto-denying every active session's in-flight requests)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cleanup_pending_for_session_does_not_touch_other_sessions():
+    """Terminating session A must deny only A's own pending requests, leaving
+    session B's untouched in both pending_permissions and pending_by_session."""
+    coord = _make_coordinator()
+    from src.permission_service import PermissionService
+
+    svc = PermissionService(coordinator=coord, session_queues={})
+
+    future_a = asyncio.get_running_loop().create_future()
+    future_b = asyncio.get_running_loop().create_future()
+    svc.pending_permissions["req-a"] = future_a
+    svc.pending_permissions["req-b"] = future_b
+    svc.pending_by_session["A"] = {"req-a"}
+    svc.pending_by_session["B"] = {"req-b"}
+
+    svc.cleanup_pending_for_session("A")
+
+    assert future_a.done()
+    assert future_a.result()["behavior"] == "deny"
+    assert not future_b.done()
+    assert "A" not in svc.pending_by_session
+    assert "B" in svc.pending_by_session
+    assert "req-b" in svc.pending_permissions
+
+
+@pytest.mark.asyncio
+async def test_cleanup_pending_for_session_multiple_requests_within_session():
+    """All of the terminating session's own requests are denied; an unrelated
+    session's request is untouched."""
+    coord = _make_coordinator()
+    from src.permission_service import PermissionService
+
+    svc = PermissionService(coordinator=coord, session_queues={})
+
+    future_a1 = asyncio.get_running_loop().create_future()
+    future_a2 = asyncio.get_running_loop().create_future()
+    future_c = asyncio.get_running_loop().create_future()
+    svc.pending_permissions["req-a1"] = future_a1
+    svc.pending_permissions["req-a2"] = future_a2
+    svc.pending_permissions["req-c"] = future_c
+    svc.pending_by_session["A"] = {"req-a1", "req-a2"}
+    svc.pending_by_session["C"] = {"req-c"}
+
+    svc.cleanup_pending_for_session("A")
+
+    assert future_a1.done() and future_a1.result()["behavior"] == "deny"
+    assert future_a2.done() and future_a2.result()["behavior"] == "deny"
+    assert not future_c.done()
+    assert "A" not in svc.pending_by_session
+    assert "C" in svc.pending_by_session
+    assert svc.pending_by_session["C"] == {"req-c"}
+
+
+@pytest.mark.asyncio
+async def test_cleanup_pending_for_session_no_pending_is_a_noop():
+    """Terminating a session with zero pending permissions must not raise and
+    must not affect another session's pending request."""
+    coord = _make_coordinator()
+    from src.permission_service import PermissionService
+
+    svc = PermissionService(coordinator=coord, session_queues={})
+
+    future_b = asyncio.get_running_loop().create_future()
+    svc.pending_permissions["req-b"] = future_b
+    svc.pending_by_session["B"] = {"req-b"}
+
+    svc.cleanup_pending_for_session("empty-session")
+
+    assert not future_b.done()
+    assert "B" in svc.pending_by_session
+    assert "empty-session" not in svc.pending_by_session
+
+
+# ---------------------------------------------------------------------------
 # Test 4: two different sessions never interact
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Resolves #1754

`PermissionService.cleanup_pending_for_session(session_id)` in `src/permission_service.py` was called on session termination to auto-deny that session's own not-yet-resolved permission prompts, but it iterated the **global** `pending_permissions` dict (every active session's pending requests) instead of scoping to the terminating session. Result: terminating any one session silently auto-denied every other active session's in-flight permission prompts.

The fix scopes the sweep to `pending_by_session[session_id]` — a `dict[str, set[str]]` mapping session_id to its own open request IDs, already added and correctly maintained by #1746 for a related-but-distinct bug. No new bookkeeping was introduced.

- `deny_all_for_interrupt()` is untouched (intentionally service-wide, out of scope).
- Behavior for a session's own pending permissions is unchanged (same deny path, message, Future resolution).

## Test plan

- [x] Added 3 regression tests to `src/tests/test_permission_service_session_grouping.py`:
  - Cross-session isolation on cleanup
  - Multiple pending requests within the terminating session, sibling session untouched
  - No-op guard when the terminating session has zero pending permissions
- [x] Confirmed all 3 new tests fail against the pre-fix code (via `git stash`) and pass with the fix
- [x] `uv run pytest src/tests/ -v` — 2240 passed, 8 pre-existing failures unrelated to this change (confirmed identical failures on unmodified code, in `test_api_links.py`, `test_api_schedules.py`, `test_issue_1598_poll_viewed_timing.py`, `test_overseer_controller.py` — none touch `permission_service.py`)
- [x] `uv run ruff check --fix` clean on both changed files
- [x] Independent code-review pass via subagent (the `/code-review` skill declines direct model invocation) — no correctness issues found; three low-severity/informational notes (a narrow pre-existing race unrelated to this diff, a cosmetic log-count inaccuracy, a suggestion for deeper integration-style tests) were left as-is per the plan's scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)