### PR TITLE
fix: make auto-started Backend reachable from Docker on native Docker Engine hosts (#1850)

### DIFF
--- a/backend/docker_utils.py
+++ b/backend/docker_utils.py
@@ -11,12 +11,18 @@ import asyncio
 import logging
 import os
 import shutil
+import socket
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
 # Default Docker image name used by the bundled wrapper
 DEFAULT_DOCKER_IMAGE = "claude-code:local"
+
+# Sandbox/proxy containers (backend/docker/claude-docker) run on Docker's default
+# bridge network — no custom network is created — so this is the one network whose
+# gateway matters for embedded-mode Docker reachability (issue #1850).
+_DEFAULT_BRIDGE_NETWORK = "bridge"
 
 
 def get_wrapper_script_path() -> Path:
@@ -76,6 +82,74 @@ async def check_docker_available() -> dict:
             pass
 
     return result
+
+
+async def detect_docker_bridge_gateway(timeout: float = 5.0) -> str | None:
+    """Return Docker's default bridge network's gateway IP (typically 172.17.0.1
+    on Linux), or None if Docker isn't available or the network has no gateway.
+
+    This is a host-side check (`docker network inspect`, no container spawned) —
+    used by embedded-mode Backend (issue #1850) to decide whether to also bind
+    that address alongside loopback, so Docker sandbox containers on native
+    Docker Engine hosts can reach it. Failure here just means "don't add that
+    bind" — callers should treat None as "loopback only," not an error.
+
+    A tighter timeout than check_docker_available()'s (request-scoped, 10s) —
+    this runs on Backend's own startup path, and repeats on every crash-restart
+    (src/backend_supervisor.py), so a wedged Docker daemon shouldn't compound
+    into a long delay there.
+    """
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "docker", "network", "inspect", _DEFAULT_BRIDGE_NETWORK,
+            "--format", "{{range .IPAM.Config}}{{.Gateway}}{{end}}",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        if proc.returncode != 0:
+            return None
+        gateway = stdout.decode().strip()
+        return gateway or None
+    except FileNotFoundError:
+        logger.debug("Docker CLI not found on PATH; embedded Backend binds loopback only")
+        return None
+    except TimeoutError:
+        logger.warning("Docker bridge gateway detection timed out")
+        return None
+    except Exception as e:
+        logger.debug(f"Docker bridge gateway detection failed: {e}")
+        return None
+
+
+def build_embedded_sockets(port: int, bridge_gateway: str | None) -> list[socket.socket]:
+    """Bind loopback plus (if reachable on this host) the Docker bridge gateway —
+    never a wildcard bind.
+
+    Binding the gateway address fails harmlessly on hosts where Docker itself runs
+    inside a VM (Docker Desktop/Rancher — the address isn't a real interface on the
+    host there, and loopback already works fine due to their mirrored networking),
+    so that failure is caught and skipped rather than treated as an error.
+    """
+    addresses = ["127.0.0.1"]
+    if bridge_gateway and bridge_gateway != "127.0.0.1":
+        addresses.append(bridge_gateway)
+
+    sockets = []
+    for address in addresses:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            sock.bind((address, port))
+        except OSError:
+            logger.info("Embedded Backend: %s:%s not bindable on this host, skipping", address, port)
+            sock.close()
+            continue
+        sock.set_inheritable(True)
+        sockets.append(sock)
+        logger.info("Embedded Backend bound to %s:%s", address, port)
+
+    return sockets
 
 
 def resolve_docker_cli_path(

--- a/backend/docker_utils.py
+++ b/backend/docker_utils.py
@@ -8,6 +8,7 @@ Issue #1052: prepare_session_ssh() — SSH key tmpfs delivery for proxy-mode ses
 """
 
 import asyncio
+import contextlib
 import logging
 import os
 import shutil
@@ -98,24 +99,41 @@ async def detect_docker_bridge_gateway(timeout: float = 5.0) -> str | None:
     this runs on Backend's own startup path, and repeats on every crash-restart
     (src/backend_supervisor.py), so a wedged Docker daemon shouldn't compound
     into a long delay there.
+
+    The whole operation (not just the read) is under one deadline: on WSL2 with
+    Docker Desktop, `docker network inspect` can itself hang past any reasonable
+    timeout (reproduced live — the CLI's cross-boundary call into the Windows-side
+    daemon stalled), and a timeout that only wrapped reading its output would
+    still leave the overall call unbounded. On timeout, the still-running process
+    is killed and reaped rather than left to leak.
     """
-    try:
+    proc: asyncio.subprocess.Process | None = None
+
+    async def _inspect() -> str | None:
+        nonlocal proc
         proc = await asyncio.create_subprocess_exec(
             "docker", "network", "inspect", _DEFAULT_BRIDGE_NETWORK,
             "--format", "{{range .IPAM.Config}}{{.Gateway}}{{end}}",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
-        stdout, _stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        stdout, _stderr = await proc.communicate()
         if proc.returncode != 0:
             return None
         gateway = stdout.decode().strip()
         return gateway or None
+
+    try:
+        return await asyncio.wait_for(_inspect(), timeout=timeout)
     except FileNotFoundError:
         logger.debug("Docker CLI not found on PATH; embedded Backend binds loopback only")
         return None
     except TimeoutError:
         logger.warning("Docker bridge gateway detection timed out")
+        if proc is not None and proc.returncode is None:
+            proc.kill()
+            with contextlib.suppress(Exception):
+                await proc.wait()
         return None
     except Exception as e:
         logger.debug(f"Docker bridge gateway detection failed: {e}")

--- a/backend/docker_utils.py
+++ b/backend/docker_utils.py
@@ -8,11 +8,11 @@ Issue #1052: prepare_session_ssh() — SSH key tmpfs delivery for proxy-mode ses
 """
 
 import asyncio
-import contextlib
 import logging
 import os
 import shutil
 import socket
+import subprocess
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -85,6 +85,31 @@ async def check_docker_available() -> dict:
     return result
 
 
+def _inspect_bridge_gateway_sync(timeout: float) -> str | None:
+    """Synchronous half of detect_docker_bridge_gateway(), run in a worker thread.
+
+    subprocess.run(..., timeout=...) is the stdlib's own, long-hardened subprocess
+    timeout mechanism (kill + reap handled internally) — used here instead of
+    asyncio subprocess + asyncio.wait_for, which two earlier attempts at this
+    exact fix both used and which both still hung on live WSL2 + Docker Desktop
+    testing: cooperative asyncio cancellation never actually interrupted the
+    docker CLI's cross-boundary call into the Windows-side daemon.
+    """
+    try:
+        result = subprocess.run(
+            ["docker", "network", "inspect", _DEFAULT_BRIDGE_NETWORK,
+             "--format", "{{range .IPAM.Config}}{{.Gateway}}{{end}}"],
+            capture_output=True,
+            timeout=timeout,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    gateway = result.stdout.decode().strip()
+    return gateway or None
+
+
 async def detect_docker_bridge_gateway(timeout: float = 5.0) -> str | None:
     """Return Docker's default bridge network's gateway IP (typically 172.17.0.1
     on Linux), or None if Docker isn't available or the network has no gateway.
@@ -100,40 +125,19 @@ async def detect_docker_bridge_gateway(timeout: float = 5.0) -> str | None:
     (src/backend_supervisor.py), so a wedged Docker daemon shouldn't compound
     into a long delay there.
 
-    The whole operation (not just the read) is under one deadline: on WSL2 with
-    Docker Desktop, `docker network inspect` can itself hang past any reasonable
-    timeout (reproduced live — the CLI's cross-boundary call into the Windows-side
-    daemon stalled), and a timeout that only wrapped reading its output would
-    still leave the overall call unbounded. On timeout, the still-running process
-    is killed and reaped rather than left to leak.
+    Runs in a worker thread via asyncio.to_thread() so the caller is never
+    blocked beyond `timeout` (+ a small margin) even if the underlying blocking
+    call never returns at all — the outer asyncio.wait_for() here doesn't need
+    to actually interrupt anything, only stop waiting on the thread's result.
     """
-    proc: asyncio.subprocess.Process | None = None
-
-    async def _inspect() -> str | None:
-        nonlocal proc
-        proc = await asyncio.create_subprocess_exec(
-            "docker", "network", "inspect", _DEFAULT_BRIDGE_NETWORK,
-            "--format", "{{range .IPAM.Config}}{{.Gateway}}{{end}}",
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        stdout, _stderr = await proc.communicate()
-        if proc.returncode != 0:
-            return None
-        gateway = stdout.decode().strip()
-        return gateway or None
-
     try:
-        return await asyncio.wait_for(_inspect(), timeout=timeout)
-    except FileNotFoundError:
-        logger.debug("Docker CLI not found on PATH; embedded Backend binds loopback only")
-        return None
+        # +1s margin over the inner subprocess.run() timeout, in case even the
+        # stdlib's own kill+reap doesn't return promptly on this platform.
+        return await asyncio.wait_for(
+            asyncio.to_thread(_inspect_bridge_gateway_sync, timeout), timeout=timeout + 1.0
+        )
     except TimeoutError:
         logger.warning("Docker bridge gateway detection timed out")
-        if proc is not None and proc.returncode is None:
-            proc.kill()
-            with contextlib.suppress(Exception):
-                await proc.wait()
         return None
     except Exception as e:
         logger.debug(f"Docker bridge gateway detection failed: {e}")

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,10 +4,15 @@ Main entry point for the Backend control-plane process (issue #498).
 
 Independently runnable: `python -m backend.main --host 127.0.0.1 --port <n> --token <t>
 --data-dir <dir>`. Auto-started by the Frontend API for the single-user self-hosted
-case (backend_supervisor.py, Phase 3) or pointed at manually for a remote deployment.
+case (backend_supervisor.py, Phase 3, always passing --embedded) or pointed at
+manually for a remote deployment (--host stays gated by check_network_binding).
+--embedded mode binds loopback plus Docker's default bridge gateway (if reachable
+on this host) instead of --host, for Docker sandbox reachability on native Docker
+Engine hosts (issue #1850) — see build_embedded_sockets() in docker_utils.py.
 """
 
 import argparse
+import asyncio
 import os
 import secrets
 import sys
@@ -19,6 +24,7 @@ import uvicorn
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from backend.config_manager import check_network_binding, ensure_config_file, load_config
+from backend.docker_utils import build_embedded_sockets, detect_docker_bridge_gateway
 from backend.secrets_keyring import configure_keyring
 from backend.web_server import create_app
 from shared.logging_config import configure_logging
@@ -52,6 +58,15 @@ def main():
     )
     parser.add_argument('--port', type=int, default=8100, help='Port to bind to (default: 8100)')
     parser.add_argument('--data-dir', default='./data', help='Data directory location (default: ./data)')
+    parser.add_argument(
+        '--embedded', action='store_true',
+        help='Set only by BackendSupervisor when auto-starting Backend '
+             '(src/backend_supervisor.py) — never for manual/remote use. Binds loopback '
+             "plus Docker's default bridge gateway (if reachable on this host) instead of "
+             '--host, so Docker sandbox containers can reach Backend on native Docker '
+             'Engine hosts (issue #1850). Never a wildcard/LAN-facing bind, so the '
+             'network-binding consent gate below does not apply to this mode.'
+    )
 
     # Experimental features
     parser.add_argument('--experimental', action='store_true', help='Enable experimental features (Agent Teams)')
@@ -105,8 +120,11 @@ def main():
     config_file = ensure_config_file()
     app_config = load_config(config_file)
 
-    # Validate network binding permission
-    if not check_network_binding(args.host, app_config, config_file):
+    # Validate network binding permission — skipped in --embedded mode, since that
+    # mode never does a real network-facing (wildcard/LAN) bind; see build_embedded_
+    # sockets() below and the --embedded help text (issue #1850). Manual/remote
+    # (non-embedded) invocations are completely unaffected — gated exactly as before.
+    if not args.embedded and not check_network_binding(args.host, app_config, config_file):
         sys.exit(1)
 
     # Validate and create data directory
@@ -176,13 +194,36 @@ def main():
     )
 
     # Run the server
-    uvicorn.run(
-        app,
-        host=args.host,
-        port=args.port,
-        log_level="info",
-        access_log=True
-    )
+    if args.embedded:
+        # Loopback plus Docker's default bridge gateway (if reachable on this host) —
+        # never a wildcard bind (issue #1850). Falls back to loopback-only wherever
+        # Docker is unavailable or the gateway address isn't real on this host (e.g.
+        # Docker Desktop/Rancher, whose bridge lives inside a VM, not the actual host).
+        bridge_gateway = asyncio.run(detect_docker_bridge_gateway())
+        sockets = build_embedded_sockets(args.port, bridge_gateway)
+        # Frontend's BackendSupervisor always reaches Backend over 127.0.0.1 (base_url,
+        # wait_ready()) — if loopback specifically failed to bind (unlike the bridge
+        # gateway, this is never expected to fail) while some other address still
+        # succeeded, continuing would silently produce a Backend Frontend can never
+        # reach instead of a clear startup failure.
+        if not any(s.getsockname()[0] == "127.0.0.1" for s in sockets):
+            print(f"Failed to bind 127.0.0.1:{args.port}", file=sys.stderr)
+            sys.exit(1)
+        bound = ", ".join(f"{s.getsockname()[0]}:{s.getsockname()[1]}" for s in sockets)
+        print(f"Embedded Backend listening on: {bound}")
+        # server.run(), not asyncio.run(server.serve(...)) — .run() calls
+        # config.setup_event_loop() first (installs uvloop when available), which a
+        # bare .serve() call would silently skip.
+        server = uvicorn.Server(uvicorn.Config(app, log_level="info", access_log=True))
+        server.run(sockets=sockets)
+    else:
+        uvicorn.run(
+            app,
+            host=args.host,
+            port=args.port,
+            log_level="info",
+            access_log=True
+        )
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_docker_utils.py
+++ b/backend/tests/test_docker_utils.py
@@ -4,6 +4,8 @@ Tests for src/docker_utils.py — shared Docker /tmp helpers (issue #832).
 
 import asyncio
 import socket
+import subprocess
+import time
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -162,69 +164,69 @@ class TestResolveDockerCliPathProxy:
 
 
 class TestDetectDockerBridgeGateway:
+    """detect_docker_bridge_gateway() runs subprocess.run(timeout=...) in a worker
+    thread (asyncio.to_thread) rather than asyncio subprocess + asyncio.wait_for —
+    two earlier fix attempts using the latter both hung identically on live WSL2 +
+    Docker Desktop testing: the docker CLI's cross-boundary call into the
+    Windows-side daemon never actually responded to cooperative asyncio
+    cancellation. subprocess.run's own kill+reap is the stdlib's long-hardened
+    mechanism for exactly this; the outer asyncio.wait_for here only needs to stop
+    waiting on the thread's result, not interrupt anything itself."""
+
+    def _completed(self, returncode: int, stdout: bytes) -> subprocess.CompletedProcess:
+        return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=b"")
+
     @pytest.mark.asyncio
     async def test_returns_gateway_on_success(self):
-        proc = MagicMock()
-        proc.communicate = AsyncMock(return_value=(b"172.17.0.1\n", b""))
-        proc.returncode = 0
-        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+        completed = self._completed(0, b"172.17.0.1\n")
+        with patch("backend.docker_utils.subprocess.run", return_value=completed):
             result = await detect_docker_bridge_gateway()
         assert result == "172.17.0.1"
 
     @pytest.mark.asyncio
     async def test_returns_none_when_docker_cli_missing(self):
-        with patch("asyncio.create_subprocess_exec", AsyncMock(side_effect=FileNotFoundError)):
+        with patch("backend.docker_utils.subprocess.run", side_effect=FileNotFoundError):
             result = await detect_docker_bridge_gateway()
         assert result is None
 
     @pytest.mark.asyncio
     async def test_returns_none_on_nonzero_returncode(self):
-        proc = MagicMock()
-        proc.communicate = AsyncMock(return_value=(b"", b"no such network"))
-        proc.returncode = 1
-        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+        completed = self._completed(1, b"")
+        with patch("backend.docker_utils.subprocess.run", return_value=completed):
             result = await detect_docker_bridge_gateway()
         assert result is None
 
     @pytest.mark.asyncio
     async def test_returns_none_on_empty_gateway(self):
-        proc = MagicMock()
-        proc.communicate = AsyncMock(return_value=(b"\n", b""))
-        proc.returncode = 0
-        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+        completed = self._completed(0, b"\n")
+        with patch("backend.docker_utils.subprocess.run", return_value=completed):
             result = await detect_docker_bridge_gateway()
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_returns_none_on_timeout(self):
-        proc = MagicMock()
-        proc.communicate = AsyncMock(return_value=(b"172.17.0.1\n", b""))
-        proc.returncode = 0
-        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)), \
-             patch("asyncio.wait_for", AsyncMock(side_effect=TimeoutError)):
+    async def test_returns_none_when_subprocess_run_itself_times_out(self):
+        with patch(
+            "backend.docker_utils.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd=["docker"], timeout=5),
+        ):
             result = await detect_docker_bridge_gateway()
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_kills_leftover_process_when_it_hangs_past_the_timeout(self):
-        """Regression test: reproduced live on WSL2 + Docker Desktop, where `docker
-        network inspect` itself hung — the deadline must cover the whole operation
-        (not just reading output), and the hung process must not be left running."""
-        async def _hang(*_args, **_kwargs):
-            await asyncio.sleep(100)
+    async def test_bounded_even_if_the_underlying_call_never_returns(self):
+        """Regression test: two earlier fix attempts both relied on asyncio-level
+        cancellation to bound a hanging docker CLI call, and both still hung on
+        live WSL2 + Docker Desktop testing — the underlying call never responded
+        to cooperative cancellation at all. This proves the caller gets control
+        back within a bounded time regardless of what the blocking call does."""
+        def _hang_forever(*_args, **_kwargs):
+            time.sleep(2)
 
-        proc = MagicMock()
-        proc.returncode = None  # still running when the timeout fires
-        proc.kill = MagicMock()
-        proc.wait = AsyncMock(return_value=None)
-        proc.communicate = AsyncMock(side_effect=_hang)
-
-        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
-            result = await detect_docker_bridge_gateway(timeout=0.05)
-
+        with patch("backend.docker_utils.subprocess.run", side_effect=_hang_forever):
+            result = await asyncio.wait_for(
+                detect_docker_bridge_gateway(timeout=0.05), timeout=5
+            )
         assert result is None
-        proc.kill.assert_called_once()
-        proc.wait.assert_awaited_once()
 
 
 class TestBuildEmbeddedSockets:

--- a/backend/tests/test_docker_utils.py
+++ b/backend/tests/test_docker_utils.py
@@ -2,6 +2,7 @@
 Tests for src/docker_utils.py — shared Docker /tmp helpers (issue #832).
 """
 
+import asyncio
 import socket
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -203,6 +204,27 @@ class TestDetectDockerBridgeGateway:
              patch("asyncio.wait_for", AsyncMock(side_effect=TimeoutError)):
             result = await detect_docker_bridge_gateway()
         assert result is None
+
+    @pytest.mark.asyncio
+    async def test_kills_leftover_process_when_it_hangs_past_the_timeout(self):
+        """Regression test: reproduced live on WSL2 + Docker Desktop, where `docker
+        network inspect` itself hung — the deadline must cover the whole operation
+        (not just reading output), and the hung process must not be left running."""
+        async def _hang(*_args, **_kwargs):
+            await asyncio.sleep(100)
+
+        proc = MagicMock()
+        proc.returncode = None  # still running when the timeout fires
+        proc.kill = MagicMock()
+        proc.wait = AsyncMock(return_value=None)
+        proc.communicate = AsyncMock(side_effect=_hang)
+
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            result = await detect_docker_bridge_gateway(timeout=0.05)
+
+        assert result is None
+        proc.kill.assert_called_once()
+        proc.wait.assert_awaited_once()
 
 
 class TestBuildEmbeddedSockets:

--- a/backend/tests/test_docker_utils.py
+++ b/backend/tests/test_docker_utils.py
@@ -2,13 +2,16 @@
 Tests for src/docker_utils.py — shared Docker /tmp helpers (issue #832).
 """
 
+import socket
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from backend.docker_utils import (
+    build_embedded_sockets,
     cleanup_session_tmp,
+    detect_docker_bridge_gateway,
     get_session_tmp_dir,
     resolve_docker_cli_path,
     translate_docker_tmp_path,
@@ -150,3 +153,116 @@ class TestResolveDockerCliPathProxy:
         _, env = resolve_docker_cli_path(docker_image="my-image")
         assert "CLAUDE_DOCKER_PROXY_IMAGE" not in env
         assert env == {"CLAUDE_DOCKER_IMAGE": "my-image"}
+
+
+# ---------------------------------------------------------------------------
+# detect_docker_bridge_gateway / build_embedded_sockets (issue #1850)
+# ---------------------------------------------------------------------------
+
+
+class TestDetectDockerBridgeGateway:
+    @pytest.mark.asyncio
+    async def test_returns_gateway_on_success(self):
+        proc = MagicMock()
+        proc.communicate = AsyncMock(return_value=(b"172.17.0.1\n", b""))
+        proc.returncode = 0
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            result = await detect_docker_bridge_gateway()
+        assert result == "172.17.0.1"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_docker_cli_missing(self):
+        with patch("asyncio.create_subprocess_exec", AsyncMock(side_effect=FileNotFoundError)):
+            result = await detect_docker_bridge_gateway()
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_nonzero_returncode(self):
+        proc = MagicMock()
+        proc.communicate = AsyncMock(return_value=(b"", b"no such network"))
+        proc.returncode = 1
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            result = await detect_docker_bridge_gateway()
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_empty_gateway(self):
+        proc = MagicMock()
+        proc.communicate = AsyncMock(return_value=(b"\n", b""))
+        proc.returncode = 0
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            result = await detect_docker_bridge_gateway()
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_timeout(self):
+        proc = MagicMock()
+        proc.communicate = AsyncMock(return_value=(b"172.17.0.1\n", b""))
+        proc.returncode = 0
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)), \
+             patch("asyncio.wait_for", AsyncMock(side_effect=TimeoutError)):
+            result = await detect_docker_bridge_gateway()
+        assert result is None
+
+
+class TestBuildEmbeddedSockets:
+    def _free_port(self) -> int:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("127.0.0.1", 0))
+            return s.getsockname()[1]
+
+    def test_binds_loopback_only_when_no_gateway(self):
+        port = self._free_port()
+        sockets = build_embedded_sockets(port, None)
+        try:
+            assert len(sockets) == 1
+            assert sockets[0].getsockname() == ("127.0.0.1", port)
+        finally:
+            for s in sockets:
+                s.close()
+
+    def test_binds_gateway_address_when_reachable(self):
+        # 127.0.0.2 is loopback-range and bindable on Linux without any Docker
+        # present — stands in for "the gateway address happens to be a real,
+        # bindable interface on this host" without depending on Docker actually
+        # being installed in the test environment.
+        port = self._free_port()
+        sockets = build_embedded_sockets(port, "127.0.0.2")
+        try:
+            addresses = {s.getsockname()[0] for s in sockets}
+            assert addresses == {"127.0.0.1", "127.0.0.2"}
+        finally:
+            for s in sockets:
+                s.close()
+
+    def test_skips_unbindable_gateway_address_without_raising(self):
+        # Simulates Docker Desktop/Rancher, where the bridge lives inside a VM, not
+        # the actual host — binding the "gateway" address fails there (issue #1850's
+        # Desktop-vs-Engine distinction). Force that deterministically (rather than
+        # relying on some real IP being unassigned on the test host) by patching
+        # socket.socket.bind to raise only for the gateway address under test.
+        port = self._free_port()
+        original_bind = socket.socket.bind
+
+        def fake_bind(self, address):
+            if address[0] == "203.0.113.5":  # TEST-NET-3 (RFC 5737), never a real interface
+                raise OSError("Cannot assign requested address")
+            return original_bind(self, address)
+
+        with patch.object(socket.socket, "bind", fake_bind):
+            sockets = build_embedded_sockets(port, "203.0.113.5")
+        try:
+            addresses = {s.getsockname()[0] for s in sockets}
+            assert addresses == {"127.0.0.1"}
+        finally:
+            for s in sockets:
+                s.close()
+
+    def test_gateway_equal_to_loopback_not_duplicated(self):
+        port = self._free_port()
+        sockets = build_embedded_sockets(port, "127.0.0.1")
+        try:
+            assert len(sockets) == 1
+        finally:
+            for s in sockets:
+                s.close()

--- a/backend/tests/test_main_entrypoint.py
+++ b/backend/tests/test_main_entrypoint.py
@@ -8,10 +8,41 @@ CLI entrypoints together (issue #498, Phase 2 onward).
 """
 
 import os
+import secrets
+import socket
+import subprocess
+import sys
+import time
 from pathlib import Path
 from unittest.mock import patch
 
+import httpx
 from starlette.testclient import TestClient
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _wait_healthy(port: int, proc: subprocess.Popen, label: str, deadline_seconds: float = 15) -> None:
+    deadline = time.monotonic() + deadline_seconds
+    last_error = None
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            output = proc.stdout.read()
+            raise AssertionError(f"{label} exited early with code {proc.returncode}:\n{output}")
+        try:
+            resp = httpx.get(f"http://127.0.0.1:{port}/health", timeout=1)
+            if resp.status_code == 200:
+                return
+        except httpx.TransportError as exc:
+            last_error = exc
+        time.sleep(0.3)
+    raise AssertionError(f"{label} never became healthy on port {port}: {last_error}")
 
 
 def test_create_app_lifespan_serves_health(tmp_path: Path):
@@ -58,3 +89,74 @@ class TestConfigureWebuiBaseUrl:
         with patch.dict(os.environ, {}, clear=True):
             configure_webui_base_url(54321)
             assert os.environ["WEBUI_BASE_URL"] == "http://cc-webui.internal:54321"
+
+
+class TestEmbeddedModeNetworkBinding:
+    """Regression tests for issue #1850: embedded mode (--embedded, set only by
+    BackendSupervisor's own auto-start spawn) must boot successfully without any
+    network-binding config approval — it never does a real network-facing bind, so
+    check_network_binding doesn't apply to it (backend/main.py). Headless/manual
+    invocations (no --embedded) must remain completely unaffected: still gated by
+    check_network_binding exactly as before this issue."""
+
+    def _base_env(self, tmp_path: Path) -> dict:
+        env = os.environ.copy()
+        env.pop("CLAUDECODE", None)
+        # Isolate from the real ~/.config/cc_webui/config.json (backend/config_manager.py's
+        # CONFIG_DIR is Path.home()-derived) so this test's outcome doesn't depend on
+        # whatever network-binding settings happen to already be on the host machine.
+        env["HOME"] = str(tmp_path)
+        return env
+
+    def test_headless_invocation_still_gated_on_non_loopback_host(self, tmp_path):
+        """No --embedded: a manual/remote invocation requesting a non-loopback --host
+        without prior config approval must still be rejected exactly as before #1850."""
+        env = self._base_env(tmp_path)
+
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "backend.main",
+                "--host", "0.0.0.0",
+                "--port", str(_free_port()),
+                "--token", secrets.token_urlsafe(16),
+                "--data-dir", str(tmp_path / "data"),
+            ],
+            cwd=str(REPO_ROOT),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+
+        assert result.returncode != 0
+        assert "Network binding requires explicit configuration" in result.stdout
+
+    def test_embedded_invocation_boots_without_gate_approval(self, tmp_path):
+        """--embedded must boot and become healthy on loopback with zero config
+        approval — it isn't gated by check_network_binding at all (issue #1850)."""
+        env = self._base_env(tmp_path)
+        port = _free_port()
+
+        proc = subprocess.Popen(
+            [
+                sys.executable, "-m", "backend.main",
+                "--embedded",
+                "--port", str(port),
+                "--token", secrets.token_urlsafe(16),
+                "--data-dir", str(tmp_path / "data"),
+            ],
+            cwd=str(REPO_ROOT),
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        try:
+            _wait_healthy(port, proc, "backend.main (embedded)")
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=5)

--- a/main.py
+++ b/main.py
@@ -181,7 +181,7 @@ def main():
             extra_backend_args=extra_backend_args,
             log_dir=data_dir_path / "logs" / "backend",
         )
-        print(f"Auto-starting Backend on 127.0.0.1:{backend_supervisor.port}")
+        print(f"Auto-starting Backend (embedded) on {backend_supervisor.host}:{backend_supervisor.port}")
 
     # Create FastAPI app
     app = create_app(

--- a/src/backend_supervisor.py
+++ b/src/backend_supervisor.py
@@ -4,7 +4,11 @@ subprocess (issue #498, Phase 3).
 Used by main.py's lifespan when no --remote-backend-url is given: auto-starts
 Backend bound to 127.0.0.1 with an OS-assigned free port and a freshly
 generated backend-scoped token — the single-user self-hosted case needs zero
-manual configuration for this to work.
+manual configuration for this to work. Passes --embedded so backend/main.py
+also binds Docker's default bridge gateway (if reachable on this host) for
+Docker sidecar reachability on native Docker Engine hosts (issue #1850) —
+see backend/docker_utils.py's build_embedded_sockets() for how that bind set
+is constructed.
 """
 
 import asyncio
@@ -83,6 +87,9 @@ class BackendSupervisor:
             "--port", str(self.port),
             "--token", self.token,
             "--data-dir", str(self.data_dir),
+            # Tells backend/main.py it was auto-started by this supervisor, not run
+            # manually/remotely — see backend/main.py's --embedded help text (#1850).
+            "--embedded",
         ]
         if self.experimental:
             cmd.append("--experimental")

--- a/src/tests/test_backend_supervisor.py
+++ b/src/tests/test_backend_supervisor.py
@@ -37,6 +37,9 @@ def test_build_command_includes_required_flags(tmp_path):
     assert "--port" in cmd and str(sup.port) in cmd
     assert "--token" in cmd and sup.token in cmd
     assert "--data-dir" in cmd and str(tmp_path) in cmd
+    # Tells backend/main.py it's auto-started, not a manual/remote invocation
+    # (issue #1850) — enables the loopback+Docker-bridge embedded bind set.
+    assert "--embedded" in cmd
     # Never spawned via "uv run" — see class docstring for why (SIGTERM propagation).
     assert cmd[0] != "uv"
 


### PR DESCRIPTION
## Summary

Auto-started Backend (`BackendSupervisor`) was unreachable from Docker sandbox containers on native Docker Engine hosts — the socket was hard-bound to `127.0.0.1`, which refuses connections arriving via the Docker bridge/host-gateway route. Docker Desktop/WSL2 masked this in dev because their mirrored networking makes `127.0.0.1` transparent across the VM boundary; native Linux Docker Engine has no such transparency.

**Design note — this diverges from the originally-approved plan, by necessity, not choice.** The approved plan called for a blanket `0.0.0.0` bind for the auto-started Backend, gated only by a new `bind_host`/`host` split. Implementing that literally surfaced a real, would-have-shipped-broken regression: `backend/main.py`'s `check_network_binding()` unconditionally rejects any non-loopback `--host` unless the user has already manually opted in via config — which is exactly nobody, by default. That would have broken **every** single-user auto-started install, not just the Docker case this issue targets. Fixing that blocker led, through a live design discussion with the user, to a materially better final design (see below) that also avoids ever touching the network-binding consent gate at all — a meaningfully safer outcome than the original plan's approach.

## What changed

- **`src/backend_supervisor.py`**: `_build_command()` now passes `--embedded` when spawning `backend.main` (alongside the unchanged `--host 127.0.0.1`, `base_url`, etc. — nothing else here changed).
- **`backend/main.py`**: new `--embedded` flag, set only by `BackendSupervisor`, never for manual/remote use.
  - Skips `check_network_binding()` entirely — embedded mode never does a real network-facing (wildcard/LAN) bind, so the consent gate doesn't apply to it. **Manual/remote (non-`--embedded`) invocations are completely unaffected** — gated exactly as before this change.
  - Instead of a single `uvicorn.run(host=..., port=...)`, builds a list of pre-bound sockets and serves via `uvicorn.Server(...).run(sockets=...)`: always binds loopback, and additionally binds Docker's default bridge gateway if that address is actually bindable on this host.
- **`backend/docker_utils.py`**: two new functions.
  - `detect_docker_bridge_gateway()` — host-side `docker network inspect bridge` (no container spawned), returns the gateway IP or `None`. Runs via `subprocess.run(timeout=...)` in a worker thread (`asyncio.to_thread`) rather than asyncio subprocess + `asyncio.wait_for` — see "WSL2 live validation" below for why.
  - `build_embedded_sockets()` — binds loopback + the gateway (if given); a failed gateway bind is caught and silently skipped, which is exactly what happens on Docker Desktop/Rancher (their bridge lives inside a VM, not the real host) or when Docker isn't installed — loopback-only, same as before this issue existed.
- **`main.py`** (Frontend): startup print reverted to describe the accurate subset (`127.0.0.1:port`) rather than a specific `bind_host` value that no longer exists as a single attribute.
- Tests: `backend/tests/test_docker_utils.py` (new function unit tests), `backend/tests/test_main_entrypoint.py` (live subprocess tests for both `--embedded` boot-without-gate-approval and headless-still-gated), `src/tests/test_backend_supervisor.py` (`--embedded` in spawned command).

## Why not the original plan's approach

The plan's own "out of scope" section reasoned about `check_network_binding` and concluded it only gates "manual/standalone entrypoints" — that assumption was incorrect; the gate is unconditional in `backend/main.py` regardless of who invokes it. Once that was found (via code review + direct reproduction — confirmed live: `python -m backend.main --host 0.0.0.0 ...` against a fresh config prints the gate's error and exits nonzero), an env-var bypass mechanism was drafted and then deliberately scrapped in favor of the current design after further review, because binding specifically to loopback + the real Docker bridge address (rather than a wildcard) is strictly narrower and never needs to touch the consent gate at all — it isn't a real network exposure in the sense the gate exists to prevent.

## WSL2 live validation (found and fixed a real bug)

The user ran the test suite on a real WSL2 + Docker Desktop host and hit a genuine hang in `detect_docker_bridge_gateway()`'s embedded-mode boot test (`INTERNALERROR`/pytest-timeout, not a clean assertion failure). Two fix attempts based on asyncio-native cancellation (`asyncio.wait_for` around the subprocess call, then also around a kill+reap cleanup step) **both still hung identically** — the `docker` CLI's cross-boundary call into the Windows-side Docker Desktop daemon never actually responded to cooperative asyncio cancellation at all. The fix that actually worked: run the stdlib's own `subprocess.run(timeout=...)` (long-hardened kill+reap, not reliant on asyncio cancellation) inside a worker thread via `asyncio.to_thread()`, bounded by an outer `asyncio.wait_for` that only needs to stop waiting on the thread's result rather than interrupt anything itself.

Along the way, two more issues surfaced that turned out to be unrelated to this PR entirely, for anyone hitting similar symptoms in the future:
- The project's `.venv` was on a `/mnt/c/...` Windows-backed WSL2 mount — importing `litellm`'s dependency chain (`boto3`/`botocore`, hundreds of files) from there was slow enough to itself time out a completely unrelated, pre-existing test (`test_create_app_lifespan_serves_health`). Moving the venv to native WSL2 filesystem resolved it.
- A `timeout -s KILL` diagnostic command (used to manually inspect boot behavior, SIGKILL rather than graceful shutdown) orphaned a child LiteLLM proxy process still bound to `litellm_proxy_manager.py`'s hardcoded port 4000, which then broke every subsequent test that boots a real Backend until that orphan was killed.

After all three fixes (the real one + ruling out the two environment red herrings), the full suite passes clean on WSL2 + Docker Desktop with no failures — only pre-existing, unrelated warnings (a Starlette/httpx deprecation notice, and a documented benign `RuntimeWarning` in an existing test).

## Explicitly out of scope (unchanged from the original plan)

- `backend/main.py`'s own `--host` default for manual/remote Backend runs.
- `configure_webui_base_url()`, `claude-docker`'s `--add-host` wiring, `addon.py`'s `_fetch_routing()`.
- `litellm_proxy_manager`'s own `127.0.0.1` base_url (separate Docker-reachability mechanism).
- `host` constructor params on `SessionCoordinator`/`BackendApp`/`ClaudeWebUI` (their own explicit `--host` flag, OAuth callback listener bind).
- `AuthMiddleware`'s `EXEMPT_PATHS`/`EXEMPT_SUFFIXES`.

## Test plan

- [x] `uv run ruff check` — zero violations on all changed files
- [x] Full suite: `uv run pytest backend/tests/ src/tests/ -v` — 2472 passed in this sandbox; the only 7 failures are pre-existing and unrelated (confirmed identical on unmodified `HEAD`: `test_api_links.py`, `test_issue_1598_poll_viewed_timing.py`, `test_overseer_controller.py` — Mock/await and timestamp issues, nothing to do with networking)
- [x] Mandatory two-process E2E test (`src/tests/test_live_two_process_e2e.py`) and Frontend CLI entrypoint smoke test (`src/tests/test_main_entrypoint.py`) both pass
- [x] Manual live verification in this sandbox: ran the real Frontend process with no `--remote-backend-url` (so `BackendSupervisor` genuinely auto-starts Backend), confirmed the spawned command includes `--embedded`, Backend's log shows `Embedded Backend listening on: 127.0.0.1:<port>` (this sandbox has no Docker daemon, so it correctly fell back to loopback-only), and `/health`+`/ready` both succeeded through Frontend's relay — with **zero manual config changes**
- [x] `builder-review` run twice (before and after the redesign); findings triaged, three fixed: `server.run(sockets=...)` instead of a bare `asyncio.run(server.serve(...))` (was silently skipping `uvloop`), an explicit check that loopback specifically bound successfully, and a tighter startup-path timeout on the Docker-bridge probe
- [x] **Live-validated on WSL2 + Docker Desktop** (real user hardware, not sandboxed): full suite passes clean after the fixes above — see "WSL2 live validation" section
- [x] **Live-validated on native Linux Docker Engine (T1, the actual scenario this issue targets)**: confirmed with the real production feature, not a synthetic check — a full Docker-sandboxed session (proxy sidecar, SSH proxy, the complete `claude-docker` setup this issue is about) launched and worked end-to-end against the auto-started, embedded-mode Backend. This is the dual-bind path (loopback + real bridge gateway) actually being exercised by a genuine sandboxed container, confirming the fix works as intended on the platform it was written for.
- [x] **Live-validated on macOS + Rancher Desktop (Docker mode)**: confirmed working. Rancher Desktop is a Lima-VM-based Docker runtime — same category as Docker Desktop/WSL2 (bridge lives inside its own VM, not the real host), a case this codebase's `claude-docker` script already explicitly documents handling for its own host-IP probe. Behaves as expected: loopback-only bind, no regression, session containers reach Backend the same way they did before this issue.

All three target platforms (native Linux Docker Engine, WSL2 + Docker Desktop, macOS + Rancher Desktop) are now live-validated on real hardware.

Resolves #1850

🤖 Generated with [Claude Code](https://claude.com/claude-code)


