### PR TITLE
fix: dynamic LiteLLM proxy port allocation, fix provider_catalog sentinel bug (#1825)

### DIFF
--- a/backend/litellm_proxy_manager.py
+++ b/backend/litellm_proxy_manager.py
@@ -37,7 +37,7 @@ class LiteLLMProxyManager:
         self,
         catalog_manager: ProviderCatalogManager,
         vault,
-        port: int = 4000,
+        port: int,
         *,
         config_file: Path | None = None,
     ):
@@ -291,22 +291,28 @@ class LiteLLMProxyManager:
         config = uvicorn.Config(_ps.app, host="0.0.0.0", port=self._port, log_level="warning")
         server = uvicorn.Server(config)
         self._server = server
-        self._server_task = asyncio.create_task(server.serve())
+
+        async def _serve() -> None:
+            # uvicorn calls sys.exit(1) on bind failure. asyncio.Task special-cases
+            # SystemExit/KeyboardInterrupt: it re-raises them out of the event loop
+            # instead of just failing this task (see Task.__step), so left uncaught
+            # here a port collision would crash the whole process. Converting to a
+            # plain RuntimeError makes it a normal task exception the polling loop
+            # below can retrieve via self._server_task.exception().
+            try:
+                await server.serve()
+            except SystemExit as e:
+                raise RuntimeError(
+                    f"LiteLLM proxy failed to start (port {self._port} in use?)"
+                ) from e
+
+        self._server_task = asyncio.create_task(_serve())
 
         # Wait until uvicorn has actually bound the port before returning.
         deadline = asyncio.get_event_loop().time() + 10.0
         while not server.started:
             if self._server_task.done():
-                try:
-                    exc = self._server_task.exception()
-                except BaseException as e:
-                    exc = e
-                # uvicorn calls sys.exit(1) on bind failure — convert to RuntimeError
-                # so it doesn't propagate as SystemExit and kill the main process.
-                if isinstance(exc, SystemExit):
-                    raise RuntimeError(
-                        f"LiteLLM proxy failed to start (port {self._port} in use?)"
-                    ) from exc
+                exc = self._server_task.exception()
                 raise exc or RuntimeError("LiteLLM proxy task exited during startup")
             if asyncio.get_event_loop().time() > deadline:
                 raise RuntimeError("LiteLLM proxy failed to bind port within 10 seconds")

--- a/backend/main.py
+++ b/backend/main.py
@@ -57,6 +57,11 @@ def main():
         help='Bind address (default: 127.0.0.1, localhost only).'
     )
     parser.add_argument('--port', type=int, default=8100, help='Port to bind to (default: 8100)')
+    parser.add_argument(
+        '--litellm-port', type=int, default=None,
+        help='Pin the embedded LiteLLM proxy to a specific port (default: dynamic '
+             'OS-assigned port, or a previously persisted value in providers.json)'
+    )
     parser.add_argument('--data-dir', default='./data', help='Data directory location (default: ./data)')
     parser.add_argument(
         '--embedded', action='store_true',
@@ -191,6 +196,7 @@ def main():
         auth_token=auth_token,
         host=args.host,
         port=args.port,
+        litellm_port=args.litellm_port,
     )
 
     # Run the server

--- a/backend/provider_catalog.py
+++ b/backend/provider_catalog.py
@@ -90,7 +90,7 @@ class ProviderCatalogStore:
     def __init__(self, data_dir: Path):
         self.providers_file = data_dir / "providers.json"
         self._entries: list[ProviderCatalogEntry] = []
-        self._litellm_port: int = 4000
+        self._litellm_port: int | None = None
         self._pending_changes: bool = False
 
     @property
@@ -98,7 +98,7 @@ class ProviderCatalogStore:
         return self._entries
 
     @property
-    def litellm_port(self) -> int:
+    def litellm_port(self) -> int | None:
         return self._litellm_port
 
     @property
@@ -110,14 +110,14 @@ class ProviderCatalogStore:
         if self.providers_file.exists():
             data = json.loads(self.providers_file.read_text(encoding="utf-8"))
             self._entries = [ProviderCatalogEntry.from_dict(e) for e in data.get("entries", [])]
-            self._litellm_port = data.get("litellm_port", 4000)
+            self._litellm_port = data.get("litellm_port")
             self._pending_changes = data.get("pending_changes", False)
             return
 
         legacy = self._read_legacy_catalog()
         if legacy:
             self._entries = [ProviderCatalogEntry.from_dict(e) for e in legacy.get("entries", [])]
-            self._litellm_port = legacy.get("litellm_port", 4000)
+            self._litellm_port = legacy.get("litellm_port")
             self._pending_changes = legacy.get("pending_changes", False)
             await self._save()
             legion_logger.info(
@@ -131,7 +131,7 @@ class ProviderCatalogStore:
         try:
             data = json.loads(_LEGACY_CONFIG_FILE.read_text(encoding="utf-8"))
             pc = data.get("provider_catalog")
-            if pc and (pc.get("entries") or pc.get("litellm_port", 4000) != 4000):
+            if pc and (pc.get("entries") or "litellm_port" in pc):
                 return pc
         except Exception:
             pass

--- a/backend/tests/test_issue_1825_litellm_port.py
+++ b/backend/tests/test_issue_1825_litellm_port.py
@@ -1,0 +1,126 @@
+"""
+Regression tests for issue #1825 — LiteLLM proxy port defaults to a hardcoded 4000,
+causing two backend instances on one host to collide. The fix makes dynamic
+OS-assigned allocation the default, with CLI flag > persisted providers.json value >
+dynamic port as the resolution precedence, and never persists the dynamic pick.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+
+import pytest
+
+from backend.web_server import BackendApp, _read_litellm_port_sync
+
+# ---------------------------------------------------------------------------
+# _read_litellm_port_sync
+# ---------------------------------------------------------------------------
+
+
+def test_read_litellm_port_sync_returns_none_when_nothing_persisted(tmp_path):
+    assert _read_litellm_port_sync(tmp_path) is None
+
+
+def test_read_litellm_port_sync_returns_persisted_value(tmp_path):
+    (tmp_path / "providers.json").write_text(
+        json.dumps({"entries": [], "litellm_port": 4321, "pending_changes": False}),
+        encoding="utf-8",
+    )
+    assert _read_litellm_port_sync(tmp_path) == 4321
+
+
+# ---------------------------------------------------------------------------
+# BackendApp resolution precedence
+# ---------------------------------------------------------------------------
+
+
+def test_backend_app_default_resolves_dynamic_bindable_port(tmp_path):
+    """No CLI flag, no persisted config — BackendApp picks a real, bindable port."""
+    app = BackendApp(data_dir=tmp_path)
+    port = app.litellm_proxy_manager.port
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", port))
+
+
+def test_two_backend_app_instances_get_different_dynamic_ports(tmp_path):
+    """Two BackendApp instances with no explicit litellm config/CLI flag don't collide."""
+    app_a = BackendApp(data_dir=tmp_path / "a")
+    app_b = BackendApp(data_dir=tmp_path / "b")
+
+    assert app_a.litellm_proxy_manager.port != app_b.litellm_proxy_manager.port
+
+
+def test_cli_pinned_port_takes_precedence_over_persisted_config(tmp_path):
+    """An explicit --litellm-port pin wins even when providers.json has its own value."""
+    (tmp_path / "providers.json").write_text(
+        json.dumps({"entries": [], "litellm_port": 5555, "pending_changes": False}),
+        encoding="utf-8",
+    )
+
+    app = BackendApp(data_dir=tmp_path, litellm_port=9999)
+
+    assert app.litellm_proxy_manager.port == 9999
+
+
+def test_persisted_config_used_when_no_cli_flag(tmp_path):
+    """A persisted providers.json value is honored when no CLI flag overrides it."""
+    (tmp_path / "providers.json").write_text(
+        json.dumps({"entries": [], "litellm_port": 5555, "pending_changes": False}),
+        encoding="utf-8",
+    )
+
+    app = BackendApp(data_dir=tmp_path)
+
+    assert app.litellm_proxy_manager.port == 5555
+
+
+def test_dynamic_port_never_persisted_to_providers_json(tmp_path):
+    """A dynamically-allocated default port must not be written to providers.json —
+    only an explicit CLI flag or an explicit prior persisted value should ever
+    appear there, so restarts keep picking fresh ports."""
+    BackendApp(data_dir=tmp_path)
+
+    providers_file = tmp_path / "providers.json"
+    assert not providers_file.exists()
+
+
+# ---------------------------------------------------------------------------
+# Crash regression: port collision must raise RuntimeError, not SystemExit,
+# and BackendApp.initialize() must swallow it and complete anyway.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_litellm_start_raises_runtime_error_not_system_exit_on_port_collision(tmp_path):
+    app = BackendApp(data_dir=tmp_path)
+    port = app.litellm_proxy_manager.port
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as blocker:
+        blocker.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        blocker.bind(("0.0.0.0", port))
+        blocker.listen(1)
+
+        with pytest.raises(RuntimeError):
+            await app.litellm_proxy_manager.start()
+
+
+@pytest.mark.asyncio
+async def test_backend_app_initialize_survives_litellm_port_collision(tmp_path):
+    """The original crash from issue #1825: a bind failure inside the LiteLLM proxy
+    manager must not take down BackendApp startup — native (non-catalog) sessions
+    still need to work."""
+    app = BackendApp(data_dir=tmp_path)
+    port = app.litellm_proxy_manager.port
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as blocker:
+        blocker.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        blocker.bind(("0.0.0.0", port))
+        blocker.listen(1)
+
+        await app.initialize()  # must not raise
+
+    assert app.litellm_proxy_manager.is_running is False
+    await app.cleanup()

--- a/backend/tests/test_litellm_proxy_manager.py
+++ b/backend/tests/test_litellm_proxy_manager.py
@@ -148,6 +148,30 @@ def test_is_running_false_before_start(manager):
     assert manager.is_running is False
 
 
+# ── Port Resolution Tests (issue #1825) ────────────────────────────────────
+
+
+def test_port_is_a_required_argument():
+    """port no longer defaults to 4000 — BackendApp must always resolve a concrete
+    value before constructing LiteLLMProxyManager."""
+    from backend.litellm_proxy_manager import LiteLLMProxyManager
+
+    with pytest.raises(TypeError):
+        LiteLLMProxyManager(AsyncMock(), AsyncMock())
+
+
+def test_default_port_resolution_picks_real_bindable_port():
+    """The system default (BackendApp's resolution, exercised here via
+    allocate_free_port() directly) yields a port that's actually bindable."""
+    import socket
+
+    from shared.net_utils import allocate_free_port
+
+    port = allocate_free_port()
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", port))
+
+
 # ── Routing Registry Tests (issue #1427 Phase 2) ──────────────────────────────
 
 

--- a/backend/tests/test_provider_catalog_migration.py
+++ b/backend/tests/test_provider_catalog_migration.py
@@ -83,6 +83,31 @@ async def test_no_migration_when_catalog_absent(tmp_path, monkeypatch):
         "providers.json should not be created when nothing to migrate"
     )
     assert store.entries == []
+    assert store.litellm_port is None
+
+
+@pytest.mark.asyncio
+async def test_migration_triggered_when_legacy_port_explicitly_4000(tmp_path, monkeypatch):
+    """Legacy config.json with litellm_port explicitly set to 4000 still migrates.
+
+    Regression test for the sentinel bug (issue #1825): the old migration gate compared
+    the value against 4000, so a legitimate `litellm_port: 4000` was indistinguishable
+    from "never set" and silently skipped migration. The fix checks key presence instead.
+    """
+    legacy_cfg = tmp_path / "config.json"
+    _write_legacy_config(legacy_cfg, {"entries": [], "litellm_port": 4000, "pending_changes": False})
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+
+    import backend.provider_catalog as pc_mod
+    monkeypatch.setattr(pc_mod, "_LEGACY_CONFIG_FILE", legacy_cfg)
+
+    store = ProviderCatalogStore(data_dir)
+    await store.load()
+
+    providers_file = data_dir / "providers.json"
+    assert providers_file.exists(), "providers.json should be created — key presence, not value, gates migration"
     assert store.litellm_port == 4000
 
 

--- a/backend/web_server.py
+++ b/backend/web_server.py
@@ -39,20 +39,24 @@ from .task_utils import task_done_log_exception
 logger = logging.getLogger(__name__)
 
 
-def _read_litellm_port_sync(data_dir: Path, default: int = 4000) -> int:
-    """Read litellm_port from providers.json or legacy config.json without async I/O."""
+def _read_litellm_port_sync(data_dir: Path) -> int | None:
+    """Read litellm_port from providers.json or legacy config.json without async I/O.
+
+    Returns None if no explicit value has ever been persisted — callers fall back to
+    a dynamically-allocated port in that case (issue #1825).
+    """
     import json as _json
     try:
         providers = data_dir / "providers.json"
         if providers.exists():
-            return _json.loads(providers.read_text(encoding="utf-8")).get("litellm_port", default)
+            return _json.loads(providers.read_text(encoding="utf-8")).get("litellm_port")
         legacy = Path.home() / ".config" / "cc_webui" / "config.json"
         if legacy.exists():
             data = _json.loads(legacy.read_text(encoding="utf-8"))
-            return data.get("provider_catalog", {}).get("litellm_port", default)
+            return data.get("provider_catalog", {}).get("litellm_port")
     except Exception:
         pass
-    return default
+    return None
 
 
 class AuthMiddleware(BaseHTTPMiddleware):
@@ -112,7 +116,8 @@ class BackendApp:
                  available_fixtures: list[str] | None = None,
                  config_file: Path | None = None,
                  auth_token: str | None = None,
-                 host: str = "127.0.0.1", port: int = 8000):
+                 host: str = "127.0.0.1", port: int = 8000,
+                 litellm_port: int | None = None):
         self.app = FastAPI(title="Claude Code WebUI Backend", version="1.0.0")
         self.host = host
         self.port = port
@@ -157,9 +162,18 @@ class BackendApp:
         from .provider_catalog import ProviderCatalogManager
         self.app_config_manager = AppConfigManager(config_file=config_file) if config_file else AppConfigManager()
         self.provider_catalog_manager = ProviderCatalogManager(self.coordinator.provider_catalog_store)
-        # Read litellm_port synchronously at init time — providers.json may not exist yet
-        # (store.load() runs in coordinator.initialize()); fall back to legacy config then default 4000.
-        _litellm_port = _read_litellm_port_sync(data_dir or Path("data"))
+        # Resolve the LiteLLM proxy port: explicit CLI flag > explicit persisted value
+        # (providers.json may not exist yet — store.load() runs in coordinator.initialize(),
+        # so read synchronously here — or migrated legacy config.json) > OS-assigned dynamic
+        # port. The dynamic port is never persisted (issue #1825).
+        from shared.net_utils import allocate_free_port
+        _persisted_litellm_port = _read_litellm_port_sync(data_dir or Path("data"))
+        if litellm_port is not None:
+            _litellm_port = litellm_port
+        elif _persisted_litellm_port is not None:
+            _litellm_port = _persisted_litellm_port
+        else:
+            _litellm_port = allocate_free_port()
         self.litellm_proxy_manager = LiteLLMProxyManager(
             self.provider_catalog_manager,
             self.coordinator.credential_vault,
@@ -929,6 +943,7 @@ def create_app(
     auth_token: str | None = None,
     host: str = "127.0.0.1",
     port: int = 8000,
+    litellm_port: int | None = None,
 ) -> FastAPI:
     """Create and configure the Backend FastAPI application"""
     app_instance = BackendApp(
@@ -937,6 +952,7 @@ def create_app(
         available_fixtures=available_fixtures,
         auth_token=auth_token,
         host=host, port=port,
+        litellm_port=litellm_port,
     )
 
     @asynccontextmanager

--- a/shared/net_utils.py
+++ b/shared/net_utils.py
@@ -1,0 +1,14 @@
+"""Shared networking helpers usable by both the Frontend API and Backend tiers."""
+
+import socket
+
+
+def allocate_free_port() -> int:
+    """Bind a throwaway socket on 127.0.0.1:0 to obtain a free OS-assigned port.
+
+    Avoids a fixed offset, which collides when multiple frontend/backend pairs
+    run on one host (issue #1825).
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]

--- a/src/backend_supervisor.py
+++ b/src/backend_supervisor.py
@@ -14,10 +14,11 @@ is constructed.
 import asyncio
 import logging
 import secrets
-import socket
 import sys
 import time
 from pathlib import Path
+
+from shared.net_utils import allocate_free_port
 
 logger = logging.getLogger(__name__)
 
@@ -29,14 +30,10 @@ _SHUTDOWN_TIMEOUT = 10.0
 
 
 def _allocate_free_port() -> int:
-    """Bind a throwaway socket on 127.0.0.1:0 to obtain a free OS-assigned port.
-
-    Avoids a fixed offset, which collides when multiple frontend/backend pairs
-    run on one host (issue #1825).
-    """
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
+    """Delegates to shared.net_utils.allocate_free_port() — kept as a local
+    name so existing tests that patch src.backend_supervisor._allocate_free_port
+    keep working."""
+    return allocate_free_port()
 
 
 class BackendSupervisor:


### PR DESCRIPTION
## Summary

Resolves #1825. Two backend instances on one host with default settings collided on the hardcoded LiteLLM proxy port `4000`, and a stale leftover litellm-proxy process holding port 4000 would guarantee a collision on the next backend restart.

- **Dynamic-by-default port allocation.** Resolution precedence, highest first:
  1. `--litellm-port` CLI flag (explicit pin)
  2. Explicit value persisted in `providers.json` (or migrated from legacy `config.json`)
  3. OS-assigned dynamic port (new default)

  The dynamic port is **never persisted** — every restart with nothing configured picks a fresh one, mirroring `BackendSupervisor`'s existing precedent for its own Backend-process port. Extracted the bind-port-0 pattern into a new `shared/net_utils.py` (`allocate_free_port()`) so both `src/` and `backend/` can use it without violating the import boundary; `src/backend_supervisor.py`'s `_allocate_free_port()` now delegates to it, keeping the same name so existing test patches (`src.backend_supervisor._allocate_free_port`) keep working.

- **Fixed `provider_catalog.py`'s migration sentinel bug.** The old gate compared the value (`pc.get("litellm_port", 4000) != 4000`), so a legitimate `litellm_port: 4000` in legacy config was indistinguishable from "never set" and silently skipped migration. Now checks key presence (`"litellm_port" in pc`).

- **`LiteLLMProxyManager.__init__`'s `port` is now a required parameter** (no more `=4000` default) — `BackendApp.__init__` always resolves a concrete value before constructing it, so there's no code path that could silently fall back to 4000.

- **Fixed a real, previously-latent crash bug found while writing the regression test.** The existing code around `litellm_proxy_manager.start()` was believed to already convert uvicorn's bind-failure `SystemExit` into a catchable `RuntimeError` via a poll-and-check `task.exception()` loop. It didn't actually work: `asyncio.Task` re-raises `SystemExit`/`KeyboardInterrupt` out of the event loop the moment the task's coroutine raises them (`Task.__step`'s special-case handling), crashing the whole process before the polling loop ever got a chance to inspect `.exception()`. Fixed by wrapping `server.serve()` in a coroutine that catches `SystemExit` and converts it to `RuntimeError` *inside* the task itself, before asyncio's task machinery can special-case it — the same working pattern already used in `backend/oauth_callback_listener_manager.py` (whose own docstring says it mirrors `LiteLLMProxyManager`, but `LiteLLMProxyManager` didn't actually have the fix until now).

- `backend/docker/proxy/addon.py` — no change (already fully dynamic via the live routing endpoint).

## Test plan

- [x] `uv run ruff check src/ backend/ shared/` — zero violations
- [x] `uv run pytest backend/tests/ src/tests/ -v` — full suite passes (2497 passed); 7 pre-existing failures unrelated to this change confirmed present on `main` too (`test_api_links.py`, `test_issue_1598_poll_viewed_timing.py`, `test_overseer_controller.py` — all `Mock can't be used in 'await' expression`, unrelated to LiteLLM/port code)
- [x] Two-process E2E test (`src/tests/test_live_two_process_e2e.py`) passes
- [x] New/updated tests cover: default construction picks a real bindable dynamic port, two `BackendApp` instances get different ports, CLI-pin precedence over persisted config, persisted config used when no CLI flag, dynamic port never written to `providers.json`, crash-regression (pre-bind the resolved port → `RuntimeError` not `SystemExit`, `BackendApp.initialize()` swallows it and completes), and the migration-sentinel case (legacy `litellm_port: 4000` still triggers migration)
- [x] Manual check: started two backend instances concurrently with no config (`--data-dir` pointed at fresh dirs) — both reported `running: true` via `/api/provider-catalog/status` with distinct dynamically-allocated ports (47457 and 45833), neither crashed
- [x] `builder-review` skill run (8 finder angles + verify pass) — two low-cost improvements applied (explicit `is not None` precedence chain instead of a truthy `or` chain that would've silently discarded an explicit `--litellm-port 0`; removed a tautological test); everything else triaged and dismissed as out-of-scope duplication/architecture suggestions or false positives from diff-generation methodology

## Note for reviewers

Existing installs that already have a `providers.json` with a customized provider catalog will have a concrete `litellm_port` value baked in from the old code's unconditional default-serialization (every `_save()` call previously wrote `litellm_port: 4000` even when never explicitly set). Per the plan's "persisted config wins" precedence, those installs will keep pinning to that value after upgrading rather than picking up the new dynamic default — this is a data-lifecycle wrinkle affecting only previously-configured installs, not a regression (same behavior as before), and no migration/cleanup path was in scope for this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)