### PR TITLE
fix: CLI entrypoint crash — replace removed add_event_handler with lifespan (#1822)

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 from src.config_manager import check_network_binding, ensure_config_file, load_config
 from src.logging_config import configure_logging
 from src.secrets_keyring import configure_keyring
-from src.web_server import create_app, shutdown_event, startup_event
+from src.web_server import create_app
 
 
 def main():
@@ -185,10 +185,6 @@ def main():
         host=args.host,
         port=args.port,
     )
-
-    # Add startup/shutdown events
-    app.add_event_handler("startup", startup_event)
-    app.add_event_handler("shutdown", shutdown_event)
 
     # Run the server
     uvicorn.run(

--- a/src/tests/test_main_entrypoint.py
+++ b/src/tests/test_main_entrypoint.py
@@ -1,0 +1,86 @@
+"""Regression tests for issue #1822 — CLI entrypoint crash on startup.
+
+`main.py` used to wire startup/shutdown via `app.add_event_handler(...)`, which was
+removed in FastAPI 0.141 (bumped in #1815/#1816). Neither test exercised
+`main.py`/`create_app()` together, so the crash went unnoticed. These tests close
+that gap: one exercises the new `lifespan` wiring in-process, the other runs the
+literal CLI entrypoint as a subprocess.
+"""
+
+import os
+import socket
+import subprocess
+import time
+from pathlib import Path
+
+import httpx
+from starlette.testclient import TestClient
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def test_create_app_lifespan_serves_health(tmp_path: Path):
+    """create_app() must wire a working lifespan; entering TestClient must not crash."""
+    from src.web_server import create_app
+
+    app = create_app(data_dir=tmp_path)
+
+    with TestClient(app) as client:
+        resp = client.get("/health")
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "healthy"
+
+
+def test_main_entrypoint_subprocess_smoke(tmp_path: Path):
+    """Run `main.py` as a real subprocess — the literal CLI entrypoint that crashed."""
+    port = _free_port()
+    env = os.environ.copy()
+    env.pop("CLAUDECODE", None)
+
+    proc = subprocess.Popen(
+        [
+            "uv", "run", "python", "main.py",
+            "--port", str(port),
+            "--data-dir", str(tmp_path),
+            "--no-auth",
+        ],
+        cwd=str(REPO_ROOT),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+    try:
+        deadline = time.monotonic() + 15
+        last_error = None
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                output = proc.stdout.read()
+                raise AssertionError(
+                    f"main.py exited early with code {proc.returncode}:\n{output}"
+                )
+            try:
+                resp = httpx.get(f"http://127.0.0.1:{port}/health", timeout=1)
+                if resp.status_code == 200:
+                    assert resp.json()["status"] == "healthy"
+                    break
+            except httpx.TransportError as exc:
+                last_error = exc
+            time.sleep(0.3)
+        else:
+            raise AssertionError(f"main.py never became healthy on port {port}: {last_error}")
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -5,6 +5,7 @@ FastAPI web server for Claude Code WebUI with HTTP long-polling support.
 import asyncio
 import logging
 import re
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -1119,21 +1120,20 @@ def create_app(
 ) -> FastAPI:
     """Create and configure the FastAPI application"""
     global webui_app
-    webui_app = ClaudeWebUI(
+    app_instance = ClaudeWebUI(
         data_dir, experimental=experimental,
         mock_sdk=mock_sdk, fixtures_dir=fixtures_dir,
         available_fixtures=available_fixtures,
         auth_token=auth_token, auth_enabled=auth_enabled,
         host=host, port=port,
     )
-    return webui_app.app
+    webui_app = app_instance
 
-async def startup_event():
-    """Application startup event"""
-    if webui_app:
-        await webui_app.initialize()
+    @asynccontextmanager
+    async def _lifespan(_app: FastAPI):
+        await app_instance.initialize()
+        yield
+        await app_instance.cleanup()
 
-async def shutdown_event():
-    """Application shutdown event"""
-    if webui_app:
-        await webui_app.cleanup()
+    app_instance.app.router.lifespan_context = _lifespan
+    return app_instance.app


### PR DESCRIPTION
## Summary
Resolves #1822

FastAPI 0.141 (bumped in #1815/#1816) removed `FastAPI.add_event_handler`, which `main.py` used to register startup/shutdown callbacks — crashing the CLI entrypoint immediately with `AttributeError: 'FastAPI' object has no attribute 'add_event_handler'`. No test exercised `main.py`/`create_app()` together, so the crash went unnoticed until this blocked #498.

## Changes Made
- `src/web_server.py`: `create_app()` now wires an `asynccontextmanager` lifespan directly onto the FastAPI app's `router.lifespan_context`, bound to that specific call's `ClaudeWebUI` instance (not the mutable module-level global, avoiding a latent bug where a later `create_app()` call in the same process could redirect an earlier app's init/cleanup onto the wrong instance). Removed the now-dead `startup_event`/`shutdown_event` functions.
- `main.py`: removed the `app.add_event_handler(...)` calls and the now-unused import.
- `src/tests/test_main_entrypoint.py` (new): a `create_app()` + `TestClient` context-manager test exercising the lifespan wiring in-process, plus a subprocess smoke test that runs `main.py` as a real CLI process and polls `/health` — the exact end-to-end path that was broken and untested.

No changes to `ClaudeWebUI.__init__`'s `FastAPI()` construction, so the three existing test call-sites that construct `ClaudeWebUI` directly (`test_issue_813_oauth.py`'s two `TestClient` sites, `integration/conftest.py`'s `ws_integration_env` fixture) are unaffected — verified by running them explicitly.

## Testing
- Full test suite: `uv run pytest src/tests/ -v` — 2398/2406 passing (the 8 remaining failures are pre-existing on `main`, unrelated to this change — reproduced independently on a clean checkout).
- Manually ran `uv run python main.py --port 8822 --no-auth`, confirmed no crash, hit `/health` successfully, stopped by PID.
- Verified the closure-binding fix directly: two `create_app()` calls in the same process now correctly keep each app's lifespan bound to its own `ClaudeWebUI` instance (mocked `initialize`/`cleanup` to confirm no cross-instance leakage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)