### PR TITLE
fix: close mark_draining race that can leak a connection on first-ever open

### DIFF
--- a/src/mcp/shared_connection_manager.py
+++ b/src/mcp/shared_connection_manager.py
@@ -67,6 +67,7 @@ class SharedMcpConnectionManager:
         self._vault = credential_vault
         self._conns: dict[str, _SharedConn] = {}
         self._open_locks: dict[str, asyncio.Lock] = {}
+        self._pending_drains: set[str] = set()
         oauth_refresh_manager.add_broadcast_subscriber(self._on_token_refreshed)
         self._cfg_lookup = None
 
@@ -84,6 +85,19 @@ class SharedMcpConnectionManager:
             )
         async with self._get_open_lock(cfg.id):
             conn = self._conns.get(cfg.id)
+            if conn is not None and conn.draining:
+                raise RuntimeError(
+                    f"MCP config '{cfg.name}' is being drained; cannot attach new sessions"
+                )
+            if cfg.id in self._pending_drains:
+                # Do not discard here: with multiple concurrent callers racing
+                # a mark_draining() on a never-opened config, discarding on the
+                # first match would let a later caller fall through and open a
+                # real connection. Only clear_pending_drain() (re-enable) may
+                # remove this marker.
+                raise RuntimeError(
+                    f"MCP config '{cfg.name}' is being drained; cannot attach new sessions"
+                )
             if conn is None:
                 conn = _SharedConn(cfg_id=cfg.id)
                 self._conns[cfg.id] = conn
@@ -110,13 +124,29 @@ class SharedMcpConnectionManager:
             await self._close(cfg_id)
 
     async def mark_draining(self, cfg_id: str) -> None:
-        """Called from config delete/disable. Close immediately if no refs."""
-        conn = self._conns.get(cfg_id)
-        if conn is None:
-            return
-        conn.draining = True
-        if conn.refcount <= 0:
-            await self._close(cfg_id)
+        """Called from config delete/disable. Close immediately if no refs.
+
+        Serialized through the per-config open-lock so a drain that arrives
+        during a first-ever open is either applied to the in-flight
+        connection or recorded in _pending_drains before get_or_open can
+        create a new _SharedConn — never lost to a bare `conn is None` race.
+        """
+        async with self._get_open_lock(cfg_id):
+            conn = self._conns.get(cfg_id)
+            if conn is None:
+                self._pending_drains.add(cfg_id)
+                return
+            conn.draining = True
+            if conn.refcount <= 0:
+                await self._close(cfg_id)
+
+    def clear_pending_drain(self, cfg_id: str) -> None:
+        """Called on config re-enable to undo a mark_draining() recorded while
+        the config had never been opened (no _SharedConn to mark). No-op if
+        cfg_id has a real (possibly draining) connection — this only clears
+        the no-conn-yet marker.
+        """
+        self._pending_drains.discard(cfg_id)
 
     async def list_tools(self, cfg) -> list[Tool]:
         """Return cached tools, opening the connection if needed."""

--- a/src/mcp_config_manager.py
+++ b/src/mcp_config_manager.py
@@ -383,6 +383,10 @@ class McpConfigManager:
             # Issue #1484: drain shared connection when disabling a config
             if enabled is False and config.enabled is True and shared_mcp_manager is not None:
                 await shared_mcp_manager.mark_draining(config_id)
+            # Issue #1805: undo a pending-drain marker left by a disable while
+            # the config had never been opened, so re-enabling isn't rejected.
+            if enabled is True and config.enabled is False and shared_mcp_manager is not None:
+                shared_mcp_manager.clear_pending_drain(config_id)
             config.enabled = enabled
         if oauth_enabled is not None:
             config.oauth_enabled = oauth_enabled

--- a/src/tests/test_shared_mcp_connection.py
+++ b/src/tests/test_shared_mcp_connection.py
@@ -271,6 +271,154 @@ async def test_mark_draining_then_release_closes():
 
 
 # ---------------------------------------------------------------------------
+# mark_draining / get_or_open race on a never-opened config (issue #1805)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mark_draining_never_opened_then_get_or_open_raises():
+    """T2: mark_draining() on a config that was never opened must record a
+    pending-drain marker; the next get_or_open() must raise before ever
+    calling _open_locked (no transport/subprocess opened for a doomed attach).
+    """
+    mgr = _make_mgr()
+    cfg = _http_cfg()
+
+    await mgr.mark_draining(cfg.id)
+    assert cfg.id not in mgr._conns
+    assert cfg.id in mgr._pending_drains
+
+    open_calls = []
+
+    async def counting_open(self, c, conn):
+        open_calls.append(c.id)
+        await _stub_open_locked(self, c, conn)
+
+    with patch.object(SharedMcpConnectionManager, "_open_locked", counting_open):
+        with pytest.raises(RuntimeError, match="drained"):
+            await mgr.get_or_open(cfg)
+
+    assert open_calls == [], "_open_locked must never be called for a pending-drain config"
+    assert cfg.id not in mgr._conns
+    # The marker is NOT consumed by a rejected get_or_open() — only
+    # clear_pending_drain() (re-enable) may remove it. See
+    # test_pending_drain_rejects_all_concurrent_racers for why.
+    assert cfg.id in mgr._pending_drains
+
+
+@pytest.mark.asyncio
+async def test_pending_drain_rejects_all_concurrent_racers():
+    """Regression: a pending-drain marker must reject every concurrent racer,
+    not just the first one to observe it.
+
+    Before this fix, get_or_open() discarded the _pending_drains entry on the
+    first match, so a second caller racing the same never-opened, just-drained
+    config would find the marker already consumed and open a live connection
+    to a config that's supposed to be draining/deleted — leaking a connection
+    and violating the issue's AC1 ("no call to _open_locked completing
+    unguarded").
+    """
+    mgr = _make_mgr()
+    cfg = _http_cfg()
+
+    await mgr.mark_draining(cfg.id)
+    assert cfg.id in mgr._pending_drains
+
+    open_calls = []
+
+    async def counting_open(self, c, conn):
+        open_calls.append(c.id)
+        await _stub_open_locked(self, c, conn)
+
+    with patch.object(SharedMcpConnectionManager, "_open_locked", counting_open):
+        results = await asyncio.gather(
+            mgr.get_or_open(cfg), mgr.get_or_open(cfg), return_exceptions=True
+        )
+
+    assert all(isinstance(r, RuntimeError) for r in results), (
+        "every concurrent racer must be rejected, not just the first"
+    )
+    assert open_calls == [], "_open_locked must never be called while the config is draining"
+    assert cfg.id not in mgr._conns
+    assert cfg.id in mgr._pending_drains  # still present; only clear_pending_drain() removes it
+
+
+@pytest.mark.asyncio
+async def test_mark_draining_serializes_behind_inflight_open():
+    """T1: mark_draining() must block until an in-flight first-ever open
+    completes, proving it's now serialized via the per-config open-lock
+    instead of racing the conn's creation/field mutation while _open_locked
+    is running.
+    """
+    mgr = _make_mgr()
+    cfg = _http_cfg()
+
+    block_open = asyncio.Event()
+
+    async def blocking_open(self, c, conn):
+        await block_open.wait()
+        await _stub_open_locked(self, c, conn)
+
+    with patch.object(SharedMcpConnectionManager, "_open_locked", blocking_open):
+        task_open = asyncio.create_task(mgr.get_or_open(cfg))
+        await asyncio.sleep(0)  # let task_open enter the lock and start blocking open
+
+        task_drain = asyncio.create_task(mgr.mark_draining(cfg.id))
+        await asyncio.sleep(0)
+        assert not task_drain.done(), "mark_draining must block behind the in-flight open"
+
+        block_open.set()
+        conn = await asyncio.wait_for(task_open, timeout=1.0)
+        await asyncio.wait_for(task_drain, timeout=1.0)
+
+    assert conn.draining is True
+    # refcount was incremented by the in-flight get_or_open before mark_draining
+    # could observe the conn, so it's still present (not closed on 0 refcount).
+    assert cfg.id in mgr._conns
+
+    await mgr.release(cfg.id)
+    assert cfg.id not in mgr._conns
+
+
+@pytest.mark.asyncio
+async def test_clear_pending_drain_allows_reenable_get_or_open_succeeds():
+    """Re-enable regression: disable(never-opened) → clear_pending_drain →
+    get_or_open must succeed normally, not be incorrectly rejected."""
+    mgr = _make_mgr()
+    cfg = _http_cfg()
+
+    await mgr.mark_draining(cfg.id)
+    assert cfg.id in mgr._pending_drains
+
+    mgr.clear_pending_drain(cfg.id)
+    assert cfg.id not in mgr._pending_drains
+
+    with patch.object(SharedMcpConnectionManager, "_open_locked", _stub_open_locked):
+        conn = await mgr.get_or_open(cfg)
+
+    assert conn.session is not None
+    assert cfg.id in mgr._conns
+
+
+@pytest.mark.asyncio
+async def test_clear_pending_drain_noop_for_live_draining_conn():
+    """clear_pending_drain() only clears the no-conn-yet marker; it must not
+    interfere with a real, actively-draining connection."""
+    mgr = _make_mgr()
+    cfg = _http_cfg()
+
+    with patch.object(SharedMcpConnectionManager, "_open_locked", _stub_open_locked):
+        await mgr.get_or_open(cfg)
+
+    mgr._conns[cfg.id].draining = True
+    mgr.clear_pending_drain(cfg.id)
+
+    assert mgr._conns[cfg.id].draining is True
+    with pytest.raises(RuntimeError, match="drained"):
+        await mgr.get_or_open(cfg)
+
+
+# ---------------------------------------------------------------------------
 # list_tools / _ensure_open — refcount-neutral for non-lifecycle callers
 # (issue #1799: a Library-level tools check must not leak a permanent hold
 # that would block a subsequent config delete/drain)


### PR DESCRIPTION
## Summary
Resolves #1805

`SharedMcpConnectionManager.mark_draining()` read `self._conns.get(cfg_id)` without any synchronization. When called for a config that had never been opened (`conn is None`), it silently no-op'd — a `get_or_open()` racing (or immediately following) it had no way to discover a drain had been requested, and would open a live upstream connection (including, for STDIO, a subprocess) for a config that was being disabled or deleted.

## Changes Made
- `mark_draining()` is now serialized through the same per-config open-lock that already guards `get_or_open()`'s create+open+refcount critical section, so a drain arriving mid-open applies cleanly instead of racing in-flight field mutation on `_SharedConn`.
- Added `self._pending_drains: set[str]` — when `mark_draining()` finds `conn is None` (now under the lock), it records `cfg_id` there instead of no-op'ing. `get_or_open()` checks this set under the same lock, before ever creating a new `_SharedConn` or opening a transport, and rejects the attach if present.
- The pending-drain marker is **not** discarded by a rejected `get_or_open()` call — only `clear_pending_drain()` removes it. (During review I found the originally-planned "discard on first match" design let a *second* concurrent racer slip through and open a live connection once the first racer had consumed the marker; not discarding fixes this and is covered by a new regression test.)
- Added `clear_pending_drain(cfg_id)`, wired into `McpConfigManager.update_config()`'s `enabled: False -> True` transition (symmetric with the existing `mark_draining()` call on the `True -> False` transition), so a disable-before-ever-opened config followed by re-enable isn't permanently and incorrectly rejected.

## Testing
- `uv run pytest src/tests/test_shared_mcp_connection.py -v` — 32/32 pass (27 pre-existing unmodified + 5 new: sequential drain-then-open rejection, concurrent racers all rejected, mid-open serialization, re-enable clears the marker, `clear_pending_drain` is a no-op against a live draining connection).
- `uv run pytest src/tests/test_mcp_config_manager.py -v` — 31/31 pass.
- Full suite: `uv run pytest src/tests/ -q` — 2395 passed, 8 pre-existing failures unrelated to this change (verified identical on `main` via `git stash`; in links/schedules/poll-timing/overseer-controller tests, unrelated to shared MCP connections).
- `uv run ruff check src/` — zero violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)