### PR TITLE
fix: reconstruct permission-mode and api-retry summaries on reload

### DIFF
--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -3413,6 +3413,34 @@ class SessionCoordinator:
                             if exit_code is not None:
                                 metadata["exit_code"] = exit_code
 
+                # Issue #1756: Synthesize content for permission-mode-change status messages
+                elif subtype == "status":
+                    status_data = data.get("data") or {}
+                    permission_mode = status_data.get("permissionMode")
+                    if permission_mode:
+                        metadata["subtype"] = "permission_mode_change"
+                        metadata["permission_mode"] = permission_mode
+                        content = f"Permission mode changed to {permission_mode}"
+
+                # Issue #1756: Synthesize content for api_retry messages (mirrors
+                # message_parser.py SystemMessageHandler's live-path logic, lines 453-465)
+                elif subtype in ("api_retry", "tengu_api_retry"):
+                    retry_data = data.get("data") or {}
+                    attempt = retry_data.get("attempt") or retry_data.get("attemptNumber")
+                    max_retries = retry_data.get("max_retries") or retry_data.get("maxRetries")
+                    wait_ms = (
+                        retry_data.get("wait_ms")
+                        or retry_data.get("waitMs")
+                        or retry_data.get("retryAfterMs")
+                    )
+                    metadata["attempt"] = attempt
+                    metadata["max_retries"] = max_retries
+                    metadata["wait_sec"] = round(wait_ms / 1000) if wait_ms else None
+                    metadata["subtype"] = "api_retry"
+                    attempt_str = f"{attempt}/{max_retries}" if attempt and max_retries else str(attempt or "?")
+                    wait_str = f" (~{round(wait_ms / 1000)}s)" if wait_ms else ""
+                    content = f"API retry {attempt_str}{wait_str}"
+
             # Handle ResultMessage
             if _type == "ResultMessage":
                 subtype = data.get("subtype")

--- a/src/tests/test_session_coordinator.py
+++ b/src/tests/test_session_coordinator.py
@@ -2226,6 +2226,97 @@ class TestConvertStoredMessageToWebsocket:
         assert result["type"] == "system"
         assert result["metadata"]["subtype"] == "task_notification"
 
+    def test_issue_1756_permission_mode_change_synthesizes_content(self, coordinator):
+        stored = {
+            "_type": "SystemMessage",
+            "timestamp": 1700000000.0,
+            "data": {
+                "subtype": "status",
+                "data": {"permissionMode": "plan"},
+            },
+        }
+        result = coordinator._convert_stored_message_to_websocket(stored)
+        assert result is not None
+        assert result["type"] == "system"
+        assert result["content"] == "Permission mode changed to plan"
+        assert result["metadata"]["subtype"] == "permission_mode_change"
+        assert result["metadata"]["permission_mode"] == "plan"
+
+    def test_issue_1756_status_without_permission_mode_unaffected(self, coordinator):
+        stored = {
+            "_type": "SystemMessage",
+            "timestamp": 1700000000.0,
+            "data": {
+                "subtype": "status",
+                "data": {},
+            },
+        }
+        result = coordinator._convert_stored_message_to_websocket(stored)
+        assert result is not None
+        assert result["content"] == ""
+        assert result["metadata"]["subtype"] == "status"
+
+    def test_issue_1756_api_retry_synthesizes_content(self, coordinator):
+        stored = {
+            "_type": "SystemMessage",
+            "timestamp": 1700000000.0,
+            "data": {
+                "subtype": "api_retry",
+                "data": {"attempt": 2, "max_retries": 5, "wait_ms": 3000},
+            },
+        }
+        result = coordinator._convert_stored_message_to_websocket(stored)
+        assert result is not None
+        assert result["content"] == "API retry 2/5 (~3s)"
+        meta = result["metadata"]
+        assert meta["subtype"] == "api_retry"
+        assert meta["attempt"] == 2
+        assert meta["max_retries"] == 5
+        assert meta["wait_sec"] == 3
+
+    def test_issue_1756_tengu_api_retry_normalized_to_api_retry(self, coordinator):
+        stored = {
+            "_type": "SystemMessage",
+            "timestamp": 1700000000.0,
+            "data": {
+                "subtype": "tengu_api_retry",
+                "data": {"attempt": 1, "max_retries": 3},
+            },
+        }
+        result = coordinator._convert_stored_message_to_websocket(stored)
+        assert result is not None
+        assert result["content"] == "API retry 1/3"
+        assert result["metadata"]["subtype"] == "api_retry"
+
+    @pytest.mark.asyncio
+    async def test_issue_1756_client_launched_content_unaffected(
+        self, temp_coordinator, sample_session_config
+    ):
+        """client_launched is stored via _send_client_launched_message in the legacy
+        {type, content, metadata} format (no _type discriminator), so it never reaches
+        _convert_stored_message_to_websocket — it's handled by the already-processed
+        branch in get_session_messages() instead. Confirm the new elif branches don't
+        change that."""
+        coordinator = temp_coordinator
+        session_id = await coordinator.create_session(**sample_session_config)
+
+        mock_storage = AsyncMock()
+        mock_storage.read_messages.return_value = [
+            {
+                "type": "system",
+                "content": "Claude Code Launched",
+                "timestamp": 1700000000.0,
+                "metadata": {"subtype": "client_launched"},
+            }
+        ]
+        mock_storage.get_message_count.return_value = 1
+        coordinator._storage_managers[session_id] = mock_storage
+
+        result = await coordinator.get_session_messages(session_id, limit=10, offset=0)
+        assert len(result["messages"]) == 1
+        assert result["messages"][0]["content"] == "Claude Code Launched"
+        assert result["messages"][0]["metadata"]["subtype"] == "client_launched"
+
 
 class TestIssue1676AgentNotification:
     """Tests for background subagent Notification hook tagging (issue #1676)."""


### PR DESCRIPTION
## Summary
Resolves #1756

System message summaries for permission-mode changes and API retries were computed only at live-broadcast time (`message_parser.py`'s `SystemMessageHandler`) and never persisted, so after a page reload the same messages fell back to a generic, empty display instead of showing e.g. "Permission mode changed to plan" or "API retry 2/5 (~3s)".

## Changes Made
- Extended `_convert_stored_message_to_websocket()` in `src/session_coordinator.py` with two new `elif` branches, mirroring the existing `hook_started`/`hook_response` reconstruction pattern already in that function:
  - `subtype == "status"` with a `permissionMode` payload → synthesizes `"Permission mode changed to {mode}"` and sets `metadata.subtype = "permission_mode_change"`
  - `subtype in ("api_retry", "tengu_api_retry")` → synthesizes `"API retry {attempt}/{max} (~{wait}s)"` and populates `attempt`/`max_retries`/`wait_sec` metadata
- Both branches read raw fields already present in every historical `messages.jsonl` row, so existing sessions regain their summaries retroactively on next load — no backfill migration needed. This function is shared by `get_session_messages()`, `get_archive_messages()`, and the task-leg registry, so session reload, archive replay, and task tracking are all fixed at once.
- No frontend changes — the frontend already renders whatever `content` it's given.

## Testing
- Added 5 unit tests to `TestConvertStoredMessageToWebsocket` in `src/tests/test_session_coordinator.py`: permission-mode-change reconstruction, a status message with no `permissionMode` (unaffected), `api_retry` and `tengu_api_retry` reconstruction (values match the existing live-path expectations in `test_issue_894_api_retry.py`), and a regression test confirming `client_launched`-style fixed-content messages (which are stored in the legacy format and never reach this function) are unaffected.
- Full backend suite: `uv run pytest src/tests/ -v` — 2242 passed (plus the 5 new tests); 8 pre-existing failures on `main` (unrelated Mock/await issues in overseer/schedule/links/polling tests, confirmed present before this change via `git stash`) are unchanged.
- `uv run ruff check src/session_coordinator.py src/tests/test_session_coordinator.py` — zero violations.
- Independent code-review pass via a review subagent caught one test-quality issue (the original `client_launched` regression test used an unrealistic stored-message shape); fixed by rewriting it to exercise the real `get_session_messages()` path with the actual legacy storage format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)