### PR TITLE
fix: scope SharedMcpConnectionManager's open lock to per-config

### DIFF
--- a/src/mcp/shared_connection_manager.py
+++ b/src/mcp/shared_connection_manager.py
@@ -66,7 +66,7 @@ class SharedMcpConnectionManager:
         self._oauth_refresh_manager = oauth_refresh_manager
         self._vault = credential_vault
         self._conns: dict[str, _SharedConn] = {}
-        self._open_lock = asyncio.Lock()
+        self._open_locks: dict[str, asyncio.Lock] = {}
         oauth_refresh_manager.add_broadcast_subscriber(self._on_token_refreshed)
         self._cfg_lookup = None
 
@@ -82,7 +82,7 @@ class SharedMcpConnectionManager:
             raise RuntimeError(
                 f"MCP config '{cfg.name}' is being drained; cannot attach new sessions"
             )
-        async with self._open_lock:
+        async with self._get_open_lock(cfg.id):
             conn = self._conns.get(cfg.id)
             if conn is None:
                 conn = _SharedConn(cfg_id=cfg.id)
@@ -154,6 +154,13 @@ class SharedMcpConnectionManager:
         self._cfg_lookup = fn
 
     # ---- private -----------------------------------------------------------
+
+    def _get_open_lock(self, cfg_id: str) -> asyncio.Lock:
+        lock = self._open_locks.get(cfg_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._open_locks[cfg_id] = lock
+        return lock
 
     async def _ensure_open(self, cfg) -> _SharedConn:
         conn = self._conns.get(cfg.id)

--- a/src/tests/test_shared_mcp_connection.py
+++ b/src/tests/test_shared_mcp_connection.py
@@ -130,6 +130,92 @@ async def test_get_or_open_opens_once_for_multiple_sessions():
 
 
 # ---------------------------------------------------------------------------
+# Per-config lock granularity (issue #1803): one broken/slow server's open
+# must not block another config's open.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_opens_for_distinct_configs_do_not_serialize():
+    """Regression test for the bug: distinct configs must not share one lock.
+
+    Fails against the old manager-wide `_open_lock`: cfg-b's open would block
+    on the lock held while cfg-a's open is in flight, and the wait_for below
+    would raise TimeoutError.
+    """
+    mgr = _make_mgr()
+    cfg_a = _http_cfg(cfg_id="cfg-a", slug="server-a")
+    cfg_b = _http_cfg(cfg_id="cfg-b", slug="server-b")
+
+    block_a = asyncio.Event()
+
+    async def patched_open(self, cfg, conn):
+        if cfg.id == "cfg-a":
+            await block_a.wait()
+        await _stub_open_locked(self, cfg, conn)
+
+    with patch.object(SharedMcpConnectionManager, "_open_locked", patched_open):
+        task_a = asyncio.create_task(mgr.get_or_open(cfg_a))
+        await asyncio.sleep(0)  # let task_a enter and block inside its own lock
+
+        conn_b = await asyncio.wait_for(mgr.get_or_open(cfg_b), timeout=1.0)
+        assert conn_b.cfg_id == "cfg-b"
+
+        block_a.set()
+        conn_a = await asyncio.wait_for(task_a, timeout=1.0)
+        assert conn_a.cfg_id == "cfg-a"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_opens_for_same_config_serialize_single_open():
+    mgr = _make_mgr()
+    cfg = _http_cfg()
+    open_calls = []
+
+    async def slow_open(self, c, conn):
+        open_calls.append(c.id)
+        await asyncio.sleep(0.05)
+        await _stub_open_locked(self, c, conn)
+
+    with patch.object(SharedMcpConnectionManager, "_open_locked", slow_open):
+        conn1, conn2 = await asyncio.gather(mgr.get_or_open(cfg), mgr.get_or_open(cfg))
+
+    assert len(open_calls) == 1, "_open_locked should run once for concurrent same-config opens"
+    assert conn1 is conn2
+    assert conn1.refcount == 2
+
+
+@pytest.mark.asyncio
+async def test_list_tools_check_does_not_block_unrelated_session_open():
+    """Maps to the issue's T4 scenario (issue #1799 Library "Show tools" path) and UC2.
+
+    Fails against the old manager-wide `_open_lock`: get_or_open(cfg_healthy)
+    would block on the same lock as list_tools(cfg_broken)'s in-flight open.
+    """
+    mgr = _make_mgr()
+    cfg_broken = _http_cfg(cfg_id="cfg-broken", slug="broken-server")
+    cfg_healthy = _http_cfg(cfg_id="cfg-healthy", slug="healthy-server")
+
+    block_broken = asyncio.Event()
+
+    async def patched_open(self, cfg, conn):
+        if cfg.id == "cfg-broken":
+            await block_broken.wait()
+        await _stub_open_locked(self, cfg, conn)
+
+    with patch.object(SharedMcpConnectionManager, "_open_locked", patched_open):
+        task_broken = asyncio.create_task(mgr.list_tools(cfg_broken))
+        await asyncio.sleep(0)  # let task_broken enter and block inside its own lock
+
+        conn_healthy = await asyncio.wait_for(mgr.get_or_open(cfg_healthy), timeout=1.0)
+        assert conn_healthy.cfg_id == "cfg-healthy"
+
+        block_broken.set()
+        tools = await asyncio.wait_for(task_broken, timeout=1.0)
+        assert [t.name for t in tools] == ["t1"]
+
+
+# ---------------------------------------------------------------------------
 # release — decrements and keeps open when not draining
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Resolves #1803

`SharedMcpConnectionManager` previously guarded connection-opening for *all* Shared MCP server configs with a single manager-wide `asyncio.Lock`. A slow or broken server's open attempt (up to 35s worst case) could block unrelated servers' connection attempts — including the Library "Show tools" check (#1799), which funnels through the same open path.

## Changes Made
- Replace `self._open_lock: asyncio.Lock` with `self._open_locks: dict[str, asyncio.Lock]`, keyed by `cfg.id`.
- Add a synchronous `_get_open_lock(cfg_id)` get-or-create helper — no `await` between the dict lookup and insert, so no create-race can produce two `Lock` objects for the same config.
- `get_or_open()` now acquires the per-config lock instead of the manager-wide one; same-config opens still serialize to a single real open attempt.
- Lock dict entries are intentionally never removed (not on `mark_draining`/`_close`/`shutdown`) — Shared MCP configs are few and admin-managed, and removing entries would risk a new create-race against an in-flight waiter.

No changes to `mark_draining`, `release`, `_close`, `shutdown`, `_on_token_refreshed`, `reconnect_lock`, or transport/OAuth/secret-resolution code — out of scope for this fix.

## Testing
- Added 3 new concurrency tests to `src/tests/test_shared_mcp_connection.py`, all exercising genuine races via `asyncio.gather`/`asyncio.create_task` (not sequential awaits):
  - `test_concurrent_opens_for_distinct_configs_do_not_serialize` — direct regression test for the bug.
  - `test_concurrent_opens_for_same_config_serialize_single_open` — confirms same-config opens still de-duplicate to one real open.
  - `test_list_tools_check_does_not_block_unrelated_session_open` — confirms the Library tools-check path (#1799) doesn't block unrelated opens.
- Full suite: `uv run pytest src/tests/test_shared_mcp_connection.py -v` — 25/25 passed (22 pre-existing + 3 new), no regressions.
- `uv run ruff check src/mcp/shared_connection_manager.py src/tests/test_shared_mcp_connection.py` — zero violations.
- No frontend changes; `npm run build` confirmed zero diff in `frontend/dist/`.
- `builder-review` code review pass (8 finder angles) run against the diff — no in-scope correctness findings. Two pre-existing races were surfaced (TOCTOU between `get_or_open`'s draining check and `mark_draining`/`_close`; a reconnect race between `_on_token_refreshed` and `get_or_open`'s reopen branch) — verified both predate this change (neither `mark_draining`/`_close` nor `_on_token_refreshed` ever acquired the old manager-wide lock either) and are unrelated to lock granularity, so left out of scope. Worth a separate follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)