### PR TITLE
[test]: fix dead get_descendants stub in overseer controller tests

### DIFF
--- a/backend/tests/test_overseer_controller.py
+++ b/backend/tests/test_overseer_controller.py
@@ -96,14 +96,10 @@ class TestSpawnWithParentName:
             return_value=parent
         )
 
-        # get_descendants returns paginated dict; extract ["descendants"] before iterating
-        mock_system.session_coordinator.get_descendants = AsyncMock(return_value={
-            "descendants": [
-                {"session_id": "parent-id", "name": "Parent", "role": "worker",
-                 "state": "active", "parent_id": "gp-id"}
-            ],
-            "total": 1, "limit": 50, "offset": 0, "has_more": False,
-        })
+        mock_system.session_coordinator.get_all_descendants = AsyncMock(return_value=[
+            {"session_id": "parent-id", "name": "Parent", "role": "worker",
+             "state": "active", "parent_id": "gp-id"}
+        ])
 
         # Mock spawn_minion to capture what parent_overseer_id is passed
         child_session = _make_session("child-id", "Child", parent_id="parent-id")
@@ -149,9 +145,7 @@ class TestSpawnWithParentName:
             return_value=unrelated
         )
         # Caller has no descendants
-        mock_system.session_coordinator.get_descendants = AsyncMock(return_value={
-            "descendants": [], "total": 0, "limit": 50, "offset": 0, "has_more": False,
-        })
+        mock_system.session_coordinator.get_all_descendants = AsyncMock(return_value=[])
 
         args = {
             "_parent_overseer_id": "caller-id",
@@ -295,16 +289,12 @@ class TestDisposeDescendant:
         sm = mock_system.session_coordinator.session_manager
         sm.get_session_info = AsyncMock(side_effect=lambda sid: session_map.get(sid))
 
-        # get_descendants returns paginated dict; extract ["descendants"] before iterating
-        mock_system.session_coordinator.get_descendants = AsyncMock(return_value={
-            "descendants": [
-                {"session_id": "parent-id", "name": "Parent", "role": "worker",
-                 "state": "active", "parent_id": "gp-id"},
-                {"session_id": "child-id", "name": "Child", "role": "worker",
-                 "state": "active", "parent_id": "parent-id"},
-            ],
-            "total": 2, "limit": 50, "offset": 0, "has_more": False,
-        })
+        mock_system.session_coordinator.get_all_descendants = AsyncMock(return_value=[
+            {"session_id": "parent-id", "name": "Parent", "role": "worker",
+             "state": "active", "parent_id": "gp-id"},
+            {"session_id": "child-id", "name": "Child", "role": "worker",
+             "state": "active", "parent_id": "parent-id"},
+        ])
 
         mock_system.overseer_controller.dispose_minion = AsyncMock(
             return_value={
@@ -381,9 +371,7 @@ class TestDisposeDescendant:
         sm.get_session_info = AsyncMock(side_effect=lambda sid: session_map.get(sid))
 
         # No descendants
-        mock_system.session_coordinator.get_descendants = AsyncMock(return_value={
-            "descendants": [], "total": 0, "limit": 50, "offset": 0, "has_more": False,
-        })
+        mock_system.session_coordinator.get_all_descendants = AsyncMock(return_value=[])
 
         args = {
             "_parent_overseer_id": "caller-id",


### PR DESCRIPTION
## Summary
Resolves #1827

Four tests in `backend/tests/test_overseer_controller.py` stubbed `session_coordinator.get_descendants` (paginated-dict shape), but `legion_mcp_tools.py`'s `_handle_spawn_minion`/`_handle_dispose_minion` only ever call `get_all_descendants` (plain list). The stub was a dead leftover from a prior refactor, so the real `get_all_descendants` resolved to an unstubbed `Mock`, and awaiting it raised `TypeError: object Mock can't be used in 'await' expression`.

## Changes Made
- Renamed the dead `get_descendants` stub to `get_all_descendants` in 4 tests
- Changed each stub's return value from the paginated `{"descendants": [...], "total": ..., ...}` dict to the plain list the production code actually consumes
- No production code changes; `get_all_descendants` already existed and behaved correctly

## Testing
- `uv run pytest backend/tests/test_overseer_controller.py -v` → 8/8 passed (previously 4 failed with `TypeError`)
- Full suite: `uv run pytest backend/tests/ src/tests/ -v` → 2500 passed, 3 pre-existing failures unrelated to this change (confirmed identical failures reproduce with this diff stashed out — `test_api_links.py` and `test_issue_1598_poll_viewed_timing.py`)
- `uv run ruff check backend/tests/test_overseer_controller.py` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)