### PR TITLE
feat: add builder-review skill for agent-invocable correctness review

### DIFF
--- a/.claude/skills/builder-review/SKILL.md
+++ b/.claude/skills/builder-review/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: builder-review
+description: Model-invocable correctness review of your own working diff — the agent-callable equivalent of /code-review medium. Use before considering a piece of work finished, or any time you want a correctness check on changes you've made.
+---
+
+# builder-review
+
+<!--
+This is a manually-synced copy of the built-in `/code-review` command's `medium` effort
+prompt, as observed in Claude Code CLI version 2.1.220 (the prompt is compiled into the CLI
+binary, not stored as a file this repo can read or wrap). Phases 0-2 below are copied
+verbatim. If drift between this copy and the live `/code-review medium` behavior is ever
+suspected, re-diff this file against the current CLI binary's embedded prompt text and update
+accordingly.
+-->
+
+medium effort → 3+5 angles × 6 candidates → 1-vote verify → ≤8 findings
+
+You are reviewing for **precision** at medium effort: every finding you surface should be one a maintainer would act on.
+
+## Phase 0 — Gather the diff
+
+Run `git diff @{upstream}...HEAD` (or `git diff main...HEAD` / `git diff HEAD~1` if there's no upstream) to get the unified diff under review. If there are uncommitted changes, or the range diff is empty, also run `git diff HEAD` and include the working-tree changes in scope — the review often runs before the commit. If a PR number, branch name, or file path was passed as an argument, review that target instead. Treat this diff as the review scope.
+
+## Phase 1 — Find candidates (3 correctness angles + 3 cleanup angles + 1 altitude angle + 1 conventions angle, up to 6 each)
+
+Run **8 independent finder angles** via the Agent tool. Each surfaces **up to 6 candidate findings** with `file`, `line`, a one-line `summary`, and a concrete `failure_scenario`. If the Agent tool is not available in your current tool set, do not error — perform each angle (and each verification) yourself, sequentially, in this context.
+
+### Angle A — line-by-line diff scan
+Read every hunk in the diff, line by line. Then Read the enclosing function for each hunk — bugs in unchanged lines of a touched function are in scope (the PR re-exposes or fails to fix them). For every line ask: what input, state, timing, or platform makes this line wrong? Look for inverted/wrong conditions, off-by-one, null/undefined deref, missing `await`, falsy-zero checks, wrong-variable copy-paste, error swallowed in catch, unescaped regex metachars.
+
+### Angle B — removed-behavior auditor
+For every line the diff DELETES or replaces, name the invariant or behavior it enforced, then search the new code for where that invariant is re-established. If you can't find it, that's a candidate: a removed guard, a dropped error path, a narrowed validation, a deleted test that was covering a real case.
+
+### Angle C — cross-file tracer
+For each function the diff changes, find its callers (Grep for the symbol) and check whether the change breaks any call site: a new precondition, a changed return shape, a new exception, a timing/ordering dependency. Also check callees: does a parallel change in the same PR make a call unsafe?
+
+### Reuse
+The angles above hunt for bugs; this one and the next two hunt for cleanup in the changed code. Flag new code that re-implements something the codebase already has — Grep shared/utility modules and files adjacent to the change, and name the existing helper to call instead.
+
+### Simplification
+Flag unnecessary complexity the diff adds: redundant or derivable state, copy-paste with slight variation, deep nesting, dead code left behind. Name the simpler form that does the same job.
+
+### Efficiency
+Flag wasted work the diff introduces: redundant computation or repeated I/O, independent operations run sequentially, blocking work added to startup or hot paths. Also flag long-lived objects built from closures or captured environments — they keep the entire enclosing scope alive for the object's lifetime (a memory leak when that scope holds large values); prefer a class/struct that copies only the fields it needs. Name the cheaper alternative.
+
+### Altitude
+Check that each change is implemented at the right depth, not as a fragile bandaid. Special cases layered on shared infrastructure are a sign the fix isn't deep enough — prefer generalizing the underlying mechanism over adding special cases.
+
+### Conventions (CLAUDE.md)
+Find the CLAUDE.md files that govern the changed code: the user-level `~/.claude/CLAUDE.md`, the repo-root CLAUDE.md, plus any CLAUDE.md or CLAUDE.local.md in a directory that is an ancestor of a changed file (a directory's CLAUDE.md only applies to files at or below it). Read each one that exists, then check the diff for clear violations of the rules they state. Only flag a violation when you can quote the exact rule and the exact line that breaks it — no style preferences, no vague "spirit of the doc" inferences. In the finding, name the CLAUDE.md path and quote the rule so the report can cite it. If no CLAUDE.md applies, return nothing for this angle.
+
+Cleanup, altitude, and conventions candidates use the same `file`/`line`/`summary` shape; in `failure_scenario`, state the concrete cost (what is duplicated, wasted, harder to maintain, or which CLAUDE.md rule is broken) instead of a crash. Correctness bugs always outrank cleanup, altitude, and conventions findings when the output cap forces a cut.
+
+Pass every candidate with a nameable failure scenario through — finders that silently drop half-believed candidates bypass the verify step and are the dominant cause of misses.
+
+## Phase 2 — Verify (1-vote, 3-state)
+
+Dedup candidates that point at the same line/mechanism, keeping the one with the most concrete failure scenario. For each remaining candidate, run **one verifier** via the Agent tool: give it the diff, the relevant file(s), and the candidate, and have it return exactly one of:
+
+- **CONFIRMED** — can name the inputs/state that trigger it and the wrong output or crash. Quote the line.
+- **PLAUSIBLE** — mechanism is real, trigger is uncertain (timing, env, config). State what would confirm it.
+- **REFUTED** — factually wrong (code doesn't say that) or guarded elsewhere. Quote the line that proves it.
+
+Keep candidates where the vote is CONFIRMED or PLAUSIBLE.
+
+## Output
+
+Do not call `ReportFindings` — it is not guaranteed to exist in the invoking agent's session. Instead, output the findings as a **JSON array in your own final response text**, inside a single fenced ```json block, with nothing else in that response besides an optional one-line lead-in. This lets the calling agent's workflow instructions locate and parse the block programmatically.
+
+The JSON array holds at most 8 entries, ranked most-severe first (correctness before cleanup on ties, most severe kept if more than 8 survive). Each entry has `file`, `line`, `summary`, `short_summary` — the claim compressed to ≤60 characters, no rationale or consequence clause — `failure_scenario`, and `category` — a short kebab-case slug for the angle that produced it (`correctness`, `simplification`, `efficiency`, `reuse`, `altitude`, `conventions`, or a more specific slug like `test-coverage` when one fits better) — plus `verdict` when a verify pass produced one. If nothing survives verification, output an empty array (`[]`) in the fenced block. Do not create or publish an artifact of the review, and do not call any human-facing reporting tool — the fenced JSON block is the report.


### PR DESCRIPTION
## Summary
- Adds `.claude/skills/builder-review/SKILL.md`, a new agent-invocable skill giving any agent a self-invocable equivalent of the human-only `/code-review medium` command.
- Investigation confirmed `/code-review` has no on-disk `SKILL.md` in this environment (it's compiled into the CLI binary), so the originally-proposed wrapper approach isn't implementable. This is a duplicated copy of Phases 0-2, byte-verbatim, version-pinned to CLI 2.1.220, with a note to re-diff if drift is suspected.
- The only behavioral change from `/code-review medium`: the Output step no longer calls `ReportFindings` (not guaranteed to exist in a Builder minion's session) — instead it returns the same finding fields as a fenced ```json block in the invoking agent's own final response text.
- `disable-model-invocation` is intentionally omitted from frontmatter, which is what keeps the skill agent-invocable.

Resolves #1764

## Test plan
- [x] Agent-invocation smoke test: invoked `builder-review` via the Skill tool against this worktree's diff — ran real Phase 0-2 fan-out (8 finder-angle agents → dedup → 8 verifier agents) and ended with a fenced JSON block, no `ReportFindings` call.
- [x] Confirmed `disable-model-invocation` absent from frontmatter (`grep` returns no match).
- [x] Confirmed skill appears in the available-skills listing for a fresh session.
- [x] Confirmed `git diff` shows only the one new file added.
- [x] Confirmed the 8-angle/6-candidate/8-finding caps are preserved unchanged from the original prompt.
- [x] Diffed the copied Phases 0-2 text byte-for-byte against the issue's reference-spec comment (§3) — identical.
- [x] Ran `/simplify` on the changed file: 1 fix applied (merged a redundant restatement of the 8-entry cap in the Output section into one clause); 1 finding dismissed as out-of-scope (suggested inventing a shared cross-skill structured-output mechanism — new-feature scope creep beyond this issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)