### PR TITLE
fix: compute per-turn usage/cost deltas instead of summing cumulative SDK snapshots (#1838)

### DIFF
--- a/backend/analytics_store.py
+++ b/backend/analytics_store.py
@@ -39,8 +39,14 @@ class AnalyticsStore:
         model: str | None,
         usage: dict,
         sdk_total_cost_usd: float | None,
-    ) -> None:
-        """Insert a turn_usage row (idempotent) and upsert session aggregate."""
+    ) -> bool:
+        """Insert a turn_usage row (idempotent) and upsert session aggregate.
+
+        Returns True on success, False if the write failed (issue #1838's
+        per-turn-delta baseline needs to know this: it must not advance past
+        a turn whose delta was never durably persisted, or that turn's
+        contribution is lost forever instead of merged into the next delta).
+        """
         input_tokens = int(usage.get("input_tokens") or 0)
         output_tokens = int(usage.get("output_tokens") or 0)
         # SDK uses cache_creation_input_tokens; normalize to cache_write_tokens
@@ -107,6 +113,8 @@ class AnalyticsStore:
             )
         except Exception:
             logger.exception("Failed to record turn usage for session %s", session_id)
+            return False
+        return True
 
     async def get_session_usage(self, session_id: str) -> dict | None:
         """Return session aggregate as dict, or None if no data exists yet."""

--- a/backend/session_coordinator.py
+++ b/backend/session_coordinator.py
@@ -212,6 +212,55 @@ def _normalize_result_usage(
     return agg, (cost if has_cost else None)
 
 
+def _delta_from_baseline(
+    usage: dict,
+    sdk_cost: float | None,
+    baseline: dict[str, float] | None,
+) -> tuple[dict, float | None, dict[str, float]]:
+    """Compute per-turn deltas from cumulative-since-subprocess snapshots.
+
+    `baseline` is None at the first turn of a new epoch (post-restart or
+    brand new session) — treated as an all-zero prior snapshot, so the
+    delta equals the turn's full raw value, exactly as intended.
+
+    A field's absence is NOT the same as a real zero: `usage` is not
+    guaranteed to carry all 4 token keys on every ResultMessage — e.g.
+    backend/tests/fixtures/multi_turn/messages.jsonl has ResultMessages
+    with `total_cost_usd` present and `usage` entirely absent, and
+    `_normalize_result_usage()`'s passthrough branch
+    (`return dict(usage), None`) copies whatever partial shape the SDK
+    sent rather than guaranteeing all 4 keys. Treating a missing key as 0
+    and writing that 0 into the baseline would corrupt the *next* turn's
+    delta for that field (the same failure mode `sdk_cost is None`
+    already guards against for cost) — so missing/None fields contribute
+    0 delta for *this* turn but leave that field's baseline untouched,
+    symmetric with the cost handling below.
+    """
+    fields = (
+        "input_tokens", "output_tokens",
+        "cache_creation_input_tokens", "cache_read_input_tokens",
+    )
+    baseline = dict(baseline or {})
+    delta: dict[str, float] = {}
+    for k in fields:
+        if k in usage and usage[k] is not None:
+            current = float(usage[k])
+            delta[k] = max(0.0, current - baseline.get(k, 0.0))
+            baseline[k] = current
+        else:
+            delta[k] = 0.0
+            # field not reported this turn — leave baseline[k] untouched
+
+    delta_cost = None
+    if sdk_cost is not None:
+        delta_cost = max(0.0, float(sdk_cost) - baseline.get("total_cost_usd", 0.0))
+        baseline["total_cost_usd"] = float(sdk_cost)
+    # else: no cost reported this turn — leave total_cost_usd baseline
+    # untouched so the next turn's delta is still computed correctly.
+
+    return delta, delta_cost, baseline
+
+
 def _tail_read_lines(path: "Path", limit: int) -> list[str]:
     """Read the last `limit` lines from a file efficiently using a deque."""
     from collections import deque
@@ -495,6 +544,10 @@ class SessionCoordinator:
         self.analytics_store = None
         # Per-session turn sequence counters (rehydrated lazily from DB on first use)
         self._turn_seq_by_session: dict[str, int] = {}
+        # Issue #1838: last-seen raw cumulative usage/cost snapshot per session,
+        # used to compute true per-turn deltas from the SDK's cumulative-since-
+        # subprocess-start counters. Reset at every new-SDK-creation epoch boundary.
+        self._usage_baseline_by_session: dict[str, dict[str, float]] = {}
         # Callback for broadcasting usage_updated events (injected by web_server)
         self._usage_broadcast_callback: Callable[[str, dict], None] | None = None
 
@@ -1895,6 +1948,12 @@ class SessionCoordinator:
             sdk.auto_approval_callback = self._create_auto_approval_callback(session_id)
             self._active_sdks[session_id] = sdk
 
+            # Issue #1838: a new SDK subprocess starts its own cumulative usage/cost
+            # counters from zero, so the per-turn delta baseline must reset here too —
+            # this fires on every genuine new-epoch creation (initial start, resume,
+            # restart, reset) and never on the "already running" early return above.
+            self._usage_baseline_by_session.pop(session_id, None)
+
             # Initialize callback lists if not exists (preserve existing callbacks)
             if session_id not in self._message_callbacks:
                 self._message_callbacks[session_id] = []
@@ -2390,6 +2449,7 @@ class SessionCoordinator:
                     try:
                         await self.analytics_store.delete_session(session_id)
                         self._turn_seq_by_session.pop(session_id, None)
+                        self._usage_baseline_by_session.pop(session_id, None)
                     except Exception:
                         logger.exception("Failed to delete analytics for session %s", session_id)
                 # Notify about session deletion (using a special state change)
@@ -4914,8 +4974,16 @@ class SessionCoordinator:
                                 self._turn_seq_by_session[session_id] = db_count
                             self._turn_seq_by_session[session_id] += 1
                             turn_seq = self._turn_seq_by_session[session_id]
+                            # Issue #1838: usage/total_cost_usd are cumulative snapshots
+                            # since subprocess start, not per-turn values — convert to
+                            # true per-turn deltas before recording.
+                            baseline = self._usage_baseline_by_session.get(session_id)
+                            usage_delta, cost_delta, new_baseline = _delta_from_baseline(
+                                usage, sdk_cost, baseline
+                            )
+                            self._usage_baseline_by_session[session_id] = new_baseline
                             await self.analytics_store.record_turn(
-                                session_id, turn_seq, _model, usage, sdk_cost
+                                session_id, turn_seq, _model, usage_delta, cost_delta
                             )
                             aggregate = await self.analytics_store.get_session_usage(session_id)
                             if aggregate and self._usage_broadcast_callback:

--- a/backend/session_coordinator.py
+++ b/backend/session_coordinator.py
@@ -4981,10 +4981,15 @@ class SessionCoordinator:
                             usage_delta, cost_delta, new_baseline = _delta_from_baseline(
                                 usage, sdk_cost, baseline
                             )
-                            self._usage_baseline_by_session[session_id] = new_baseline
-                            await self.analytics_store.record_turn(
+                            turn_recorded = await self.analytics_store.record_turn(
                                 session_id, turn_seq, _model, usage_delta, cost_delta
                             )
+                            if turn_recorded:
+                                self._usage_baseline_by_session[session_id] = new_baseline
+                            # else: leave the baseline un-advanced — the next successful
+                            # write computes its delta against the stale baseline, so this
+                            # turn's un-recorded usage/cost is naturally absorbed into that
+                            # turn's delta rather than lost.
                             aggregate = await self.analytics_store.get_session_usage(session_id)
                             if aggregate and self._usage_broadcast_callback:
                                 try:

--- a/backend/tests/test_analytics_store.py
+++ b/backend/tests/test_analytics_store.py
@@ -136,3 +136,25 @@ async def test_cache_field_aliases_are_mapped(store):
     agg = await store.get_session_usage("sid-7")
     assert agg["cache_write_tokens"] == 8
     assert agg["cache_read_tokens"] == 4
+
+
+# ---------------------------------------------------------------------------
+# record_turn() success/failure signal (issue #1838 follow-up)
+# ---------------------------------------------------------------------------
+
+
+async def test_record_turn_returns_true_on_success(store):
+    assert await store.record_turn("sid-8", 1, None, {"input_tokens": 10}, 0.01) is True
+
+
+async def test_record_turn_returns_false_on_write_failure(store, monkeypatch):
+    async def failing_execute_write(*args, **kwargs):
+        raise RuntimeError("db locked")
+
+    monkeypatch.setattr(store._db, "execute_write", failing_execute_write)
+
+    assert await store.record_turn("sid-9", 1, None, {"input_tokens": 10}, 0.01) is False
+
+    # No row should have been recorded.
+    agg = await store.get_session_usage("sid-9")
+    assert agg is None

--- a/backend/tests/test_session_coordinator.py
+++ b/backend/tests/test_session_coordinator.py
@@ -2955,3 +2955,60 @@ class TestIssue1838UsageBaselineReset:
 
         assert success is True
         assert coordinator._usage_baseline_by_session[session_id] == {"total_cost_usd": 42.0}
+
+
+class TestIssue1838RecordTurnFailurePreservesBaseline:
+    """If analytics_store.record_turn() fails to persist a turn, the in-memory
+    baseline must NOT advance — otherwise that turn's usage/cost is lost forever
+    instead of being naturally absorbed into the next successfully-recorded
+    turn's delta (issue #1838 follow-up)."""
+
+    @pytest.mark.asyncio
+    async def test_failed_write_does_not_advance_baseline_and_next_turn_absorbs_it(
+        self, temp_coordinator
+    ):
+        coordinator = temp_coordinator
+        session_id = "test-session-1838-failure"
+
+        coordinator.analytics_store = AsyncMock()
+        coordinator.analytics_store.get_turn_count.return_value = 0
+        coordinator.analytics_store.get_session_usage.return_value = None
+        # First call (turn 1) fails to persist; second call (turn 2) succeeds.
+        coordinator.analytics_store.record_turn = AsyncMock(side_effect=[False, True])
+
+        message_callback = coordinator._create_message_callback(session_id)
+
+        # Turn 1: cumulative usage since subprocess start = 100 input tokens, $10.00.
+        await message_callback({
+            "type": "result",
+            "timestamp": 1700000000.0,
+            "session_id": session_id,
+            "usage": {"input_tokens": 100, "output_tokens": 0},
+            "total_cost_usd": 10.0,
+        })
+
+        # The failed write must leave no baseline behind.
+        assert session_id not in coordinator._usage_baseline_by_session
+
+        # Turn 2: cumulative usage since subprocess start = 250 input tokens, $22.50.
+        await message_callback({
+            "type": "result",
+            "timestamp": 1700000010.0,
+            "session_id": session_id,
+            "usage": {"input_tokens": 250, "output_tokens": 0},
+            "total_cost_usd": 22.5,
+        })
+
+        # Turn 2's delta must be computed against the un-advanced (still-absent)
+        # baseline, so it equals the FULL raw cumulative value (250 / $22.50) —
+        # naturally including turn 1's un-recorded 100 tokens / $10.00, not just
+        # the 150 / $12.50 that turn 2 alone contributed.
+        assert coordinator.analytics_store.record_turn.call_count == 2
+        second_call_args = coordinator.analytics_store.record_turn.call_args_list[1].args
+        _, _, _, usage_delta_arg, cost_delta_arg = second_call_args
+        assert usage_delta_arg["input_tokens"] == 250
+        assert cost_delta_arg == 22.5
+
+        # And the baseline is now correctly advanced to the latest cumulative value.
+        assert coordinator._usage_baseline_by_session[session_id]["input_tokens"] == 250
+        assert coordinator._usage_baseline_by_session[session_id]["total_cost_usd"] == 22.5

--- a/backend/tests/test_session_coordinator.py
+++ b/backend/tests/test_session_coordinator.py
@@ -2898,3 +2898,60 @@ class TestCreateEphemeralSession:
         session_info = await coordinator.session_manager.get_session_info(session_id)
         assert session_info.is_ephemeral is True
         assert session_info.name == "[Scheduled] hourly-check"
+
+
+class TestIssue1838UsageBaselineReset:
+    """The per-turn usage delta baseline must reset exactly on start_session()'s
+    new-SDK-creation path (initial start/resume/restart/reset), and never on the
+    "already running" early-return path — an authoritative lifecycle boundary,
+    not value-trend inference (issue #1838)."""
+
+    @pytest.mark.asyncio
+    async def test_start_session_resets_baseline_on_new_sdk_creation(
+        self, temp_coordinator, sample_session_config
+    ):
+        coordinator = temp_coordinator
+        session_id = await coordinator.create_session(**sample_session_config)
+
+        mock_sdk_instance = AsyncMock()
+        mock_sdk_instance.start.return_value = True
+        mock_sdk_instance.is_running = Mock(return_value=False)  # is_running() is sync on the real SDK
+        coordinator.set_sdk_factory(Mock(return_value=mock_sdk_instance))
+
+        # Seed a stale baseline as if a prior epoch had already recorded usage.
+        coordinator._usage_baseline_by_session[session_id] = {"total_cost_usd": 999.0}
+
+        success = await coordinator.start_session(session_id)
+
+        assert success is True
+        assert session_id not in coordinator._usage_baseline_by_session
+
+    @pytest.mark.asyncio
+    async def test_start_session_early_return_does_not_reset_baseline(
+        self, temp_coordinator, sample_session_config
+    ):
+        coordinator = temp_coordinator
+        session_id = await coordinator.create_session(**sample_session_config)
+
+        mock_sdk_instance = AsyncMock()
+        mock_sdk_instance.start.return_value = True
+        mock_sdk_instance.is_running = Mock(return_value=False)  # is_running() is sync on the real SDK
+        coordinator.set_sdk_factory(Mock(return_value=mock_sdk_instance))
+
+        # First call creates the SDK (not yet running).
+        await coordinator.start_session(session_id)
+
+        # Session state must be startable again (e.g. paused without the SDK
+        # subprocess itself stopping) for a second start_session() call to reach
+        # the coordinator's "already running" check at all.
+        await coordinator.session_manager.update_session_state(session_id, SessionState.PAUSED)
+
+        # Now the SDK reports as running, so the second call takes the
+        # "already running" early return and must not touch the baseline.
+        mock_sdk_instance.is_running.return_value = True
+        coordinator._usage_baseline_by_session[session_id] = {"total_cost_usd": 42.0}
+
+        success = await coordinator.start_session(session_id)
+
+        assert success is True
+        assert coordinator._usage_baseline_by_session[session_id] == {"total_cost_usd": 42.0}

--- a/backend/tests/test_session_coordinator_usage.py
+++ b/backend/tests/test_session_coordinator_usage.py
@@ -1,5 +1,5 @@
 """Unit tests for usage normalisation against SDK 0.1.72+ (issue #1287)."""
-from backend.session_coordinator import _normalize_result_usage
+from backend.session_coordinator import _delta_from_baseline, _normalize_result_usage
 
 
 def test_prefers_usage_when_populated():
@@ -69,3 +69,130 @@ def test_empty_inputs_return_empty_dict():
     out, cost = _normalize_result_usage({}, {})
     assert out == {}
     assert cost is None
+
+
+# --- Issue #1838: per-turn delta computation from cumulative SDK snapshots ---
+
+
+def test_t1_single_epoch_no_restart_deltas_sum_to_last_cumulative():
+    cumulative_costs = [24.79, 84.98, 90.60, 91.43, 93.78, 96.58, 117.62]
+    baseline = None
+    total_cost = 0.0
+    for c in cumulative_costs:
+        _, delta_cost, baseline = _delta_from_baseline({}, c, baseline)
+        total_cost += delta_cost
+    assert abs(total_cost - cumulative_costs[-1]) < 1e-9
+
+
+def test_t2_restart_new_epoch_stays_below_old_peak():
+    baseline = None
+    total_cost = 0.0
+    for c in (50.0, 80.0):
+        _, delta_cost, baseline = _delta_from_baseline({}, c, baseline)
+        total_cost += delta_cost
+    assert total_cost == 80.0
+
+    # Simulate the start_session() reset hook for a new epoch.
+    baseline = None
+    for c in (10.0, 30.0):
+        _, delta_cost, baseline = _delta_from_baseline({}, c, baseline)
+        total_cost += delta_cost
+
+    # Old epoch's peak (80.0) is fully preserved; new epoch's own 30.0 is added on top.
+    assert total_cost == 110.0
+
+
+def test_t3_restart_new_epoch_first_turn_exceeds_old_peak():
+    baseline = None
+    total_cost = 0.0
+    for c in (50.0, 80.0):
+        _, delta_cost, baseline = _delta_from_baseline({}, c, baseline)
+        total_cost += delta_cost
+
+    # Restart: new epoch's first turn already exceeds the old epoch's peak.
+    baseline = None
+    _, delta_cost, baseline = _delta_from_baseline({}, 200.0, baseline)
+    total_cost += delta_cost
+
+    # Old epoch's cost must still be fully counted, not dropped/overwritten.
+    assert total_cost == 280.0
+
+
+def test_t4_multiple_restarts_every_epoch_counted_once():
+    epochs = [[24.79, 84.98], [1.08, 5.0], [0.5]]
+    total_cost = 0.0
+    for epoch in epochs:
+        baseline = None
+        for c in epoch:
+            _, delta_cost, baseline = _delta_from_baseline({}, c, baseline)
+            total_cost += delta_cost
+    assert abs(total_cost - (84.98 + 5.0 + 0.5)) < 1e-9
+
+
+def test_regression_issue_1838_real_numbers_not_600_86():
+    """Reproduces the issue's real session: summing cumulative snapshots directly
+    gives $600.86; true per-turn deltas must sum to ~$118.70."""
+    epoch1_cumulative = [24.79, 84.98, 90.60, 91.43, 93.78, 96.58, 117.62]
+    epoch2_cumulative = [1.08]
+
+    naive_sum = sum(epoch1_cumulative) + sum(epoch2_cumulative)
+    assert abs(naive_sum - 600.86) < 1e-2  # sanity-check the buggy baseline
+
+    total_cost = 0.0
+    baseline = None
+    for c in epoch1_cumulative:
+        _, delta_cost, baseline = _delta_from_baseline({}, c, baseline)
+        total_cost += delta_cost
+
+    baseline = None  # simulate start_session()'s new-SDK-creation reset hook
+    for c in epoch2_cumulative:
+        _, delta_cost, baseline = _delta_from_baseline({}, c, baseline)
+        total_cost += delta_cost
+
+    assert abs(total_cost - 118.70) < 1e-6
+
+
+def test_missing_usage_fields_leave_baseline_untouched():
+    """A field absent from `usage` must contribute 0 delta this turn but must NOT
+    zero out its baseline, matching backend/tests/fixtures/multi_turn/messages.jsonl's
+    real ResultMessage with `usage` entirely absent."""
+    baseline = {"input_tokens": 100.0, "output_tokens": 50.0}
+
+    delta, delta_cost, new_baseline = _delta_from_baseline({}, None, baseline)
+
+    assert delta == {
+        "input_tokens": 0.0,
+        "output_tokens": 0.0,
+        "cache_creation_input_tokens": 0.0,
+        "cache_read_input_tokens": 0.0,
+    }
+    assert delta_cost is None
+    assert new_baseline["input_tokens"] == 100.0
+    assert new_baseline["output_tokens"] == 50.0
+    assert "total_cost_usd" not in new_baseline
+
+    # The following turn with real values must compute its delta against the
+    # preserved baseline, not a spuriously zeroed one.
+    delta2, _, _ = _delta_from_baseline(
+        {"input_tokens": 150, "output_tokens": 80}, None, new_baseline
+    )
+    assert delta2["input_tokens"] == 50.0
+    assert delta2["output_tokens"] == 30.0
+
+
+def test_none_baseline_treated_as_all_zero():
+    delta, delta_cost, new_baseline = _delta_from_baseline(
+        {"input_tokens": 10, "output_tokens": 5}, 1.5, None
+    )
+    assert delta == {
+        "input_tokens": 10.0,
+        "output_tokens": 5.0,
+        "cache_creation_input_tokens": 0.0,
+        "cache_read_input_tokens": 0.0,
+    }
+    assert delta_cost == 1.5
+    assert new_baseline == {
+        "input_tokens": 10.0,
+        "output_tokens": 5.0,
+        "total_cost_usd": 1.5,
+    }


### PR DESCRIPTION
## Summary

- The turn-completion handler in `backend/session_coordinator.py` fed each `ResultMessage`'s `usage`/`total_cost_usd` straight into `analytics_store.record_turn()` as if they were per-turn values. They're actually counters cumulative since the SDK subprocess started, so summing them across turns inflated a real session's reported cost by ~5x ($600.86 reported vs ~$118.70 actual spend).
- Adds a per-session baseline of the last-seen cumulative snapshot (`self._usage_baseline_by_session`), reset exactly at `start_session()`'s new-SDK-creation point — the single authoritative epoch boundary that covers initial start, resume, restart, and reset uniformly (never on the "already running" early-return path).
- Adds `_delta_from_baseline()`, a pure helper that converts each turn's cumulative usage/cost into a true per-turn delta before recording, with symmetric missing-field handling: an absent/`None` token field or cost this turn contributes 0 delta but leaves that field's baseline untouched, so it doesn't corrupt the next turn's delta (mirrors the existing `sdk_cost is None` guard).
- Out of scope, matching the approved plan: no retroactive correction of historical `turn_usage`/`session_usage` rows, no changes to `estimated_cost_usd`/pricing logic, and issues #1831 (NULL model fallback) / #1840 (subagent usage never recorded) are left untouched.

### Deliberate small deviation from the approved plan's scope

The plan specified no `analytics_store.py` changes. Post-review, a builder-review pass (3 independent finder angles) surfaced a real gap: the in-memory baseline was committed the moment a delta was computed, regardless of whether `analytics_store.record_turn()`'s DB write actually succeeded — and `record_turn()` already swallowed write exceptions silently with no success/failure signal. A transient DB failure would therefore permanently drop that turn's usage/cost, since the baseline had already advanced past it with no way to recover it on a later turn — a materially worse failure mode than the original bug (each turn's row used to be self-contained).

Fixed with a minimal, requested change: `record_turn()` now returns `bool` (success/failure) instead of swallowing silently with no signal, and the call site only commits the new baseline when it returns `True`. On failure, the baseline is left as-is, so the next successful turn's delta is computed against the stale baseline and naturally absorbs the unrecorded turn's contribution instead of losing it — the same self-healing pattern already used for missing usage fields. No other changes to `record_turn()`'s logic/logging.

## Test plan

- [x] New unit tests for `_delta_from_baseline()` in `backend/tests/test_session_coordinator_usage.py`: T1 (single epoch), T2 (restart, new epoch stays below old peak), T3 (restart, new epoch's first turn exceeds old peak), T4 (multiple restarts), a regression test reproducing the issue's real numbers (sums to ~$118.70, not $600.86), a missing-usage-field test (baseline preserved, not zeroed), and a `None`-baseline-as-zero test.
- [x] New tests in `backend/tests/test_session_coordinator.py` (`TestIssue1838UsageBaselineReset`) confirming `start_session()` resets the baseline on genuine new-SDK-creation and leaves it untouched on the "already running" early return.
- [x] New test (`TestIssue1838RecordTurnFailurePreservesBaseline`) confirming a failed `record_turn()` write does not advance the baseline, and the next successful turn's delta correctly includes both the failed turn's and the new turn's combined contribution.
- [x] New tests in `backend/tests/test_analytics_store.py` confirming `record_turn()` returns `True` on success and `False` on a simulated DB write failure, with no row persisted on failure.
- [x] Full suite: `uv run pytest backend/tests/ src/tests/ -v` — 2484 passed. The 7 pre-existing failures (`test_api_links`, `test_issue_1598_poll_viewed_timing`, `test_overseer_controller`) reproduce identically on `main` with this diff stashed, confirming they're unrelated to this change.
- [x] Mandatory two-process E2E test: `src/tests/test_live_two_process_e2e.py` passes.
- [x] `uv run ruff check` clean on all changed files.
- [x] `builder-review` (8-angle review) run against the diff; findings triaged. The recurring, independently-corroborated baseline-before-persistence finding above is now fixed. Remaining findings (architecture-placement preferences for where the cumulative-to-delta conversion should live, minor DRY/comment duplication, test parametrization style) were style/design opinions on a plan that was already reviewed and approved, and were dismissed as out of Builder scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)