### PR TITLE
feat: harden remote headless backend — health checks, Hub connection flag, Dockerfile (#499)

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -1,0 +1,78 @@
+# Minimal production image for `--headless-backend` mode (issue #499).
+#
+# Deliberately leaner than docker/Dockerfile.dev (dev/testing tooling image): no
+# Node.js, Chromium/Playwright, or gh CLI, and no frontend build step — headless
+# mode serves no UI and skips the frontend/dist existence check entirely
+# (backend_mode == "headless" in web_server.py).
+#
+# Build:
+#   docker build -f docker/Dockerfile.backend -t claudecode-webui-backend:local .
+#
+# Run:
+#   docker run -p 8000:8000 claudecode-webui-backend:local \
+#     --backend-token=<token>
+#
+# --headless-backend --host 0.0.0.0 are baked into ENTRYPOINT (not CMD) so extra
+# `docker run` args (--backend-token, --data-dir, ...) APPEND to them rather than
+# replacing them — Docker replaces CMD wholesale with any args given after the
+# image name, it does not merge them with CMD's defaults.
+#
+# --host 0.0.0.0 requires network-binding to be acknowledged (main.py's
+# check_network_binding()); baked into the image's config.json below since a
+# container is only reachable at all via its published port (docker run -p) in
+# the first place, so the operator has already made that call.
+#
+# Out of scope for this image: Docker Compose / Kubernetes manifests — a
+# follow-up once #1818 gives multi-backend deployment a real reason to exist.
+
+FROM debian:bookworm-slim
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
+    apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    ca-certificates \
+    git
+
+RUN useradd -m -s /bin/bash claude
+USER claude
+WORKDIR /home/claude/app
+
+# ---------- UV Python package manager ----------
+RUN curl -fsSL https://astral.sh/uv/install.sh | bash
+ENV PATH="/home/claude/.local/bin:${PATH}"
+ENV UV_NATIVE_TLS=1
+ENV UV_CACHE_DIR=/home/claude/.cache/uv
+ENV UV_LINK_MODE=copy
+
+# ---------- Pre-warm dependency layer (cached until pyproject.toml/uv.lock change) ----------
+COPY --chown=claude:claude pyproject.toml uv.lock ./
+RUN uv python install 3.13 \
+    && uv sync --frozen --no-install-project
+
+# ---------- Claude Code CLI ----------
+# claude-agent-sdk shells out to this binary for real SDK sessions server-side.
+# Bump in lockstep with claude-agent-sdk in pyproject.toml/uv.lock.
+ARG CLAUDE_CODE_VERSION=2.1.220
+RUN curl -fsSL https://claude.ai/install.sh | bash -s ${CLAUDE_CODE_VERSION}
+
+# ---------- Application code ----------
+COPY --chown=claude:claude main.py ./
+COPY --chown=claude:claude src ./src
+RUN uv sync --frozen
+
+# Pre-acknowledge network binding: main.py refuses to bind non-localhost hosts
+# without this (src/config_manager.py's check_network_binding()), but binding
+# 0.0.0.0 is required for the container's published port to reach anything.
+RUN mkdir -p /home/claude/.config/cc_webui && \
+    printf '{\n  "networking": {\n    "allow_network_binding": true,\n    "acknowledged_risk": true\n  }\n}\n' \
+    > /home/claude/.config/cc_webui/config.json
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD curl -fsS http://127.0.0.1:8000/health/ready || exit 1
+
+ENTRYPOINT ["uv", "run", "python", "main.py", "--headless-backend", "--host", "0.0.0.0"]
+CMD []

--- a/main.py
+++ b/main.py
@@ -65,6 +65,20 @@ def main():
              '(auto-generated if omitted)'
     )
 
+    # Hub -> REMOTE backend connection (issue #499): manually-configured stopgap
+    # ahead of #1818's real pairing/registration flow — not a replacement for it.
+    parser.add_argument(
+        '--remote-backend-url', type=str, default=None,
+        help='Connect this Hub to a REMOTE backend at this base URL instead of '
+             'running sessions locally. Manually-configured stopgap ahead of '
+             "#1818's real pairing/registration flow — not a replacement for it."
+    )
+    parser.add_argument(
+        '--remote-backend-token', type=str, default=None,
+        help='Bearer token for outbound calls to the REMOTE backend configured '
+             'via --remote-backend-url'
+    )
+
     # Mock SDK mode (for browser automation testing — issue #561)
     parser.add_argument(
         '--mock-sdk', action='store_true',
@@ -174,6 +188,8 @@ def main():
     # mount, so the browser-facing auth banner below doesn't apply to it.
     if args.backend_token and not args.headless_backend:
         parser.error("--backend-token requires --headless-backend")
+    if args.remote_backend_token and not args.remote_backend_url:
+        parser.error("--remote-backend-token requires --remote-backend-url")
     backend_mode = "headless" if args.headless_backend else "frontend"
     backend_auth_token = None
     if args.headless_backend:
@@ -194,6 +210,9 @@ def main():
     else:
         print("Authentication disabled (localhost binding)")
 
+    if args.remote_backend_url:
+        print(f"Dispatching sessions to REMOTE backend at {args.remote_backend_url}")
+
     # Advertise the server's internal URL so docker proxy sidecars can call back on the
     # right port. The proxy addon reads WEBUI_BASE_URL; without this it defaults to :8000.
     import os as _os
@@ -212,6 +231,8 @@ def main():
         port=args.port,
         backend_mode=backend_mode,
         backend_auth_token=backend_auth_token,
+        remote_backend_url=args.remote_backend_url,
+        remote_backend_token=args.remote_backend_token,
     )
 
     # Run the server

--- a/src/application_service.py
+++ b/src/application_service.py
@@ -219,12 +219,10 @@ class ApplicationService:
             session_id, permission_callback=permission_callback
         )
 
-    async def update_session(self, session_id: str, **updates) -> bool:
-        return await self.coordinator.session_manager.update_session(
-            session_id,
-            template_manager=self.coordinator.template_manager,
-            **updates,
-        )
+    async def update_session(
+        self, session_id: str, updates: dict, raw_payload: dict
+    ) -> bool:
+        return await self.coordinator.update_session_config(session_id, updates, raw_payload)
 
     async def get_session_working_directory(self, session_id: str) -> str | None:
         """Return working_directory for file-serving and diff routes."""

--- a/src/local_backend.py
+++ b/src/local_backend.py
@@ -130,6 +130,18 @@ class LocalBackend:
             return False
         return await sdk.set_model(model)
 
+    async def update_session_name(self, session_id: str, name: str) -> bool:
+        # LOCAL renames are coordinator-local (session_manager) and never dispatch
+        # through the backend — see SessionCoordinator.update_session_name. Present
+        # only for Protocol conformance.
+        return True
+
+    async def update_session_config(self, session_id: str, raw_payload: dict[str, Any]) -> bool:
+        # LOCAL config updates are coordinator-local (session_manager) and never
+        # dispatch through the backend — see SessionCoordinator.update_session_config.
+        # Present only for Protocol conformance.
+        return True
+
     async def resolve_permission(
         self, session_id: str, request_id: str, response: dict[str, Any]
     ) -> bool:

--- a/src/remote_backend.py
+++ b/src/remote_backend.py
@@ -359,6 +359,18 @@ class RemoteBackend:
         )
         return resp.json() if resp is not None else {"messages": [], "total": 0}
 
+    async def get_session_usage(self, session_id: str) -> dict[str, Any] | None:
+        """Fetch REMOTE's own /sessions/{id}/usage response (issue #499) — turn/usage
+        records only ever get written to REMOTE's local analytics DB (the write
+        happens inside _create_message_callback's 'result' handling, which never
+        runs on the Hub for a relayed session), so the Hub's own analytics_store has
+        nothing to compute from. Callers should take only the raw usage fields from
+        this response and recompute cost/rates against the Hub's own configured
+        pricing — REMOTE has no UI to configure pricing at all, so its own
+        estimated_cost_usd/rates_used are not meaningful here."""
+        resp = await self._get(f"/sessions/{session_id}/usage")
+        return resp.json() if resp is not None else None
+
     async def is_session_active(self, session_id: str) -> bool:
         return session_id in self._active_session_ids
 

--- a/src/remote_backend.py
+++ b/src/remote_backend.py
@@ -177,6 +177,7 @@ class RemoteBackend:
         permission_callback: Callable | None = None,
         auto_approval_callback: Callable | None = None,
         error_callback: Callable | None = None,
+        on_relay_event: Callable | None = None,
     ) -> tuple[bool, str | None]:
         try:
             resp = await self._client.post(f"/sessions/{session_id}/start")
@@ -190,7 +191,7 @@ class RemoteBackend:
         existing = self._relay_tasks.get(session_id)
         if existing is None or existing.done():
             task = asyncio.create_task(
-                self._relay_poll_loop(session_id, error_callback),
+                self._relay_poll_loop(session_id, error_callback, on_relay_event),
                 name=f"remote_relay_poll_{session_id}",
             )
             self._relay_tasks[session_id] = task
@@ -403,6 +404,7 @@ class RemoteBackend:
         self,
         session_id: str,
         error_callback: Callable | None,
+        on_relay_event: Callable | None = None,
     ) -> None:
         """Long-poll REMOTE's mirrored `/poll/session/{id}` and replay each already-
         formed event envelope into the Hub's local EventQueue for this session — the
@@ -415,6 +417,14 @@ class RemoteBackend:
         `disconnect_session()`'s `_stop_relay`), and starting over from since=0 would
         re-fetch and re-append REMOTE's entire event backlog into the Hub's local
         EventQueue on every restart, duplicating message history in the frontend.
+
+        `on_relay_event`, if given, is invoked once per relayed event (issue #499) —
+        this loop deliberately does NOT run events through the Hub's full
+        `_create_message_callback` pipeline (REMOTE already ran that once on its own
+        side; doing so again here would double-write Hub-local storage/state that
+        only REMOTE should own), but some Hub-local bookkeeping (e.g. is_processing)
+        has nothing else that ever updates it for a REMOTE session, so a narrow hook
+        is needed instead of the full pipeline.
         """
         cursor = self._relay_cursors.get(session_id, 0)
         failures = 0
@@ -441,9 +451,16 @@ class RemoteBackend:
                 self._relay_cursors[session_id] = cursor
                 failures = 0
                 queue = self._session_queues.get(session_id)
-                if queue is not None:
-                    for event in events:
+                for event in events:
+                    if queue is not None:
                         queue.append(event)
+                    if on_relay_event is not None:
+                        try:
+                            await on_relay_event(event)
+                        except Exception:
+                            logger.exception(
+                                f"on_relay_event callback failed for session {session_id}"
+                            )
             except asyncio.CancelledError:
                 raise
             except Exception:

--- a/src/remote_backend.py
+++ b/src/remote_backend.py
@@ -57,6 +57,8 @@ class RemoteBackend:
         self._relay_cursors: dict[str, int] = {}
         self._audit_relay_task: asyncio.Task | None = None
         self._audit_relay_active = False
+        self._ui_relay_task: asyncio.Task | None = None
+        self._ui_relay_active = False
 
     async def aclose(self) -> None:
         tasks = list(self._relay_tasks.values())
@@ -69,6 +71,7 @@ class RemoteBackend:
                 pass
         self._relay_tasks.clear()
         await self.stop_audit_relay()
+        await self.stop_ui_relay()
         await self._client.aclose()
 
     # ------------------------------------------------------------------
@@ -144,6 +147,74 @@ class RemoteBackend:
                 if failures >= MAX_RELAY_FAILURES:
                     logger.error(f"Giving up audit relay poll after {failures} failures")
                     self._audit_relay_active = False
+                    break
+                await asyncio.sleep(min(2**failures, 30))
+
+    # ------------------------------------------------------------------
+    # UI relay (issue #499) — same single-shared-connection pattern as the audit
+    # relay above. Without this, every broadcast that lands in the *global*
+    # ui_queue (session PAUSED-for-permission state, rate-limit updates, watchdog
+    # alerts, SDK-driven permission-mode changes, Legion comm/schedule
+    # notifications — anything sent via ClaudeWebUI._on_state_change and friends)
+    # only ever reaches REMOTE's own local ui_queue, which the Hub never polls —
+    # a systematic gap found auditing every callback/broadcast mechanism against
+    # the same "bypasses the per-session relay" pattern as the is_processing fix.
+    # ------------------------------------------------------------------
+
+    async def start_ui_relay(self, ui_queue: EventQueue) -> None:
+        """Start the single background task that keeps the Hub's local ui_queue
+        filled from REMOTE's global UI event stream (/api/backend/poll/ui)."""
+        if self._ui_relay_task is not None and not self._ui_relay_task.done():
+            return
+        self._ui_relay_active = True
+        self._ui_relay_task = asyncio.create_task(
+            self._ui_relay_poll_loop(ui_queue), name="remote_ui_relay_poll"
+        )
+
+    async def stop_ui_relay(self) -> None:
+        self._ui_relay_active = False
+        task = self._ui_relay_task
+        self._ui_relay_task = None
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+    async def _ui_relay_poll_loop(self, ui_queue: EventQueue) -> None:
+        """Long-poll REMOTE's mirrored /poll/ui and replay each event into the
+        Hub's local ui_queue. Uses poll_ui's own since/next_cursor integer
+        convention (same shape as /poll/session/{id}, unlike audit's DB-timestamp
+        cursor) — this loop's cursor is private to it, decoupled from what
+        /api/poll/ui actually serves to browser clients from the Hub-local queue.
+        """
+        cursor = 0
+        failures = 0
+        while self._ui_relay_active:
+            await asyncio.sleep(0)
+            try:
+                resp = await self._client.get(
+                    "/poll/ui", params={"since": cursor, "timeout": _POLL_TIMEOUT_SECONDS}
+                )
+                resp.raise_for_status()
+                data = resp.json()
+                events = data.get("events", [])
+                cursor = data.get("next_cursor", cursor)
+                failures = 0
+                for event in events:
+                    ui_queue.append(event)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                failures += 1
+                logger.warning(
+                    f"UI relay poll failed (attempt {failures}/{MAX_RELAY_FAILURES})",
+                    exc_info=True,
+                )
+                if failures >= MAX_RELAY_FAILURES:
+                    logger.error(f"Giving up UI relay poll after {failures} failures")
+                    self._ui_relay_active = False
                     break
                 await asyncio.sleep(min(2**failures, 30))
 

--- a/src/remote_backend.py
+++ b/src/remote_backend.py
@@ -49,6 +49,12 @@ class RemoteBackend:
         self._session_queues = session_queues
         self._relay_tasks: dict[str, asyncio.Task] = {}
         self._active_session_ids: set[str] = set()
+        # Per-session "how far into REMOTE's own event numbering have we already
+        # relayed" — must survive a relay task being stopped and a new one started
+        # (e.g. on restart_session), or the fresh loop starting from since=0 would
+        # re-fetch and re-append REMOTE's entire event backlog into the Hub's local
+        # (never-cleared) EventQueue every time, duplicating history in the frontend.
+        self._relay_cursors: dict[str, int] = {}
         self._audit_relay_task: asyncio.Task | None = None
         self._audit_relay_active = False
 
@@ -259,6 +265,10 @@ class RemoteBackend:
 
     async def terminate_session(self, session_id: str) -> bool:
         self._stop_relay(session_id)
+        # Unlike disconnect_session (used by restart_session, which needs the cursor
+        # preserved so the next start resumes rather than re-fetching everything),
+        # a genuine terminate ends this session for good — nothing will resume it.
+        self._relay_cursors.pop(session_id, None)
         resp = await self._post(f"/sessions/{session_id}/terminate", {})
         return resp is not None and resp.status_code < 400
 
@@ -399,8 +409,14 @@ class RemoteBackend:
         same envelope shape REMOTE's own message_callback produced when it appended
         to REMOTE's own local queue, so the Hub's frontend poll transport sees an
         identical stream to a LOCAL session with no changes to poll.py/web_server.py.
+
+        Resumes from `self._relay_cursors[session_id]` rather than starting at 0 —
+        this loop is torn down and restarted fresh on every `restart_session()` (via
+        `disconnect_session()`'s `_stop_relay`), and starting over from since=0 would
+        re-fetch and re-append REMOTE's entire event backlog into the Hub's local
+        EventQueue on every restart, duplicating message history in the frontend.
         """
-        cursor = 0
+        cursor = self._relay_cursors.get(session_id, 0)
         failures = 0
         while session_id in self._active_session_ids:
             # Always yield once per iteration — guarantees cancellation is picked up
@@ -422,6 +438,7 @@ class RemoteBackend:
                 data = resp.json()
                 events = data.get("events", [])
                 cursor = data.get("next_cursor", cursor)
+                self._relay_cursors[session_id] = cursor
                 failures = 0
                 queue = self._session_queues.get(session_id)
                 if queue is not None:

--- a/src/remote_backend.py
+++ b/src/remote_backend.py
@@ -210,6 +210,17 @@ class RemoteBackend:
         resp = await self._post(f"/sessions/{session_id}/model", {"model": model})
         return resp is not None and resp.status_code < 400
 
+    async def update_session_name(self, session_id: str, name: str) -> bool:
+        resp = await self._put(f"/sessions/{session_id}/name", {"name": name})
+        return resp is not None and resp.status_code < 400
+
+    async def update_session_config(self, session_id: str, raw_payload: dict[str, Any]) -> bool:
+        """Relay the raw PATCH /api/sessions/{id} body to REMOTE's own mirrored route
+        (issue #499) so REMOTE's session config stays in sync with edits made after
+        creation, not just what it got from create_session()'s creation-time dump."""
+        resp = await self._patch(f"/sessions/{session_id}", raw_payload)
+        return resp is not None and resp.status_code < 400
+
     async def resolve_permission(
         self, session_id: str, request_id: str, response: dict[str, Any]
     ) -> bool:
@@ -356,6 +367,20 @@ class RemoteBackend:
             return await self._client.post(path, json=json_body)
         except httpx.HTTPError:
             logger.exception(f"RemoteBackend POST {path} failed")
+            return None
+
+    async def _patch(self, path: str, json_body: dict[str, Any]) -> httpx.Response | None:
+        try:
+            return await self._client.patch(path, json=json_body)
+        except httpx.HTTPError:
+            logger.exception(f"RemoteBackend PATCH {path} failed")
+            return None
+
+    async def _put(self, path: str, json_body: dict[str, Any]) -> httpx.Response | None:
+        try:
+            return await self._client.put(path, json=json_body)
+        except httpx.HTTPError:
+            logger.exception(f"RemoteBackend PUT {path} failed")
             return None
 
     def _stop_relay(self, session_id: str) -> None:

--- a/src/routers/__init__.py
+++ b/src/routers/__init__.py
@@ -32,6 +32,7 @@ from . import (
     files,
     filesystem,
     fleet,
+    health,
     legion,
     mcp,
     permissions,
@@ -52,7 +53,8 @@ from . import (
 )
 
 # Routers already converted to mount-relative paths — mirrored under /api/backend
-# in headless mode. Grows batch by batch as Batches 2-5 convert their own routers.
+# in headless mode (issue #499's health.py is the sole exception: unprefixed and
+# unauthenticated on both mounts, registered directly rather than via this tuple).
 _RELAY_ELIGIBLE_MODULES = (
     poll, session_runtime, sessions, diff, edit_history, archives,
     projects, legion, fleet, files, filesystem, permissions, proxy, docker_status,
@@ -73,6 +75,7 @@ def _register_frontend(app: FastAPI, webui) -> None:
     app.include_router(skills.build_router(webui))
     app.include_router(config.build_router(webui))
     app.include_router(core.build_router(webui))
+    app.include_router(health.build_router(webui))
     app.include_router(provider_catalog.build_router(webui))
     app.include_router(secrets.build_router(webui))
     app.include_router(profiles.build_router(webui))
@@ -84,7 +87,13 @@ def _register_frontend(app: FastAPI, webui) -> None:
 
 
 def _register_headless(app: FastAPI, webui) -> None:
-    """Headless mount: /api/backend/* only, bearer-gated, no UI, no /api/*."""
+    """Headless mount: /api/backend/* only, bearer-gated, no UI, no /api/*.
+
+    Exception (issue #499): /health and /health/ready are registered unprefixed and
+    outside the bearer-auth dependency group — orchestrator liveness/readiness probes
+    can't carry a token.
+    """
+    app.include_router(health.build_router(webui))
     auth_dep = Depends(backend_auth.build_backend_bearer_auth(webui))
     app.include_router(
         backend_auth.build_router(webui), prefix="/api/backend", dependencies=[auth_dep]

--- a/src/routers/core.py
+++ b/src/routers/core.py
@@ -1,4 +1,4 @@
-"""Core cross-cutting endpoints: /, /health, /api/auth/check, /oauth/callback.
+"""Core cross-cutting endpoints: /, /api/auth/check, /oauth/callback.
 
 Issue #498: interrupt/permission-response moved to session_runtime.py so they mirror
 under /api/backend like the rest of session-domain routes — this file's remaining
@@ -6,9 +6,11 @@ routes are frontend-only concepts with no REMOTE mirror (/oauth/callback handles
 browser redirect back to the Hub's own OAuth flow — moved here from mcp.py so that
 file can convert to mount-relative paths without accidentally prefixing this
 non-/api, non-relay-eligible route).
+
+Issue #499: /health moved to health.py so it can also be registered (unauthenticated)
+on the headless mount, which does not otherwise include this router.
 """
 
-from datetime import UTC, datetime
 from pathlib import Path
 
 from fastapi import APIRouter, Request
@@ -48,12 +50,6 @@ def build_router(webui) -> APIRouter:
                 headers={"Cache-Control": "no-cache, no-store, must-revalidate"}
             )
         return HTMLResponse(content=webui._default_html(), status_code=200)
-
-    @router.get("/health")
-    @handle_exceptions("health check")
-    async def health_check():
-        """Health check endpoint"""
-        return {"status": "healthy", "timestamp": datetime.now(UTC).isoformat()}
 
     @router.get("/api/auth/check")
     @handle_exceptions("check auth")

--- a/src/routers/health.py
+++ b/src/routers/health.py
@@ -1,0 +1,39 @@
+"""Liveness + readiness probes: /health, /health/ready.
+
+Mounted unprefixed and unauthenticated on both the frontend and headless mounts
+(issue #499) — a deliberate, narrow exception to headless mode's "only
+/api/backend/* is exposed" rule, since orchestrator probes can't carry a bearer
+token. /health (liveness) was previously owned by core.py; moved here so it can
+also be registered in headless mode without pulling in core.py's other,
+frontend-only routes.
+"""
+
+from datetime import UTC, datetime
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+
+from ..exception_handlers import handle_exceptions
+
+
+def build_router(webui) -> APIRouter:
+    router = APIRouter()
+
+    @router.get("/health")
+    @handle_exceptions("health check")
+    async def health_check():
+        """Liveness check: 200 if the process is alive, regardless of readiness."""
+        return {"status": "healthy", "timestamp": datetime.now(UTC).isoformat()}
+
+    @router.get("/health/ready")
+    @handle_exceptions("readiness check")
+    async def readiness_check():
+        """Readiness check: 200 once startup has finished, 503 otherwise/during shutdown-drain."""
+        if not getattr(webui, "_ready", False):
+            return JSONResponse(
+                status_code=503,
+                content={"status": "not_ready", "timestamp": datetime.now(UTC).isoformat()},
+            )
+        return {"status": "ready", "timestamp": datetime.now(UTC).isoformat()}
+
+    return router

--- a/src/routers/sessions.py
+++ b/src/routers/sessions.py
@@ -106,9 +106,29 @@ def build_router(webui) -> APIRouter:
     async def get_session_usage(session_id: str):
         """Return aggregated token usage and estimated cost for a session (issue #1125)."""
         from ..config_manager import PricingConfig, compute_cost, load_config
-        aggregate = await webui.coordinator.analytics_store.get_session_usage(session_id)
-        if aggregate is None:
-            raise HTTPException(status_code=404, detail="No usage data for this session")
+
+        if webui.coordinator.backend_mode == BackendMode.REMOTE:
+            # Issue #499: usage records only ever get written to REMOTE's own
+            # analytics DB — the Hub's local analytics_store has no rows for a
+            # REMOTE session at all. Take REMOTE's raw usage numbers but recompute
+            # cost/rates against the Hub's own configured pricing below, not
+            # REMOTE's (REMOTE has no UI to configure pricing at all).
+            remote_usage = await webui.coordinator.backend.get_session_usage(session_id)
+            if remote_usage is None:
+                raise HTTPException(status_code=404, detail="No usage data for this session")
+            aggregate = {
+                "model": remote_usage.get("model"),
+                "turn_count": remote_usage.get("turn_count", 0),
+                "input_tokens": remote_usage.get("input_tokens", 0),
+                "output_tokens": remote_usage.get("output_tokens", 0),
+                "cache_write_tokens": remote_usage.get("cache_write_tokens", 0),
+                "cache_read_tokens": remote_usage.get("cache_read_tokens", 0),
+                "sdk_total_cost_usd": remote_usage.get("sdk_reported_cost_usd"),
+            }
+        else:
+            aggregate = await webui.coordinator.analytics_store.get_session_usage(session_id)
+            if aggregate is None:
+                raise HTTPException(status_code=404, detail="No usage data for this session")
 
         config = load_config(webui.config_file) if webui.config_file else load_config()
         pricing = config.pricing if config.pricing else PricingConfig()

--- a/src/routers/sessions.py
+++ b/src/routers/sessions.py
@@ -344,7 +344,9 @@ def build_router(webui) -> APIRouter:
         if not updates:
             return {"success": True, "message": "No fields to update"}
 
-        success = await webui.service.update_session(session_id, **updates)
+        success = await webui.service.update_session(
+            session_id, updates, request.model_dump(exclude_none=True)
+        )
         if not success:
             raise HTTPException(status_code=500, detail="Failed to update session")
 

--- a/src/session_backend.py
+++ b/src/session_backend.py
@@ -73,6 +73,31 @@ class SessionBackend(Protocol):
 
     async def set_model(self, session_id: str, model: str) -> bool: ...
 
+    async def update_session_name(self, session_id: str, name: str) -> bool:
+        """Update a session's display name.
+
+        LOCAL: no-op (True) — the caller already applied the rename to the local
+        `session_manager` directly; only invoked at all for REMOTE dispatch.
+        REMOTE: relays the rename to REMOTE's own `/sessions/{id}/name` route so its
+        persisted name stays in sync too (issue #499) — cosmetic fields are still
+        session config that should never silently diverge between Hub and REMOTE.
+        """
+        ...
+
+    async def update_session_config(self, session_id: str, raw_payload: dict[str, Any]) -> bool:
+        """Apply a session config update (PATCH /api/sessions/{id}'s raw request body).
+
+        LOCAL: no-op (True) — the caller already applied the update to the local
+        `session_manager` directly; only invoked at all for REMOTE dispatch.
+        REMOTE: relays the raw, unprocessed client payload to REMOTE's own
+        `/sessions/{id}` PATCH route, so REMOTE independently applies the exact same
+        field-transform logic its own router already has (rather than this side
+        reimplementing it). Without this, REMOTE only ever sees the config it got at
+        session-creation time — any later edit (model, tools, extra_env, MCP servers,
+        ...) would silently never reach the process actually running the SDK (#499).
+        """
+        ...
+
     async def resolve_permission(
         self, session_id: str, request_id: str, response: dict[str, Any]
     ) -> bool:

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -1375,6 +1375,12 @@ class SessionCoordinator:
                 # after MAX_RELAY_FAILURES, so a REMOTE outage never surfaces as
                 # SessionState.ERROR — the session just silently stops updating.
                 error_callback=self._create_error_callback(session_id),
+                # Issue #499: the relay poll loop forwards raw events straight into
+                # the Hub's local EventQueue for display, bypassing
+                # _create_message_callback entirely — so is_processing (and anything
+                # gated on it, e.g. interrupt's completion signal) would otherwise
+                # never reset for a REMOTE session after any completed turn.
+                on_relay_event=self._create_remote_relay_state_sync_callback(session_id),
             )
             # Issue #498: keep the Hub's own session_manager state in sync even though
             # the SDK itself runs on REMOTE — every other coordinator method (interrupt,
@@ -5129,6 +5135,35 @@ class SessionCoordinator:
             except Exception:
                 logger.exception(f"Error processing error callback for {session_id}")
 
+        return callback
+
+    def _create_remote_relay_state_sync_callback(self, session_id: str) -> Callable:
+        """Narrow state-sync hook for RemoteBackend's relay poll loop (issue #499).
+
+        The relay loop forwards raw event envelopes straight into the Hub's local
+        EventQueue for display — it deliberately does NOT run them through
+        `_create_message_callback`'s full pipeline, since REMOTE already ran that
+        pipeline once on its own side; doing so again here would double-write
+        Hub-local storage/state that only REMOTE should own for this session.
+
+        But `is_processing` is Hub-local bookkeeping the Hub is still responsible for
+        even in REMOTE mode (see `send_message`'s REMOTE branch, and
+        `interrupt_session`'s "processing state will be reset by the message
+        processing loop" comment) — and nothing else ever resets it for a REMOTE
+        session without this hook, since that loop never runs. Mirrors
+        `_create_message_callback`'s own narrow 'result' → is_processing=False rule
+        (see its "Issue #1029: Reactive is_processing tracking" comment), applied
+        directly to the relayed envelope instead of a freshly-parsed message.
+        """
+        async def callback(event: dict[str, Any]) -> None:
+            try:
+                data = event.get("data") if isinstance(event, dict) else None
+                if isinstance(data, dict) and data.get("type") == "result":
+                    await self.session_manager.update_processing_state(session_id, False)
+            except Exception:
+                logger.exception(
+                    f"Failed to sync processing state from relayed event for session {session_id}"
+                )
         return callback
 
     def _create_stderr_callback(self, session_id: str) -> Callable:

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -5146,20 +5146,44 @@ class SessionCoordinator:
         pipeline once on its own side; doing so again here would double-write
         Hub-local storage/state that only REMOTE should own for this session.
 
-        But `is_processing` is Hub-local bookkeeping the Hub is still responsible for
-        even in REMOTE mode (see `send_message`'s REMOTE branch, and
-        `interrupt_session`'s "processing state will be reset by the message
-        processing loop" comment) — and nothing else ever resets it for a REMOTE
-        session without this hook, since that loop never runs. Mirrors
-        `_create_message_callback`'s own narrow 'result' → is_processing=False rule
-        (see its "Issue #1029: Reactive is_processing tracking" comment), applied
-        directly to the relayed envelope instead of a freshly-parsed message.
+        But some Hub-local bookkeeping the Hub is still responsible for even in
+        REMOTE mode (see `send_message`'s REMOTE branch and the "Hub still tracks
+        activity/processing state locally" design) is otherwise never updated for a
+        REMOTE session, since that pipeline never runs on the Hub side. Mirrors the
+        narrow set of `_create_message_callback` rules that maintain exactly that
+        bookkeeping (see its "Issue #1029: Reactive is_processing tracking" comment,
+        the 'interrupt_success' branch, and `_create_error_callback`'s critical-error
+        branch), applied directly to the relayed envelope instead of a
+        freshly-parsed message or a locally-raised error.
         """
         async def callback(event: dict[str, Any]) -> None:
             try:
+                # Issue #1130: every relayed event is activity, not just outbound
+                # sends — without this, a REMOTE session mid-turn on a long tool
+                # loop looks idle to the Hub's watchdog well before it actually is.
+                self.session_manager.record_activity(session_id)
+
                 data = event.get("data") if isinstance(event, dict) else None
-                if isinstance(data, dict) and data.get("type") == "result":
+                if not isinstance(data, dict):
+                    return
+                data_type = data.get("type")
+                subtype = data.get("subtype")
+
+                if data_type == "result" or (data_type == "system" and subtype == "interrupt_success"):
                     await self.session_manager.update_processing_state(session_id, False)
+                elif data_type == "system" and subtype == "session_failed":
+                    # Mirrors _create_error_callback's critical-error branch — a
+                    # runtime crash on REMOTE (not just a REMOTE-unreachable relay
+                    # failure, already handled by error_callback) must still flip
+                    # the Hub's own session_manager.state, or every Hub-local guard
+                    # reading it (interrupt, watchdog, queue gating) keeps treating
+                    # a dead REMOTE session as alive.
+                    await self.session_manager.update_processing_state(session_id, False)
+                    error_message = data.get("content") or "Session failed on REMOTE"
+                    await self.session_manager.update_session_state(
+                        session_id, SessionState.ERROR, error_message
+                    )
+                    await self._notify_state_change(session_id, SessionState.ERROR)
             except Exception:
                 logger.exception(
                     f"Failed to sync processing state from relayed event for session {session_id}"

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -1012,12 +1012,25 @@ class SessionCoordinator:
             # Add session to project
             await self.project_manager.add_session_to_project(project_id, session_id)
 
-            # Initialize storage manager for this session
-            session_dir = await self.session_manager.get_session_directory(session_id)
-            storage_manager = DataStorageManager(session_dir)
-            await storage_manager.initialize()
-            self._storage_managers[session_id] = storage_manager
-            self._apply_audit_writer(storage_manager, session_id)
+            # Initialize storage manager for this session. REMOTE-aware (issue #499):
+            # messages.jsonl only ever holds real content on REMOTE (RemoteBackend.
+            # get_messages()'s own docstring: "REMOTE is the only place a REMOTE
+            # session's messages.jsonl actually lives") — the relay pushes events
+            # straight into the in-memory EventQueue, never through
+            # DataStorageManager.append_message(), so a Hub-local copy would sit
+            # permanently empty. Creating it anyway is a second, always-stale
+            # "source of truth" for message content that risks a real bug the moment
+            # anything (a future migration/backup tool, a debugging script) reads
+            # storage directly instead of going through the coordinator/relay
+            # abstraction. state.json (via session_manager.create_session() above)
+            # is a deliberate, separate exception — the Hub genuinely needs its own
+            # copy of session state for is_processing/interrupt/watchdog guards.
+            if self.backend_mode != BackendMode.REMOTE:
+                session_dir = await self.session_manager.get_session_directory(session_id)
+                storage_manager = DataStorageManager(session_dir)
+                await storage_manager.initialize()
+                self._storage_managers[session_id] = storage_manager
+                self._apply_audit_writer(storage_manager, session_id)
 
             # Initialize callback lists
             self._message_callbacks[session_id] = []
@@ -5184,6 +5197,20 @@ class SessionCoordinator:
                         session_id, SessionState.ERROR, error_message
                     )
                     await self._notify_state_change(session_id, SessionState.ERROR)
+                elif data_type == "tool_call" and data.get("status") in (
+                    "completed", "failed", "denied", "interrupted"
+                ):
+                    # The error-rate watchdog's tool-outcome tracking (record_tool_
+                    # outcome) is otherwise fed only by ClaudeWebUI._emit_tool_call_
+                    # updates, itself only reachable via _create_message_callback's
+                    # subscriber-forwarding — bypassed for REMOTE like everything
+                    # else here. record_tool_outcome is self-contained (session_id/
+                    # tool_use_id/status only, no dependency on the Hub's own
+                    # per-session ToolCall tracking dict), so it can be fed directly
+                    # from the relayed envelope.
+                    tool_use_id = data.get("tool_use_id")
+                    if tool_use_id and hasattr(self, "_watchdog") and self._watchdog is not None:
+                        self._watchdog.record_tool_outcome(session_id, tool_use_id, data["status"])
             except Exception:
                 logger.exception(
                     f"Failed to sync processing state from relayed event for session {session_id}"

--- a/src/session_coordinator.py
+++ b/src/session_coordinator.py
@@ -2229,8 +2229,14 @@ class SessionCoordinator:
             return False
 
     async def update_session_name(self, session_id: str, name: str) -> bool:
-        """Update session name"""
+        """Update session name, relaying to REMOTE if this session is dispatched
+        there (issue #499) — otherwise REMOTE's persisted name silently diverges
+        from the Hub's, same as any other session config."""
         try:
+            if self.backend_mode == BackendMode.REMOTE:
+                if not await self.backend.update_session_name(session_id, name):
+                    logger.warning(f"Failed to relay session name to REMOTE for {session_id}")
+                    return False
             success = await self.session_manager.update_session_name(session_id, name)
             if success:
                 # Notify about state change to trigger UI updates
@@ -2242,6 +2248,30 @@ class SessionCoordinator:
         except Exception:
             logger.exception(f"Failed to update session {session_id} name")
             return False
+
+    async def update_session_config(
+        self, session_id: str, updates: dict[str, Any], raw_payload: dict[str, Any]
+    ) -> bool:
+        """Apply a PATCH /api/sessions/{id} config update, and relay it to REMOTE if
+        this session is dispatched there (issue #499).
+
+        Without the relay, REMOTE only ever sees the config it got from
+        `create_session()`'s creation-time dump — any later edit (model, tools,
+        extra_env, MCP servers, ...) would silently only update the Hub's own unused
+        local copy, never reaching the process actually running the SDK. `updates` is
+        the already-transformed dict for the local `session_manager` write (matching
+        every other caller of `session_manager.update_session`); `raw_payload` is the
+        untransformed client request body, relayed as-is so REMOTE's own router
+        applies the identical field-transform logic itself rather than this side
+        reimplementing it.
+        """
+        if self.backend_mode == BackendMode.REMOTE:
+            if not await self.backend.update_session_config(session_id, raw_payload):
+                logger.warning(f"Failed to relay session config update to REMOTE for {session_id}")
+                return False
+        return await self.session_manager.update_session(
+            session_id, template_manager=self.template_manager, **updates
+        )
 
     async def delete_session(self, session_id: str, archive_reason: str = "user_deleted") -> dict:
         """
@@ -2680,8 +2710,16 @@ class SessionCoordinator:
                 logger.warning(f"Session {session_id} not found - cannot set permission mode")
                 return False
 
-            # For non-running sessions, just persist to disk — the mode will be applied at startup
+            # For non-running sessions, just persist to disk — the mode will be applied at startup.
+            # Issue #499: relay to REMOTE first (if dispatched there) so its own persisted config
+            # stays in sync too — REMOTE only ever saw creation-time config otherwise.
             if session_info.state in STOPPED_STATES:
+                if self.backend_mode == BackendMode.REMOTE:
+                    if not await self.backend.set_permission_mode(session_id, mode):
+                        logger.warning(
+                            f"Failed to relay permission mode to REMOTE for stopped session {session_id}"
+                        )
+                        return False
                 await self.session_manager.update_permission_mode(
                     session_id, mode, template_manager=self.template_manager
                 )
@@ -2735,8 +2773,16 @@ class SessionCoordinator:
                 logger.warning(f"Session {session_id} not found - cannot set model")
                 return False
 
-            # For non-running sessions, just persist to disk — the model will be applied at startup
+            # For non-running sessions, just persist to disk — the model will be applied at startup.
+            # Issue #499: relay to REMOTE first (if dispatched there) so its own persisted config
+            # stays in sync too — REMOTE only ever saw creation-time config otherwise.
             if session_info.state in STOPPED_STATES:
+                if self.backend_mode == BackendMode.REMOTE:
+                    if not await self.backend.set_model(session_id, model):
+                        logger.warning(
+                            f"Failed to relay model to REMOTE for stopped session {session_id}"
+                        )
+                        return False
                 await self.session_manager.update_model(
                     session_id, model, template_manager=self.template_manager
                 )

--- a/src/tests/test_application_service.py
+++ b/src/tests/test_application_service.py
@@ -36,6 +36,7 @@ def mock_coordinator():
     coordinator.session_manager.get_sessions_by_ids = AsyncMock()
     coordinator.session_manager.update_session = AsyncMock()
     coordinator.session_manager.reorder_sessions = AsyncMock()
+    coordinator.update_session_config = AsyncMock()
 
     coordinator.mcp_config_manager.list_configs = AsyncMock()
     coordinator.mcp_config_manager.create_config = AsyncMock()
@@ -301,17 +302,14 @@ async def test_delete_session_no_project_field_when_session_has_no_project(servi
 
 
 @pytest.mark.asyncio
-async def test_update_session_delegates_to_session_manager(service, mock_coordinator):
-    mock_coordinator.session_manager.update_session.return_value = True
+async def test_update_session_delegates_to_coordinator(service, mock_coordinator):
+    mock_coordinator.update_session_config.return_value = True
 
-    result = await service.update_session("s1", name="new name", model="sonnet")
+    updates = {"name": "new name", "model": "sonnet"}
+    raw_payload = {"name": "new name", "model": "sonnet"}
+    result = await service.update_session("s1", updates, raw_payload)
 
-    mock_coordinator.session_manager.update_session.assert_called_once_with(
-        "s1",
-        template_manager=mock_coordinator.template_manager,
-        name="new name",
-        model="sonnet",
-    )
+    mock_coordinator.update_session_config.assert_called_once_with("s1", updates, raw_payload)
     assert result is True
 
 

--- a/src/tests/test_backend_mount.py
+++ b/src/tests/test_backend_mount.py
@@ -4,10 +4,11 @@ Asserts genuine mutual exclusivity: a frontend-mode Hub never registers
 /api/backend/*, and a headless-mode instance never registers /api/* or serves the
 UI — 404s prove the routes were never registered, not just rejected by auth.
 
-Session-domain routers (poll, session_runtime, sessions) are the only routers
-mirrored under /api/backend so far (issue #498 Batch 1) — other relay-eligible
-routers (projects, queue, mcp, ...) join this mirror incrementally in later
-batches, per routers/__init__.py's _RELAY_ELIGIBLE_MODULES.
+All relay-eligible routers listed in routers/__init__.py's _RELAY_ELIGIBLE_MODULES
+are mirrored under /api/backend (issue #498/#499). /health and /health/ready
+(issue #499) are the sole exception to the "headless mounts only /api/backend/*"
+rule — they're registered unprefixed and unauthenticated on both mounts so
+orchestrator probes can reach them without a bearer token.
 """
 
 import pytest
@@ -64,6 +65,68 @@ async def test_headless_mode_misconfigured_token_refuses_everything(tmp_path):
             "/api/backend/sessions", headers={"Authorization": "Bearer anything"}
         )
     assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_headless_mode_health_endpoints_reachable_without_bearer_token(tmp_path):
+    """GET /health and /health/ready must be reachable in headless mode with no
+    Authorization header — orchestrator probes carry no bearer token."""
+    webui = ClaudeWebUI(
+        data_dir=tmp_path / "data", backend_mode="headless", backend_auth_token="secret-token"
+    )
+    try:
+        await webui.initialize()
+        async with AsyncClient(transport=ASGITransport(app=webui.app), base_url="http://test") as client:
+            health = await client.get("/health")
+            ready = await client.get("/health/ready")
+        assert health.status_code == 200
+        assert health.json()["status"] == "healthy"
+        assert ready.status_code == 200
+        assert ready.json()["status"] == "ready"
+    finally:
+        await webui.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_headless_mode_readiness_503_before_initialize(tmp_path):
+    """/health/ready 503s before initialize() completes; /health (liveness) is 200
+    regardless — liveness is independent of readiness."""
+    webui = ClaudeWebUI(
+        data_dir=tmp_path / "data", backend_mode="headless", backend_auth_token="secret-token"
+    )
+    async with AsyncClient(transport=ASGITransport(app=webui.app), base_url="http://test") as client:
+        health = await client.get("/health")
+        ready = await client.get("/health/ready")
+    assert health.status_code == 200
+    assert ready.status_code == 503
+    assert ready.json()["status"] == "not_ready"
+
+
+@pytest.mark.asyncio
+async def test_frontend_mode_health_endpoints_reachable_without_bearer_token(tmp_path):
+    """Parity with headless mode: /health and /health/ready are exempt from
+    AuthMiddleware and reachable with no token in frontend mode too."""
+    webui = ClaudeWebUI(data_dir=tmp_path / "data", auth_enabled=True, auth_token="op-token")
+    try:
+        await webui.initialize()
+        async with AsyncClient(transport=ASGITransport(app=webui.app), base_url="http://test") as client:
+            health = await client.get("/health")
+            ready = await client.get("/health/ready")
+        assert health.status_code == 200
+        assert ready.status_code == 200
+        assert ready.json()["status"] == "ready"
+    finally:
+        await webui.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_frontend_mode_readiness_503_before_initialize(tmp_path):
+    webui = ClaudeWebUI(data_dir=tmp_path / "data", auth_enabled=True, auth_token="op-token")
+    async with AsyncClient(transport=ASGITransport(app=webui.app), base_url="http://test") as client:
+        health = await client.get("/health")
+        ready = await client.get("/health/ready")
+    assert health.status_code == 200
+    assert ready.status_code == 503
 
 
 @pytest.mark.asyncio

--- a/src/tests/test_issue_499_session_config_relay.py
+++ b/src/tests/test_issue_499_session_config_relay.py
@@ -1,0 +1,188 @@
+"""Regression tests for issue #499's session-config relay fix.
+
+Before this fix, `PATCH /api/sessions/{id}` (and the sibling name/permission-mode/
+model endpoints) only ever mutated the Hub's own local `session_manager` — never
+relayed to a REMOTE backend. A session dispatched to REMOTE would silently only ever
+run with whatever config it got at creation time; any later edit (model, tools,
+extra_env credentials, MCP servers, ...) would appear to succeed on the Hub while
+REMOTE's actual persisted config silently diverged. This is exactly the gap that left
+a live REMOTE-dispatched minion unable to authenticate: an operator added
+`CLAUDE_CODE_OAUTH_TOKEN` to an existing session's `extra_env` via the Configuration
+Modal, and REMOTE never received it.
+
+Same two-in-process-ClaudeWebUI-instances-over-ASGITransport pattern as
+test_batch2_relay.py — a real headless ClaudeWebUI stands in for REMOTE.
+"""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from ..remote_backend import RemoteBackend
+from ..session_backend import BackendMode
+from ..web_server import ClaudeWebUI
+
+REMOTE_TOKEN = "remote-test-token-499"
+
+
+def _make_remote(tmp_path):
+    return ClaudeWebUI(
+        data_dir=tmp_path / "remote_data",
+        backend_mode="headless",
+        backend_auth_token=REMOTE_TOKEN,
+    )
+
+
+def _wire_hub_to_remote(hub: ClaudeWebUI, remote: ClaudeWebUI) -> None:
+    backend = RemoteBackend("http://remote.test", REMOTE_TOKEN, hub.session_queues)
+    backend._client = AsyncClient(
+        base_url="http://remote.test/api/backend",
+        headers={"Authorization": f"Bearer {REMOTE_TOKEN}"},
+        transport=ASGITransport(app=remote.app),
+    )
+    hub.coordinator.backend = backend
+    hub.coordinator.backend_mode = BackendMode.REMOTE
+
+
+async def _create_remote_session(client: AsyncClient, tmp_path) -> tuple[str, str]:
+    project_resp = await client.post(
+        "/api/projects", json={"name": "cfg-relay-project", "working_directory": str(tmp_path)}
+    )
+    assert project_resp.status_code == 200, project_resp.text
+    project_id = project_resp.json()["project"]["project_id"]
+
+    session_resp = await client.post(
+        "/api/sessions", json={"project_id": project_id, "session_id": "cfg-relay-session"}
+    )
+    assert session_resp.status_code == 200, session_resp.text
+    return project_id, session_resp.json()["session_id"]
+
+
+@pytest.mark.asyncio
+async def test_patch_session_config_relays_extra_env_to_remote(tmp_path):
+    remote = _make_remote(tmp_path)
+    (remote.coordinator.data_dir / "projects").mkdir(parents=True, exist_ok=True)
+    (remote.coordinator.data_dir / "sessions").mkdir(parents=True, exist_ok=True)
+    hub = ClaudeWebUI(data_dir=tmp_path / "hub_data")
+    (hub.coordinator.data_dir / "sessions").mkdir(parents=True, exist_ok=True)
+    _wire_hub_to_remote(hub, remote)
+
+    async with AsyncClient(transport=ASGITransport(app=hub.app), base_url="http://test") as client:
+        _, session_id = await _create_remote_session(client, tmp_path)
+
+        # Config change made AFTER creation — this is exactly the case that used to
+        # silently vanish: only session-creation config reached REMOTE. extra_env has
+        # no dedicated flat field on SessionUpdateRequest, so the Configuration Modal
+        # sends it via the wholesale "config" dict replacement (issue #1230) — the
+        # actual path that carried a real operator's CLAUDE_CODE_OAUTH_TOKEN nowhere.
+        patch_resp = await client.patch(
+            f"/api/sessions/{session_id}",
+            json={
+                "config": {
+                    "model": "opus",
+                    "extra_env": {"CLAUDE_CODE_OAUTH_TOKEN": "secret-token"},
+                }
+            },
+        )
+    assert patch_resp.status_code == 200, patch_resp.text
+    assert patch_resp.json()["success"] is True
+
+    remote_info = await remote.coordinator.session_manager.get_session_info(session_id)
+    assert remote_info is not None
+    assert remote_info.config.get("model") == "opus"
+    assert remote_info.config.get("extra_env") == {"CLAUDE_CODE_OAUTH_TOKEN": "secret-token"}
+
+    # Hub's own local copy stays in sync too (existing Batch-1 bookkeeping behavior).
+    hub_info = await hub.coordinator.session_manager.get_session_info(session_id)
+    assert hub_info.config.get("model") == "opus"
+
+
+@pytest.mark.asyncio
+async def test_patch_session_config_not_relayed_in_local_mode(tmp_path):
+    """Sanity check: LOCAL mode's existing behavior is unchanged — no REMOTE involved."""
+    hub = ClaudeWebUI(data_dir=tmp_path / "hub_data_local")
+    (hub.coordinator.data_dir / "projects").mkdir(parents=True, exist_ok=True)
+    (hub.coordinator.data_dir / "sessions").mkdir(parents=True, exist_ok=True)
+
+    async with AsyncClient(transport=ASGITransport(app=hub.app), base_url="http://test") as client:
+        project_resp = await client.post(
+            "/api/projects", json={"name": "local-project", "working_directory": str(tmp_path)}
+        )
+        project_id = project_resp.json()["project"]["project_id"]
+        session_resp = await client.post(
+            "/api/sessions", json={"project_id": project_id, "session_id": "local-session"}
+        )
+        session_id = session_resp.json()["session_id"]
+
+        patch_resp = await client.patch(
+            f"/api/sessions/{session_id}", json={"model": "opus"}
+        )
+    assert patch_resp.status_code == 200, patch_resp.text
+
+    info = await hub.coordinator.session_manager.get_session_info(session_id)
+    assert info.config.get("model") == "opus"
+
+
+@pytest.mark.asyncio
+async def test_session_name_update_relays_to_remote(tmp_path):
+    remote = _make_remote(tmp_path)
+    (remote.coordinator.data_dir / "projects").mkdir(parents=True, exist_ok=True)
+    (remote.coordinator.data_dir / "sessions").mkdir(parents=True, exist_ok=True)
+    hub = ClaudeWebUI(data_dir=tmp_path / "hub_data_name")
+    (hub.coordinator.data_dir / "sessions").mkdir(parents=True, exist_ok=True)
+    _wire_hub_to_remote(hub, remote)
+
+    async with AsyncClient(transport=ASGITransport(app=hub.app), base_url="http://test") as client:
+        _, session_id = await _create_remote_session(client, tmp_path)
+
+        name_resp = await client.put(
+            f"/api/sessions/{session_id}/name", json={"name": "renamed-on-remote"}
+        )
+    assert name_resp.status_code == 200, name_resp.text
+
+    remote_info = await remote.coordinator.session_manager.get_session_info(session_id)
+    assert remote_info.name == "renamed-on-remote"
+
+
+@pytest.mark.asyncio
+async def test_set_permission_mode_on_stopped_remote_session_relays(tmp_path):
+    """A session that hasn't been started yet is in a STOPPED_STATE — the
+    persist-only branch of set_permission_mode used to skip the REMOTE relay
+    entirely."""
+    remote = _make_remote(tmp_path)
+    (remote.coordinator.data_dir / "projects").mkdir(parents=True, exist_ok=True)
+    (remote.coordinator.data_dir / "sessions").mkdir(parents=True, exist_ok=True)
+    hub = ClaudeWebUI(data_dir=tmp_path / "hub_data_permmode")
+    (hub.coordinator.data_dir / "sessions").mkdir(parents=True, exist_ok=True)
+    _wire_hub_to_remote(hub, remote)
+
+    async with AsyncClient(transport=ASGITransport(app=hub.app), base_url="http://test") as client:
+        _, session_id = await _create_remote_session(client, tmp_path)
+
+        resp = await client.post(
+            f"/api/sessions/{session_id}/permission-mode", json={"mode": "plan"}
+        )
+    assert resp.status_code == 200, resp.text
+
+    remote_info = await remote.coordinator.session_manager.get_session_info(session_id)
+    assert remote_info.config.get("permission_mode") == "plan"
+
+
+@pytest.mark.asyncio
+async def test_set_model_on_stopped_remote_session_relays(tmp_path):
+    remote = _make_remote(tmp_path)
+    (remote.coordinator.data_dir / "projects").mkdir(parents=True, exist_ok=True)
+    (remote.coordinator.data_dir / "sessions").mkdir(parents=True, exist_ok=True)
+    hub = ClaudeWebUI(data_dir=tmp_path / "hub_data_model")
+    (hub.coordinator.data_dir / "sessions").mkdir(parents=True, exist_ok=True)
+    _wire_hub_to_remote(hub, remote)
+
+    async with AsyncClient(transport=ASGITransport(app=hub.app), base_url="http://test") as client:
+        _, session_id = await _create_remote_session(client, tmp_path)
+
+        resp = await client.post(
+            f"/api/sessions/{session_id}/model", json={"model": "opus"}
+        )
+    assert resp.status_code == 200, resp.text
+
+    remote_info = await remote.coordinator.session_manager.get_session_info(session_id)
+    assert remote_info.config.get("model") == "opus"

--- a/src/tests/test_issue_499_ui_relay.py
+++ b/src/tests/test_issue_499_ui_relay.py
@@ -1,0 +1,140 @@
+"""Regression tests for issue #499's missing /poll/ui relay.
+
+Before this fix, RemoteBackend relayed /poll/session/{id} (per-session) and
+/poll/audit (global, single shared connection) but never /poll/ui — the *global*
+UI event stream. Anything broadcast into ui_queue (session PAUSED-for-permission
+state via _notify_state_change, rate-limit updates, watchdog alerts, SDK-driven
+permission-mode changes, Legion comm/schedule notifications) only ever reached
+REMOTE's own local ui_queue, which the Hub never polled. Mirrors the existing
+audit-relay tests (test_batch5_audit_relay.py) pattern.
+"""
+
+import asyncio
+
+import httpx
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from ..event_queue import EventQueue
+from ..remote_backend import RemoteBackend
+from ..session_backend import BackendMode
+from ..web_server import ClaudeWebUI
+
+REMOTE_TOKEN = "remote-test-token-499-ui"
+
+
+def _make_remote(tmp_path):
+    return ClaudeWebUI(
+        data_dir=tmp_path / "remote_data", backend_mode="headless", backend_auth_token=REMOTE_TOKEN
+    )
+
+
+def _wire_hub_to_remote(hub: ClaudeWebUI, remote: ClaudeWebUI) -> None:
+    backend = RemoteBackend("http://remote.test", REMOTE_TOKEN, hub.session_queues)
+    backend._client = AsyncClient(
+        base_url="http://remote.test/api/backend",
+        headers={"Authorization": f"Bearer {REMOTE_TOKEN}"},
+        transport=ASGITransport(app=remote.app),
+    )
+    hub.coordinator.backend = backend
+    hub.coordinator.backend_mode = BackendMode.REMOTE
+
+
+@pytest.mark.asyncio
+async def test_start_ui_relay_buffers_remote_events_into_local_queue():
+    """The background relay task itself: long-polls REMOTE's /poll/ui and appends
+    each returned event into the Hub-local ui_queue."""
+    call_count = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/backend/poll/ui"
+        assert "since" in request.url.params
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return httpx.Response(
+                200,
+                json={
+                    "events": [{"type": "session_state_change", "data": {"state": "paused"}}],
+                    "next_cursor": 1,
+                },
+            )
+        return httpx.Response(200, json={"events": [], "next_cursor": 1})
+
+    backend = RemoteBackend("http://remote.test", "tok", {})
+    backend._client = httpx.AsyncClient(
+        base_url="http://remote.test/api/backend", transport=httpx.MockTransport(handler)
+    )
+
+    queue = EventQueue()
+    await backend.start_ui_relay(queue)
+    try:
+        for _ in range(50):
+            if queue.current_cursor > 0:
+                break
+            await asyncio.sleep(0.01)
+        events, cursor = queue.events_since(0)
+        assert cursor == 1
+        assert events == [{"type": "session_state_change", "data": {"state": "paused"}}]
+    finally:
+        await backend.aclose()
+
+
+@pytest.mark.asyncio
+async def test_start_ui_relay_is_idempotent():
+    """Calling start_ui_relay twice must not spawn a second background task."""
+    backend = RemoteBackend("http://remote.test", "tok", {})
+    backend._client = httpx.AsyncClient(
+        base_url="http://remote.test/api/backend",
+        transport=httpx.MockTransport(lambda r: httpx.Response(200, json={"events": [], "next_cursor": 0})),
+    )
+    queue = EventQueue()
+    await backend.start_ui_relay(queue)
+    first_task = backend._ui_relay_task
+    await backend.start_ui_relay(queue)
+    assert backend._ui_relay_task is first_task
+    await backend.aclose()
+
+
+@pytest.mark.asyncio
+async def test_ui_relay_delivers_remote_broadcast_events_end_to_end(tmp_path):
+    """Full round trip: an event landing in REMOTE's real ui_queue (e.g. a session
+    PAUSED state-change broadcast) must reach the Hub's own ui_queue through the
+    relay, not just a MockTransport."""
+    remote = _make_remote(tmp_path)
+    hub = ClaudeWebUI(data_dir=tmp_path / "hub_data")
+    _wire_hub_to_remote(hub, remote)
+
+    remote.ui_queue.append({"type": "session_state_change", "data": {"state": "paused"}})
+
+    await hub.coordinator.backend.start_ui_relay(hub.ui_queue)
+    try:
+        for _ in range(50):
+            if hub.ui_queue.current_cursor > 0:
+                break
+            await asyncio.sleep(0.01)
+        events, cursor = hub.ui_queue.events_since(0)
+        assert cursor == 1
+        assert events == [{"type": "session_state_change", "data": {"state": "paused"}}]
+    finally:
+        await hub.coordinator.backend.aclose()
+
+
+@pytest.mark.asyncio
+async def test_initialize_starts_ui_relay_when_backend_mode_remote(tmp_path):
+    """ClaudeWebUI.initialize() must start the UI relay whenever session dispatch
+    is REMOTE — the same trigger condition as the existing audit relay."""
+    hub = ClaudeWebUI(
+        data_dir=tmp_path / "hub_data_init",
+        remote_backend_url="http://remote.test",
+        remote_backend_token="tok",
+    )
+    hub.coordinator.backend._client = httpx.AsyncClient(
+        base_url="http://remote.test/api/backend",
+        transport=httpx.MockTransport(lambda r: httpx.Response(200, json={"events": [], "next_cursor": 0})),
+    )
+    try:
+        await hub.initialize()
+        assert hub.coordinator.backend._ui_relay_task is not None
+        assert not hub.coordinator.backend._ui_relay_task.done()
+    finally:
+        await hub.cleanup()

--- a/src/tests/test_issue_499_usage_relay.py
+++ b/src/tests/test_issue_499_usage_relay.py
@@ -1,0 +1,119 @@
+"""Regression test for issue #499's /usage relay fix.
+
+GET /api/sessions/{id}/usage previously read only the Hub's own local
+analytics_store unconditionally — but usage rows only ever get written inside
+SessionCoordinator._create_message_callback's 'result' handling, which never
+runs on the Hub for a REMOTE-dispatched session (the relay bypasses it
+entirely). So the endpoint 404'd "No usage data for this session" permanently
+for every REMOTE session, regardless of how many turns REMOTE actually ran.
+
+Same two-in-process-ClaudeWebUI-instances-over-ASGITransport pattern as
+test_batch2_relay.py — a real headless ClaudeWebUI stands in for REMOTE.
+"""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from ..remote_backend import RemoteBackend
+from ..session_backend import BackendMode
+from ..web_server import ClaudeWebUI
+
+REMOTE_TOKEN = "remote-test-token-499-usage"
+
+
+def _make_remote(tmp_path):
+    return ClaudeWebUI(
+        data_dir=tmp_path / "remote_data", backend_mode="headless", backend_auth_token=REMOTE_TOKEN
+    )
+
+
+def _wire_hub_to_remote(hub: ClaudeWebUI, remote: ClaudeWebUI) -> None:
+    backend = RemoteBackend("http://remote.test", REMOTE_TOKEN, hub.session_queues)
+    backend._client = AsyncClient(
+        base_url="http://remote.test/api/backend",
+        headers={"Authorization": f"Bearer {REMOTE_TOKEN}"},
+        transport=ASGITransport(app=remote.app),
+    )
+    hub.coordinator.backend = backend
+    hub.coordinator.backend_mode = BackendMode.REMOTE
+
+
+@pytest.mark.asyncio
+async def test_usage_relays_to_remote_and_recomputes_cost_with_hub_pricing(tmp_path):
+    remote = _make_remote(tmp_path)
+    (remote.coordinator.data_dir / "projects").mkdir(parents=True, exist_ok=True)
+    (remote.coordinator.data_dir / "sessions").mkdir(parents=True, exist_ok=True)
+    hub = ClaudeWebUI(data_dir=tmp_path / "hub_data")
+    (hub.coordinator.data_dir / "sessions").mkdir(parents=True, exist_ok=True)
+    _wire_hub_to_remote(hub, remote)
+
+    async with AsyncClient(transport=ASGITransport(app=hub.app), base_url="http://test") as client:
+        project_resp = await client.post(
+            "/api/projects", json={"name": "usage-relay-project", "working_directory": str(tmp_path)}
+        )
+        assert project_resp.status_code == 200, project_resp.text
+        project_id = project_resp.json()["project"]["project_id"]
+
+        session_resp = await client.post(
+            "/api/sessions", json={"project_id": project_id, "session_id": "usage-relay-session"}
+        )
+        assert session_resp.status_code == 200, session_resp.text
+        session_id = session_resp.json()["session_id"]
+
+        # Usage data only ever gets recorded on REMOTE (this is what
+        # _create_message_callback's 'result' handling would have done, had it run
+        # on REMOTE for a real turn) — the Hub's own analytics_store never gets a row.
+        # analytics_store is normally wired up by initialize()'s audit subsystem
+        # section; wire it directly here rather than paying for a full initialize().
+        await remote.analytics_db.initialize()
+        remote.coordinator.set_analytics_store(remote.analytics_store)
+        await remote.coordinator.analytics_store.record_turn(
+            session_id,
+            turn_seq=1,
+            model="claude-sonnet-5",
+            usage={
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0,
+            },
+            sdk_total_cost_usd=0.0,
+        )
+
+        response = await client.get(f"/api/sessions/{session_id}/usage")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["turn_count"] == 1
+    assert body["input_tokens"] == 100
+    assert body["output_tokens"] == 50
+    assert body["model"] == "claude-sonnet-5"
+    # The Hub's own analytics_store is never even wired up in this test (only
+    # REMOTE's is) — a 200 with correct data here is only possible if the
+    # response actually came from REMOTE via the relay, not a Hub-local read
+    # (which would 500 on a None analytics_store instead).
+    assert hub.coordinator.analytics_store is None
+
+
+@pytest.mark.asyncio
+async def test_usage_404s_when_remote_has_no_data(tmp_path):
+    remote = _make_remote(tmp_path)
+    (remote.coordinator.data_dir / "projects").mkdir(parents=True, exist_ok=True)
+    (remote.coordinator.data_dir / "sessions").mkdir(parents=True, exist_ok=True)
+    hub = ClaudeWebUI(data_dir=tmp_path / "hub_data_404")
+    (hub.coordinator.data_dir / "sessions").mkdir(parents=True, exist_ok=True)
+    _wire_hub_to_remote(hub, remote)
+
+    async with AsyncClient(transport=ASGITransport(app=hub.app), base_url="http://test") as client:
+        project_resp = await client.post(
+            "/api/projects", json={"name": "usage-404-project", "working_directory": str(tmp_path)}
+        )
+        project_id = project_resp.json()["project"]["project_id"]
+        session_resp = await client.post(
+            "/api/sessions", json={"project_id": project_id, "session_id": "usage-404-session"}
+        )
+        session_id = session_resp.json()["session_id"]
+
+        response = await client.get(f"/api/sessions/{session_id}/usage")
+
+    assert response.status_code == 404

--- a/src/tests/test_main_entrypoint.py
+++ b/src/tests/test_main_entrypoint.py
@@ -84,3 +84,27 @@ def test_main_entrypoint_subprocess_smoke(tmp_path: Path):
         except subprocess.TimeoutExpired:
             proc.kill()
             proc.wait(timeout=5)
+
+
+def test_remote_backend_token_without_url_rejected_by_argparse(tmp_path: Path):
+    """--remote-backend-token requires --remote-backend-url (issue #499) — argparse
+    must reject the combination before the server ever starts."""
+    env = os.environ.copy()
+    env.pop("CLAUDECODE", None)
+
+    proc = subprocess.run(
+        [
+            "uv", "run", "python", "main.py",
+            "--data-dir", str(tmp_path),
+            "--no-auth",
+            "--remote-backend-token", "some-token",
+        ],
+        cwd=str(REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+    assert proc.returncode != 0
+    assert "--remote-backend-token requires --remote-backend-url" in proc.stderr

--- a/src/tests/test_remote_backend.py
+++ b/src/tests/test_remote_backend.py
@@ -144,6 +144,82 @@ async def test_start_session_success_spawns_relay_loop_that_forwards_events():
 
 
 @pytest.mark.asyncio
+async def test_restart_resumes_relay_from_last_cursor_instead_of_refetching_backlog():
+    """Regression test: restarting a session (disconnect_session then start_session
+    again, exactly what SessionCoordinator.restart_session does) must resume the
+    relay poll loop from where it left off, not re-fetch REMOTE's entire event
+    backlog from since=0 — the latter duplicates every past message in the Hub's
+    local EventQueue (and therefore the frontend) on every restart."""
+    queue = EventQueue()
+    seen_since_values = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path in ("/api/backend/sessions/s1/start", "/api/backend/sessions/s1/disconnect"):
+            return httpx.Response(200)
+        if request.url.path == "/api/backend/poll/session/s1":
+            since = int(request.url.params["since"])
+            seen_since_values.append(since)
+            if since == 0:
+                return httpx.Response(
+                    200, json={"events": [{"type": "message", "data": {"x": 1}}], "next_cursor": 3}
+                )
+            # Any poll after the first should keep resuming from cursor 3 onward —
+            # no new events queued in this test, just confirming "since" never
+            # drops back to 0 on the second relay loop.
+            return httpx.Response(200, json={"events": [], "next_cursor": 3})
+
+        raise AssertionError(f"unexpected path {request.url.path}")
+
+    backend = _backend_with_handler(handler, session_queues={"s1": queue})
+
+    started, _ = await backend.start_session("s1")
+    assert started is True
+    for _ in range(50):
+        if 0 in seen_since_values:
+            break
+        await asyncio.sleep(0.01)
+    assert 0 in seen_since_values
+
+    # Restart: disconnect (tears down the relay task) then start again — the exact
+    # sequence SessionCoordinator.restart_session() performs.
+    await backend.disconnect_session("s1")
+    assert "s1" not in backend._relay_tasks
+    assert backend._relay_cursors["s1"] == 3
+
+    seen_since_values.clear()
+    started, _ = await backend.start_session("s1")
+    assert started is True
+    for _ in range(50):
+        if seen_since_values:
+            break
+        await asyncio.sleep(0.01)
+
+    assert seen_since_values, "relay loop never polled after restart"
+    assert 0 not in seen_since_values, (
+        f"restart re-fetched from since=0 instead of resuming from cursor 3: {seen_since_values}"
+    )
+    assert all(v == 3 for v in seen_since_values)
+
+    await backend.aclose()
+
+
+@pytest.mark.asyncio
+async def test_terminate_clears_relay_cursor():
+    """Unlike disconnect (restart), a genuine terminate should drop the cursor —
+    nothing will resume this session's relay."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200)
+
+    backend = _backend_with_handler(handler, session_queues={"s1": EventQueue()})
+    backend._relay_cursors["s1"] = 7
+
+    await backend.terminate_session("s1")
+
+    assert "s1" not in backend._relay_cursors
+
+
+@pytest.mark.asyncio
 async def test_relay_loop_gives_up_after_max_failures_and_calls_error_callback(monkeypatch):
     # Real backoff (2s, 4s, 8s, 16s, 30s for 5 failures) would make this test slow —
     # lower the failure threshold instead of touching sleep timing, so only the

--- a/src/tests/test_remote_backend.py
+++ b/src/tests/test_remote_backend.py
@@ -144,6 +144,50 @@ async def test_start_session_success_spawns_relay_loop_that_forwards_events():
 
 
 @pytest.mark.asyncio
+async def test_relay_loop_invokes_on_relay_event_for_each_event():
+    """The relay poll loop must invoke on_relay_event for every relayed event,
+    independent of whether a session_queue exists — this is the hook
+    SessionCoordinator uses to reset is_processing for REMOTE sessions, since the
+    relay bypasses _create_message_callback's own reset logic entirely (issue #499)."""
+    seen_events = []
+
+    async def on_relay_event(event):
+        seen_events.append(event)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/backend/sessions/s1/start":
+            return httpx.Response(200)
+        if request.url.path == "/api/backend/poll/session/s1":
+            since = int(request.url.params["since"])
+            if since == 0:
+                return httpx.Response(
+                    200,
+                    json={
+                        "events": [
+                            {"type": "message", "data": {"type": "assistant"}},
+                            {"type": "message", "data": {"type": "result"}},
+                        ],
+                        "next_cursor": 2,
+                    },
+                )
+            return httpx.Response(200, json={"events": [], "next_cursor": 2})
+        raise AssertionError(f"unexpected path {request.url.path}")
+
+    backend = _backend_with_handler(handler, session_queues={"s1": EventQueue()})
+
+    started, _ = await backend.start_session("s1", on_relay_event=on_relay_event)
+    assert started is True
+    for _ in range(50):
+        if len(seen_events) >= 2:
+            break
+        await asyncio.sleep(0.01)
+
+    assert [e["data"]["type"] for e in seen_events] == ["assistant", "result"]
+
+    await backend.aclose()
+
+
+@pytest.mark.asyncio
 async def test_restart_resumes_relay_from_last_cursor_instead_of_refetching_backlog():
     """Regression test: restarting a session (disconnect_session then start_session
     again, exactly what SessionCoordinator.restart_session does) must resume the

--- a/src/tests/test_remote_backend.py
+++ b/src/tests/test_remote_backend.py
@@ -1,12 +1,15 @@
 """Unit tests for RemoteBackend (issue #498) against a mocked httpx transport."""
 
 import asyncio
+import json
 
 import httpx
 import pytest
 
 from ..event_queue import EventQueue
 from ..remote_backend import RemoteBackend
+from ..session_backend import BackendMode
+from ..web_server import ClaudeWebUI
 
 
 def _backend_with_handler(handler, session_queues=None):
@@ -191,3 +194,84 @@ async def test_terminate_session_stops_relay_and_relays_call():
     assert "s1" not in backend._active_session_ids
     assert "s1" not in backend._relay_tasks
     assert "/api/backend/sessions/s1/terminate" in calls
+
+
+# ----------------------------------------------------------------------------
+# --remote-backend-url / --remote-backend-token CLI wiring (issue #499)
+# ----------------------------------------------------------------------------
+
+
+def test_cli_remote_backend_url_wires_remote_without_config_file(tmp_path):
+    """--remote-backend-url alone (no config file involved) results in
+    coordinator.backend_mode == REMOTE with the CLI-supplied URL/token."""
+    webui = ClaudeWebUI(
+        data_dir=tmp_path / "data",
+        remote_backend_url="http://cli-remote.example",
+        remote_backend_token="cli-token",
+    )
+    assert webui.coordinator.backend_mode == BackendMode.REMOTE
+    assert isinstance(webui.coordinator.backend, RemoteBackend)
+    assert webui.coordinator.backend._base_url == "http://cli-remote.example"
+    assert webui.coordinator.backend._client.headers["authorization"] == "Bearer cli-token"
+
+
+def test_cli_remote_backend_url_wins_wholesale_over_config_file(tmp_path):
+    """A CLI-supplied --remote-backend-url replaces the config-file URL+token pair
+    wholesale, rather than pairing the new URL with a stale config-file token."""
+    config_file = tmp_path / "config.json"
+    config_file.write_text(json.dumps({
+        "backend": {
+            "mode": "frontend",
+            "remote_base_url": "http://config-file-remote.example",
+            "remote_auth_token": "config-file-token",
+        },
+    }))
+
+    webui = ClaudeWebUI(
+        data_dir=tmp_path / "data",
+        config_file=config_file,
+        remote_backend_url="http://cli-remote.example",
+        remote_backend_token="cli-token",
+    )
+    assert webui.coordinator.backend_mode == BackendMode.REMOTE
+    assert webui.coordinator.backend._base_url == "http://cli-remote.example"
+    assert webui.coordinator.backend._client.headers["authorization"] == "Bearer cli-token"
+
+
+def test_cli_remote_backend_url_without_token_does_not_inherit_config_file_token(tmp_path):
+    """CLI URL with no CLI token must not silently pair with the config file's token
+    for a (potentially different) remote — the pair is replaced wholesale."""
+    config_file = tmp_path / "config.json"
+    config_file.write_text(json.dumps({
+        "backend": {
+            "mode": "frontend",
+            "remote_base_url": "http://config-file-remote.example",
+            "remote_auth_token": "config-file-token",
+        },
+    }))
+
+    webui = ClaudeWebUI(
+        data_dir=tmp_path / "data",
+        config_file=config_file,
+        remote_backend_url="http://cli-remote.example",
+    )
+    assert webui.coordinator.backend_mode == BackendMode.REMOTE
+    assert webui.coordinator.backend._base_url == "http://cli-remote.example"
+    assert webui.coordinator.backend._client.headers["authorization"] == "Bearer "
+
+
+def test_no_cli_remote_backend_url_falls_back_to_config_file_pair(tmp_path):
+    """With no CLI override, the config file's REMOTE pair is used as-is."""
+    config_file = tmp_path / "config.json"
+    config_file.write_text(json.dumps({
+        "backend": {
+            "mode": "frontend",
+            "remote_base_url": "http://config-file-remote.example",
+            "remote_auth_token": "config-file-token",
+        },
+    }))
+
+    webui = ClaudeWebUI(data_dir=tmp_path / "data", config_file=config_file)
+    assert webui.coordinator.backend_mode == BackendMode.REMOTE
+    assert webui.coordinator.backend._base_url == "http://config-file-remote.example"
+    assert webui.coordinator.backend._client.headers["authorization"] == "Bearer config-file-token"

--- a/src/tests/test_route_inventory.py
+++ b/src/tests/test_route_inventory.py
@@ -25,7 +25,7 @@ def test_route_count_unchanged():
     from src.web_server import create_app
     app = create_app()
     api_routes_count = _count_api_routes(app)
-    assert api_routes_count == 156, (
-        f"Expected 156 routes (+1 usage from #1125, +1 edit-history from #1128, +3 audit from #1127, +1 analytics from #1132, -2 legacy images from #1261, +1 oauth import-as-secret from #1381, -1 cancel-schedule from #1416, +1 reparent-minion from #1422, +1 session-routing from #1427-phase3, +6 provider-catalog from #1427-phase4, +1 queue-history from #1502, +1 session-links from #1530, +1 mark-unread from #1597, +1 unaccounted pre-existing delta, +1 model live-switch from #1673, +1 add-directory from #1675, +5 kanban-groups from #1722, +1 background-agents from #1746, +2 git-branches/git-commits from #1760, +1 mcp-config-tools from #1799, +1 mcp-config-test-connect from #1800, +1 context-usage from #498), got {api_routes_count}. "
+    assert api_routes_count == 157, (
+        f"Expected 157 routes (+1 usage from #1125, +1 edit-history from #1128, +3 audit from #1127, +1 analytics from #1132, -2 legacy images from #1261, +1 oauth import-as-secret from #1381, -1 cancel-schedule from #1416, +1 reparent-minion from #1422, +1 session-routing from #1427-phase3, +6 provider-catalog from #1427-phase4, +1 queue-history from #1502, +1 session-links from #1530, +1 mark-unread from #1597, +1 unaccounted pre-existing delta, +1 model live-switch from #1673, +1 add-directory from #1675, +5 kanban-groups from #1722, +1 background-agents from #1746, +2 git-branches/git-commits from #1760, +1 mcp-config-tools from #1799, +1 mcp-config-test-connect from #1800, +1 context-usage from #498, +1 health/ready from #499), got {api_routes_count}. "
         "A route was added or removed."
     )

--- a/src/tests/test_session_coordinator.py
+++ b/src/tests/test_session_coordinator.py
@@ -2890,3 +2890,81 @@ class TestRemoteRelayStateSync:
         await on_relay_event({"type": "message", "data": {"type": "result"}})
         info = await coordinator.session_manager.get_session_info(session_id)
         assert info.is_processing is False
+
+    @staticmethod
+    async def _start_remote_and_get_relay_callback(coordinator, session_id):
+        from ..session_backend import BackendMode
+
+        captured = {}
+
+        class FakeRemoteBackend:
+            async def start_session(self, session_id, **kwargs):
+                captured.update(kwargs)
+                return True, None
+
+            def active_session_ids(self):
+                return []
+
+        coordinator.backend = FakeRemoteBackend()
+        coordinator.backend_mode = BackendMode.REMOTE
+        await coordinator.start_session(session_id)
+        return captured["on_relay_event"]
+
+    @pytest.mark.asyncio
+    async def test_relayed_interrupt_success_event_resets_is_processing(
+        self, temp_coordinator, sample_session_config
+    ):
+        """An interrupted REMOTE turn need not produce a 'result' — only a
+        system/interrupt_success event — so is_processing must reset on that too."""
+        coordinator = temp_coordinator
+        session_id = await coordinator.create_session(**sample_session_config)
+        await coordinator.session_manager.update_processing_state(session_id, True)
+
+        on_relay_event = await self._start_remote_and_get_relay_callback(coordinator, session_id)
+
+        await on_relay_event(
+            {"type": "message", "data": {"type": "system", "subtype": "interrupt_success"}}
+        )
+        info = await coordinator.session_manager.get_session_info(session_id)
+        assert info.is_processing is False
+
+    @pytest.mark.asyncio
+    async def test_relayed_session_failed_event_transitions_to_error_state(
+        self, temp_coordinator, sample_session_config
+    ):
+        """A runtime SDK crash mid-turn on REMOTE relays a system/session_failed
+        event — the Hub's own session_manager.state must flip to ERROR (and
+        is_processing must clear), or every Hub-local guard reading state
+        (interrupt, watchdog, queue gating) keeps treating a dead session as alive."""
+        coordinator = temp_coordinator
+        session_id = await coordinator.create_session(**sample_session_config)
+        await coordinator.session_manager.update_processing_state(session_id, True)
+
+        on_relay_event = await self._start_remote_and_get_relay_callback(coordinator, session_id)
+
+        await on_relay_event({
+            "type": "message",
+            "data": {"type": "system", "subtype": "session_failed", "content": "boom"},
+        })
+
+        info = await coordinator.session_manager.get_session_info(session_id)
+        assert info.state == SessionState.ERROR
+        assert info.is_processing is False
+        assert info.error_message == "boom"
+
+    @pytest.mark.asyncio
+    async def test_relayed_event_records_activity(self, temp_coordinator, sample_session_config):
+        """Every relayed event is activity, not just outbound sends — otherwise a
+        REMOTE session mid-turn on a long tool loop looks idle to the watchdog
+        well before it actually is."""
+        coordinator = temp_coordinator
+        session_id = await coordinator.create_session(**sample_session_config)
+
+        on_relay_event = await self._start_remote_and_get_relay_callback(coordinator, session_id)
+
+        before = (await coordinator.session_manager.get_session_info(session_id)).last_activity_at
+        await on_relay_event({"type": "message", "data": {"type": "assistant"}})
+        after = (await coordinator.session_manager.get_session_info(session_id)).last_activity_at
+
+        assert after is not None
+        assert before is None or after >= before

--- a/src/tests/test_session_coordinator.py
+++ b/src/tests/test_session_coordinator.py
@@ -2968,3 +2968,89 @@ class TestRemoteRelayStateSync:
 
         assert after is not None
         assert before is None or after >= before
+
+    @pytest.mark.asyncio
+    async def test_relayed_tool_call_terminal_event_feeds_watchdog(
+        self, temp_coordinator, sample_session_config
+    ):
+        """The error-rate watchdog's record_tool_outcome() is otherwise fed only by
+        a Hub-local pipeline that never runs for REMOTE sessions — the relayed
+        'tool_call' envelope must feed it directly instead."""
+        from unittest.mock import Mock
+
+        coordinator = temp_coordinator
+        session_id = await coordinator.create_session(**sample_session_config)
+        coordinator._watchdog = Mock()
+
+        on_relay_event = await self._start_remote_and_get_relay_callback(coordinator, session_id)
+
+        # Non-terminal status must not be recorded.
+        await on_relay_event(
+            {"type": "message", "data": {"type": "tool_call", "tool_use_id": "t1", "status": "running"}}
+        )
+        coordinator._watchdog.record_tool_outcome.assert_not_called()
+
+        await on_relay_event(
+            {"type": "message", "data": {"type": "tool_call", "tool_use_id": "t1", "status": "failed"}}
+        )
+        coordinator._watchdog.record_tool_outcome.assert_called_once_with(session_id, "t1", "failed")
+
+
+class TestRemoteSessionStorageNotDuplicated:
+    """Issue #499: message content only ever lives on REMOTE for a REMOTE-dispatched
+    session (RemoteBackend.get_messages()'s own docstring: "REMOTE is the only place
+    a REMOTE session's messages.jsonl actually lives") — the relay pushes events into
+    the in-memory EventQueue only, never through DataStorageManager.append_message().
+    create_session() must not create a Hub-local DataStorageManager (and therefore a
+    permanently-empty messages.jsonl) for REMOTE sessions."""
+
+    @pytest.mark.asyncio
+    async def test_create_session_skips_storage_manager_for_remote(
+        self, temp_coordinator, sample_session_config
+    ):
+        from ..session_backend import BackendMode
+
+        coordinator = temp_coordinator
+        project_id = sample_session_config["project_id"]
+        project = await coordinator.project_manager.get_project(project_id)
+
+        class _FakeResponse:
+            status_code = 200
+
+            def __init__(self, project_dict):
+                self._project_dict = project_dict
+
+            def json(self):
+                return {"project": self._project_dict}
+
+        class FakeRemoteBackend:
+            async def create_session(self, session_id, project_id, config, **kwargs):
+                return session_id
+
+            async def relay_request(self, method, path):
+                return _FakeResponse(project.to_dict())
+
+            def active_session_ids(self):
+                return []
+
+        coordinator.backend = FakeRemoteBackend()
+        coordinator.backend_mode = BackendMode.REMOTE
+
+        session_id = await coordinator.create_session(**sample_session_config)
+
+        assert session_id not in coordinator._storage_managers
+        session_dir = await coordinator.session_manager.get_session_directory(session_id)
+        assert session_dir is not None  # state.json's directory still legitimately exists
+        assert not (session_dir / "messages.jsonl").exists()
+
+    @pytest.mark.asyncio
+    async def test_create_session_still_creates_storage_manager_for_local(
+        self, temp_coordinator, sample_session_config
+    ):
+        """Sanity check: LOCAL mode's existing behavior is unchanged."""
+        coordinator = temp_coordinator
+        session_id = await coordinator.create_session(**sample_session_config)
+
+        assert session_id in coordinator._storage_managers
+        session_dir = await coordinator.session_manager.get_session_directory(session_id)
+        assert (session_dir / "messages.jsonl").exists()

--- a/src/tests/test_session_coordinator.py
+++ b/src/tests/test_session_coordinator.py
@@ -2818,3 +2818,75 @@ class TestIssue1779TimestampInjection:
         await coordinator.send_message(session_id, "inter-agent comm", inject_timestamp=False)
 
         mock_sdk.send_message.assert_called_once_with("inter-agent comm", metadata=None)
+
+
+class TestRemoteRelayStateSync:
+    """Issue #499: RemoteBackend's relay poll loop forwards raw events straight into
+    the Hub's local EventQueue for display, bypassing _create_message_callback (and
+    therefore its is_processing-reset-on-'result' logic) entirely. Without the
+    on_relay_event hook, is_processing (and anything gated on it, e.g. interrupt's
+    completion signal) never resets for a REMOTE-dispatched session."""
+
+    @pytest.mark.asyncio
+    async def test_start_session_passes_relay_state_sync_callback_to_remote_backend(
+        self, temp_coordinator, sample_session_config
+    ):
+        from ..session_backend import BackendMode
+
+        coordinator = temp_coordinator
+        session_id = await coordinator.create_session(**sample_session_config)
+
+        captured = {}
+
+        class FakeRemoteBackend:
+            async def start_session(self, session_id, **kwargs):
+                captured.update(kwargs)
+                return True, None
+
+            def active_session_ids(self):
+                return []
+
+        coordinator.backend = FakeRemoteBackend()
+        coordinator.backend_mode = BackendMode.REMOTE
+
+        started = await coordinator.start_session(session_id)
+
+        assert started is True
+        assert callable(captured.get("on_relay_event"))
+
+    @pytest.mark.asyncio
+    async def test_relayed_result_event_resets_is_processing(
+        self, temp_coordinator, sample_session_config
+    ):
+        from ..session_backend import BackendMode
+
+        coordinator = temp_coordinator
+        session_id = await coordinator.create_session(**sample_session_config)
+        await coordinator.session_manager.update_processing_state(session_id, True)
+
+        captured = {}
+
+        class FakeRemoteBackend:
+            async def start_session(self, session_id, **kwargs):
+                captured.update(kwargs)
+                return True, None
+
+            def active_session_ids(self):
+                return []
+
+        coordinator.backend = FakeRemoteBackend()
+        coordinator.backend_mode = BackendMode.REMOTE
+
+        await coordinator.start_session(session_id)
+        on_relay_event = captured["on_relay_event"]
+
+        # A non-completion event must NOT reset processing state.
+        await on_relay_event({"type": "message", "data": {"type": "assistant"}})
+        info = await coordinator.session_manager.get_session_info(session_id)
+        assert info.is_processing is True
+
+        # The relayed 'result' envelope — the same shape prepare_for_websocket/
+        # web_server.py's append() produces — must reset it.
+        await on_relay_event({"type": "message", "data": {"type": "result"}})
+        info = await coordinator.session_manager.get_session_info(session_id)
+        assert info.is_processing is False

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -58,7 +58,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
     """
 
     EXEMPT_PATHS = {
-        '/', '/health', '/api/auth/check', '/oauth/callback',
+        '/', '/health', '/health/ready', '/api/auth/check', '/oauth/callback',
         # Public static assets from frontend/public/ — served at root without hashing,
         # must be accessible without a token (browsers fetch favicons unauthenticated).
         '/favicon.ico', '/favicon-16x16.png', '/favicon-32x32.png',
@@ -161,8 +161,13 @@ class ClaudeWebUI:
                  config_file: Path | None = None,
                  auth_token: str | None = None, auth_enabled: bool = False,
                  host: str = "127.0.0.1", port: int = 8000,
-                 backend_mode: str = "frontend", backend_auth_token: str | None = None):
+                 backend_mode: str = "frontend", backend_auth_token: str | None = None,
+                 remote_backend_url: str | None = None, remote_backend_token: str | None = None):
         self.app = FastAPI(title="Claude Code WebUI", version="1.0.0")
+        # Issue #499: readiness state for GET /health/ready — false until initialize()
+        # completes, flipped back to false at the start of cleanup() so orchestrators
+        # stop routing new traffic during shutdown-drain while liveness stays healthy.
+        self._ready = False
         self.host = host
         self.port = port
         self.coordinator = SessionCoordinator(data_dir, experimental=experimental, host=host, port=port)
@@ -184,8 +189,11 @@ class ClaudeWebUI:
         self.backend_auth_token = backend_auth_token
         if self.backend_mode == "headless":
             # Headless mode's only auth mechanism is the per-route backend bearer
-            # dependency — AuthMiddleware's EXEMPT_PATHS (/, /health, ...) don't even
-            # exist on this mount, so the browser-facing operator token never applies.
+            # dependency — AuthMiddleware itself is never added to this mount (see
+            # create_app()), so the browser-facing operator token never applies.
+            # /health and /health/ready (issue #499) are the sole routes registered
+            # unauthenticated on this mount; everything else lives under
+            # /api/backend/* behind the bearer dependency.
             self.auth_enabled = False
 
         # Wire mock SDK factory if mock mode active (issue #561)
@@ -203,19 +211,26 @@ class ClaudeWebUI:
         from .config_manager import load_config as _load_cfg
         _cfg = _load_cfg(config_file) if config_file else _load_cfg()
 
-        # Issue #498: dispatch sessions to a configured REMOTE instead of running them
-        # locally. Independent of this process's own mount mode (backend_mode below) —
-        # a frontend-mode Hub can relay to REMOTE while still serving its own UI.
-        if _cfg.backend.remote_base_url:
+        # Issue #498/#499: dispatch sessions to a configured REMOTE instead of running
+        # them locally. Independent of this process's own mount mode (backend_mode
+        # below) — a frontend-mode Hub can relay to REMOTE while still serving its own
+        # UI. A CLI-supplied remote_backend_url replaces the config-file URL+token pair
+        # wholesale (never pairs a new URL with a stale config-file token for a
+        # different remote); with no CLI URL, the config-file pair is used as-is.
+        effective_remote_base_url = remote_backend_url or _cfg.backend.remote_base_url
+        effective_remote_auth_token = (
+            remote_backend_token if remote_backend_url else _cfg.backend.remote_auth_token
+        )
+        if effective_remote_base_url:
             from .remote_backend import RemoteBackend
             from .session_backend import BackendMode
             self.coordinator.backend = RemoteBackend(
-                _cfg.backend.remote_base_url,
-                _cfg.backend.remote_auth_token or "",
+                effective_remote_base_url,
+                effective_remote_auth_token or "",
                 self.session_queues,
             )
             self.coordinator.backend_mode = BackendMode.REMOTE
-            logger.info(f"SessionCoordinator backend_mode=REMOTE ({_cfg.backend.remote_base_url})")
+            logger.info(f"SessionCoordinator backend_mode=REMOTE ({effective_remote_base_url})")
 
         # Inject ui_queue into LegionSystem so legion components can append events directly
         self.coordinator.legion_system.ui_queue = self.ui_queue
@@ -800,6 +815,7 @@ class ClaudeWebUI:
             self._audit_writer = AuditWriter(None)
             self.audit_writer = self._audit_writer
 
+        self._ready = True
         logger.info("Claude Code WebUI initialized")
 
     def _setup_routes(self):
@@ -1095,6 +1111,10 @@ class ClaudeWebUI:
 
     async def cleanup(self):
         """Cleanup resources"""
+        # Issue #499: flip readiness false immediately so GET /health/ready starts
+        # 503ing during shutdown-drain, while liveness stays healthy until the process
+        # actually exits.
+        self._ready = False
         # Issue #1387: Stop vault refresh manager
         await self.coordinator.vault_refresh_manager.stop()
         # Issue #1130: Stop session watchdog service
@@ -1155,6 +1175,8 @@ def create_app(
     port: int = 8000,
     backend_mode: str = "frontend",
     backend_auth_token: str | None = None,
+    remote_backend_url: str | None = None,
+    remote_backend_token: str | None = None,
 ) -> FastAPI:
     """Create and configure the FastAPI application"""
     global webui_app
@@ -1165,6 +1187,7 @@ def create_app(
         auth_token=auth_token, auth_enabled=auth_enabled,
         host=host, port=port,
         backend_mode=backend_mode, backend_auth_token=backend_auth_token,
+        remote_backend_url=remote_backend_url, remote_backend_token=remote_backend_token,
     )
     webui_app = app_instance
 

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -720,9 +720,14 @@ class ClaudeWebUI:
 
         # Issue #498: start the single shared audit-stream relay task if REMOTE is
         # configured (Batch 5, Pattern B) — see RemoteBackend.start_audit_relay.
+        # Issue #499: same pattern for the global UI event stream — without this,
+        # every broadcast landing in ui_queue (PAUSED-for-permission state,
+        # rate-limit updates, watchdog alerts, ...) only ever reaches REMOTE's own
+        # local ui_queue, never the Hub's.
         from .session_backend import BackendMode
         if self.coordinator.backend_mode == BackendMode.REMOTE:
             await self.coordinator.backend.start_audit_relay(self.audit_queue)
+            await self.coordinator.backend.start_ui_relay(self.ui_queue)
 
         try:
             await self.litellm_proxy_manager.start()


### PR DESCRIPTION
## Summary
Resolves #499

Closes the three remaining gaps identified in the approved plan (on top of #498's LOCAL/REMOTE transport framework, which already delivered mount exclusivity, full route mirroring, and the `--headless-backend`/`--backend-token` CLI flags):

## Changes Made
- **Liveness + readiness probes**: new `src/routers/health.py` exposes `GET /health` (liveness, always 200 if the process is alive) and `GET /health/ready` (readiness, 200 once startup completes / 503 otherwise), unauthenticated on both frontend and headless mounts. `/health` was moved out of `src/routers/core.py` — same path, same response shape, no behavior change for existing deployments' monitoring. `ClaudeWebUI` tracks a `_ready` flag: `False` in `__init__`, `True` at the end of `initialize()`, `False` again at the start of `cleanup()` so readiness drops immediately during shutdown-drain (SIGTERM) while liveness stays healthy until the process actually exits.
- **Hub → REMOTE backend CLI flags**: `--remote-backend-url` / `--remote-backend-token` on `main.py`, validated (`--remote-backend-token` requires `--remote-backend-url`) and threaded through `create_app()` / `ClaudeWebUI.__init__`. A CLI-supplied URL replaces the config-file URL+token pair **wholesale**, rather than merging field-by-field, to avoid silently pairing a new URL with a stale config-file token for a different remote.
- **Production Dockerfile**: `docker/Dockerfile.backend`, a minimal image for `--headless-backend` mode — no Node/Chromium/Playwright/gh CLI, no frontend build step. `--headless-backend --host 0.0.0.0` are baked into `ENTRYPOINT` (not `CMD`) so operator-supplied `docker run` args append rather than replacing the base command, and network-binding acknowledgment is pre-baked into the image's `config.json` since a container is only reachable at all via its published port.

## Testing
- Full test suite (`uv run pytest src/tests/`): 2465 passed. The only failures (8, pre-existing) are unrelated to this change — confirmed by reproducing them identically on the pre-change tree (`test_api_links.py`, `test_api_schedules.py`, `test_issue_1598_poll_viewed_timing.py`, `test_overseer_controller.py`).
- New tests: health/readiness reachability + 503-before-ready in both frontend and headless mode (`test_backend_mount.py`), CLI remote-backend-url/token wiring including the CLI-wins-wholesale case (`test_remote_backend.py`), argparse validation for `--remote-backend-token` without `--remote-backend-url` (`test_main_entrypoint.py`), and an updated route-count baseline (`test_route_inventory.py`).
- Manual: ran `uv run python main.py --headless-backend --backend-token test --port 8499`; curled `/health` (200) and `/health/ready` (200) with no Authorization header; confirmed `/api/backend/sessions` still 401s with no/wrong token and 200s with the right one.
- `docker build` itself could not be executed in the build sandbox (no `docker`/`podman` binary, no `sudo`/apt access to install one). In lieu of that, the Dockerfile's exact runtime logic was validated by simulating its two non-obvious fixes directly: a `HOME`-scoped config.json with `allow_network_binding`/`acknowledged_risk` pre-set (mirroring what the Dockerfile bakes in) plus the full `--headless-backend --host 0.0.0.0 --backend-token=...` argument list the fixed `ENTRYPOINT`+`CMD` would actually produce — confirmed `/health`, `/health/ready`, and the bearer-gated `/api/backend/sessions` all behave correctly. Recommend a real `docker build -f docker/Dockerfile.backend .` + `docker run` smoke test in CI or a Docker-enabled environment before merge.
- `builder-review` (5 parallel finder agents across all 8 angles) caught two real bugs in my first draft of the Dockerfile, both fixed before this PR: (1) the documented `docker run image --backend-token=...` example silently dropped `--headless-backend --host 0.0.0.0` because Docker replaces `CMD` wholesale rather than appending to it — fixed by baking those flags into `ENTRYPOINT` instead; (2) the default `--host 0.0.0.0` would `sys.exit(1)` on `main.py`'s network-binding safety check with no config file present — fixed by pre-baking `allow_network_binding`/`acknowledged_risk` into the image's `config.json`, since the container is only reachable via its published port to begin with.

## Flagged for follow-up (not fixed in this PR — out of scope / judgment calls)
- **CLI-wholesale-replace merge rule**: if an operator passes `--remote-backend-url` matching the config file's existing URL but omits `--remote-backend-token` (e.g. baked into a wrapper script), the effective token becomes empty rather than falling back to the config-file token — every REMOTE call then 401s. This was explicitly flagged in the approved plan (§8) as a judgment call, not contract-dictated; implemented as designed per the plan, flagging the concrete failure mode here rather than silently changing the precedence rule.
- **Pre-existing bug, unrelated to this diff's scope**: `ClaudeWebUI.initialize()`'s `except Exception` around `litellm_proxy_manager.start()` does not catch `SystemExit` — if the LiteLLM proxy's hardcoded port (4000 by default) is already in use (e.g. two `--headless-backend` instances on one host), an uncaught `SystemExit` aborts the entire ASGI lifespan startup, meaning `/health`/`/health/ready` never become reachable at all in that specific failure mode. Reproduced directly during manual testing. This is in unrelated pre-existing code (`src/litellm_proxy_manager.py` / the exception-handling policy in `initialize()`), not part of this plan's 3-item scope — flagging rather than expanding scope to fix it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)