### PR TITLE
fix: include legion_id in broadcasted schedule events

### DIFF
--- a/src/web_server.py
+++ b/src/web_server.py
@@ -408,6 +408,7 @@ class ClaudeWebUI:
     async def _broadcast_schedule_event(self, legion_id: str, event: dict):
         """Broadcast schedule event to UI poll queue."""
         try:
+            event["legion_id"] = legion_id
             self.ui_queue.append(event)
         except Exception:
             logger.exception("Error appending schedule event")


### PR DESCRIPTION
## Summary
Resolves #1796

`ClaudeWebUI._broadcast_schedule_event` in `src/web_server.py` accepted `legion_id` as a parameter but never merged it into the `event` dict before pushing it onto the UI poll queue. The frontend's `polling.js` reads `payload.legion_id` to route `schedule_updated`/`schedule_execution` events to the right legion's schedule store, so without this key those events were effectively dropped client-side — the right-sidebar Schedules panel and badge count never live-updated on create/pause/resume/delete/run-now, requiring a page reload to see current state.

## Changes Made
- Add `event["legion_id"] = legion_id` in `_broadcast_schedule_event` before appending to `self.ui_queue` (`src/web_server.py`).

## Testing
- Full pytest suite: 2350 passed, 8 pre-existing failures confirmed unrelated (reproduce identically with the fix reverted).
- `uv run ruff check src/web_server.py`: zero violations.
- Manual verification against a live dev server (video + screenshots captured):
  - **T1**: Created a schedule via REST while the right sidebar's Schedules panel was open — badge and panel updated live, no reload.
  - **T2**: Two browser tabs on the same session — paused a schedule in Tab A, confirmed live update in Tab B; resumed from Tab B, confirmed live update back in Tab A.
  - **T3** (regression): Panel's own pause/resume buttons still update the acting tab instantly (this path bypasses the broadcast via direct REST-response store updates) — confirmed working, unaffected by this change.
  - **T4**: Deleted a schedule via REST while a tab was viewing it — confirmed live removal, badge cleared, panel returned to empty state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)