### PR TITLE
fix: serialize token-refresh reconnect with get_or_open's reopen path

### DIFF
--- a/src/application_service.py
+++ b/src/application_service.py
@@ -478,7 +478,9 @@ class ApplicationService:
         Status resolution order: disabled -> needs-auth (oauth enabled, no stored
         token) -> connected/failed via SharedMcpConnectionManager.list_tools(). The
         connection attempt can block up to ~35s on a broken shared server (inherited
-        from SharedMcpConnectionManager._open_locked's own timeout).
+        from SharedMcpConnectionManager._open_locked's own timeout), or up to ~70s if
+        a concurrent OAuth token-refresh reconnect (_on_token_refreshed) is also
+        contending for the same config's open-lock (issue #1806).
         """
         from src.mcp_config_manager import McpServerType
 

--- a/src/mcp/shared_connection_manager.py
+++ b/src/mcp/shared_connection_manager.py
@@ -351,18 +351,19 @@ class SharedMcpConnectionManager:
         if conn is None or conn.session is None:
             return
         _logger.info("shared MCP token refresh — reconnecting cfg=%s", server_id)
-        async with conn.reconnect_lock:
-            cfg = await self._lookup_cfg(server_id)
-            if cfg is None:
-                _logger.warning(
-                    "shared MCP refresh: cfg %s not found, leaving conn closed", server_id
-                )
-                return
-            await self._mark_disconnected_locked(conn)
-            try:
-                await self._open_locked(cfg, conn)
-            except Exception:
-                _logger.exception("Reconnect after refresh failed cfg=%s", server_id)
+        async with self._get_open_lock(server_id):
+            async with conn.reconnect_lock:
+                cfg = await self._lookup_cfg(server_id)
+                if cfg is None:
+                    _logger.warning(
+                        "shared MCP refresh: cfg %s not found, leaving conn closed", server_id
+                    )
+                    return
+                await self._mark_disconnected_locked(conn)
+                try:
+                    await self._open_locked(cfg, conn)
+                except Exception:
+                    _logger.exception("Reconnect after refresh failed cfg=%s", server_id)
 
     async def _enter_transport(self, cfg, stack: AsyncExitStack):
         """Open the right client transport based on cfg.type.

--- a/src/routers/mcp.py
+++ b/src/routers/mcp.py
@@ -239,7 +239,9 @@ def build_router(webui) -> APIRouter:
         """Return live tool list for a shared-connection MCP server (issue #1799).
 
         Triggers a connection attempt (opening one if not already open) and blocks
-        until the outcome is known — can take up to ~35s on a broken connection.
+        until the outcome is known — can take up to ~35s on a broken connection, or
+        up to ~70s if a concurrent OAuth token-refresh reconnect is also contending
+        for the same config's open-lock (issue #1806).
         Returns {"status": "disabled"|"needs-auth"|"connected"|"failed", "tools": [...], "error": str|None}.
         """
         result = await webui.service.get_mcp_config_tools(config_id)

--- a/src/tests/test_shared_mcp_connection.py
+++ b/src/tests/test_shared_mcp_connection.py
@@ -381,6 +381,105 @@ async def test_token_refresh_triggers_reconnect():
 
 
 # ---------------------------------------------------------------------------
+# Mutual exclusion between _on_token_refreshed()'s reopen and get_or_open()'s
+# reopen branch (issue #1806)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_token_refresh_and_get_or_open_reopen_serialize():
+    """T1: _on_token_refreshed() and get_or_open() must never call _open_locked
+    concurrently for the same conn.
+
+    Before the #1806 fix, _on_token_refreshed() only held conn.reconnect_lock (not
+    the per-config open-lock), so it could race with get_or_open()'s reopen branch
+    and open two competing connections for the same conn. The fix nests
+    reconnect_lock inside the open-lock in _on_token_refreshed(), so the two paths
+    must now serialize, with the loser observing the winner's live session and
+    skipping its own reopen (AC1).
+    """
+    mgr = _make_mgr()
+    cfg = _http_cfg()
+
+    with patch.object(SharedMcpConnectionManager, "_open_locked", _stub_open_locked):
+        conn = await mgr.get_or_open(cfg)
+
+    mgr.set_cfg_lookup(AsyncMock(return_value=cfg))
+
+    in_flight = 0
+    max_in_flight = 0
+    entries = []
+    entered_gate = asyncio.Event()
+    gate = asyncio.Event()
+
+    async def gated_open(self, c, con):
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        entries.append(asyncio.current_task().get_name())
+        entered_gate.set()
+        await gate.wait()
+        in_flight -= 1
+        await _stub_open_locked(self, c, con)
+
+    with patch.object(SharedMcpConnectionManager, "_open_locked", gated_open):
+        t_refresh = asyncio.create_task(mgr._on_token_refreshed(cfg.id), name="refresh")
+        await asyncio.wait_for(entered_gate.wait(), timeout=1.0)
+
+        assert max_in_flight == 1
+        assert entries == ["refresh"]
+
+        # get_or_open must block on the same open-lock refresh is holding — it
+        # cannot enter _open_locked (gated_open) until refresh releases it.
+        t_open = asyncio.create_task(mgr.get_or_open(cfg), name="reopen")
+        await asyncio.sleep(0)
+
+        assert max_in_flight == 1, "only one _open_locked call should be in flight"
+        assert entries == ["refresh"], (
+            "get_or_open must not enter _open_locked while refresh holds the open-lock"
+        )
+
+        gate.set()
+        await asyncio.wait_for(asyncio.gather(t_refresh, t_open), timeout=1.0)
+
+    assert max_in_flight == 1, "the two reopen paths must never call _open_locked concurrently"
+    assert entries == ["refresh"], "get_or_open should see the refreshed live session and skip its own reopen"
+    assert conn.session is not None
+    assert conn.refcount == 2
+
+
+@pytest.mark.asyncio
+async def test_repeated_concurrent_refresh_and_reopen_no_deadlock():
+    """T4: stress the nested open-lock/reconnect_lock acquisition in
+    _on_token_refreshed() across many concurrent iterations to prove no deadlock.
+    """
+    mgr = _make_mgr()
+    cfg = _http_cfg()
+
+    with patch.object(SharedMcpConnectionManager, "_open_locked", _stub_open_locked):
+        conn = await mgr.get_or_open(cfg)
+
+    mgr.set_cfg_lookup(AsyncMock(return_value=cfg))
+
+    with patch.object(SharedMcpConnectionManager, "_open_locked", _stub_open_locked):
+        for i in range(20):
+            prev_generation = conn.generation
+            refresh_coro = mgr._on_token_refreshed(cfg.id)
+            open_coro = mgr.get_or_open(cfg)
+            if i % 2 == 0:
+                tasks = [asyncio.create_task(refresh_coro), asyncio.create_task(open_coro)]
+            else:
+                tasks = [asyncio.create_task(open_coro), asyncio.create_task(refresh_coro)]
+            try:
+                await asyncio.wait_for(asyncio.gather(*tasks), timeout=1.0)
+            except TimeoutError:
+                pytest.fail(f"iteration {i}: concurrent refresh/reopen deadlocked")
+            assert conn.generation >= prev_generation, "generation must not go backwards"
+
+    assert conn.generation > 0
+
+
+# ---------------------------------------------------------------------------
 # OAuth header built for HTTP; not for STDIO
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Resolves #1806

`_on_token_refreshed()` previously only held `conn.reconnect_lock` while reopening a shared MCP connection after an OAuth token refresh, while `get_or_open()`'s reopen branch holds the per-config open-lock. Since these paths used different locks, they could race and each open a competing connection for the same config, orphaning one.

## Changes Made
- Nest `conn.reconnect_lock` inside the per-config open-lock (open-lock outer, reconnect_lock inner) in `_on_token_refreshed()`, matching `get_or_open()`'s existing locking. No logic change beyond the added lock acquisition and one indent level.
- `call_tool()` → `_call_tool_locked()` is untouched — it still only acquires `reconnect_lock`, never the open-lock, so no new deadlock path is introduced (only `_on_token_refreshed()` now ever holds both locks).
- Updated two docstrings (`application_service.py`, `routers/mcp.py`) that documented `get_mcp_config_tools()`'s ~35s worst-case block — with this fix, a concurrent token-refresh reconnect can now queue behind the same open-lock, pushing the worst case to ~70s.
- Added `test_concurrent_token_refresh_and_get_or_open_reopen_serialize` (T1): proves mutual exclusion — the two reopen paths never call `_open_locked` concurrently, and the loser observes the winner's live session and skips its own reopen.
- Added `test_repeated_concurrent_refresh_and_reopen_no_deadlock` (T4): stress test looping 20 iterations of concurrent refresh/reopen (alternating start order), each bounded by a 1s timeout, asserting no deadlock and monotonically increasing `conn.generation`.

## Testing
- `uv run pytest src/tests/test_shared_mcp_connection.py -v` — all 27 tests pass (25 existing + 2 new).
- `uv run pytest src/tests/ -q` — full suite run; 2391 passed, 8 pre-existing failures unrelated to this change (verified against the base commit before this diff — same failures reproduce without these changes).
- `uv run ruff check` — zero violations on all touched files.
- Self-reviewed via `builder-review` skill (8 finder angles + verification); the one confirmed finding (stale ~35s latency docs) was fixed as part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)