### PR TITLE
[fix]: fall back to SDK-reported model when no config override resolves

### DIFF
--- a/backend/session_coordinator.py
+++ b/backend/session_coordinator.py
@@ -548,6 +548,12 @@ class SessionCoordinator:
         # used to compute true per-turn deltas from the SDK's cumulative-since-
         # subprocess-start counters. Reset at every new-SDK-creation epoch boundary.
         self._usage_baseline_by_session: dict[str, dict[str, float]] = {}
+        # Issue #1831: SDK-reported model from the most recent assistant message of
+        # the current in-flight turn. Cleared once consumed by that turn's result
+        # handler, so a turn with no assistant message (e.g. an immediate
+        # synthetic/error result) correctly yields no fallback instead of a stale
+        # value from a previous turn.
+        self._last_turn_model_by_session: dict[str, str] = {}
         # Callback for broadcasting usage_updated events (injected by web_server)
         self._usage_broadcast_callback: Callable[[str, dict], None] | None = None
 
@@ -2444,6 +2450,8 @@ class SessionCoordinator:
 
             if success:
                 coord_logger.info(f"Session {session_id} deleted")
+                # Issue #1831: Clear any in-flight-turn model tracked for this session
+                self._last_turn_model_by_session.pop(session_id, None)
                 # Issue #1125: Remove analytics rows for deleted session
                 if self.analytics_store:
                     try:
@@ -4968,6 +4976,13 @@ class SessionCoordinator:
                                 _model = _resolve_analytics_model_label(_eff)
                             else:
                                 _model = None
+                            # Issue #1831: fall back to the current turn's SDK-reported
+                            # model when no configured override resolved a label. Pop
+                            # unconditionally so the cache never leaks into the next turn.
+                            if _model is None:
+                                _model = self._last_turn_model_by_session.pop(session_id, None)
+                            else:
+                                self._last_turn_model_by_session.pop(session_id, None)
                             # Lazily initialise turn_seq from DB on first use after restart
                             if session_id not in self._turn_seq_by_session:
                                 db_count = await self.analytics_store.get_turn_count(session_id)
@@ -5010,6 +5025,16 @@ class SessionCoordinator:
                         await self.session_manager.update_processing_state(session_id, True)
                     except Exception:
                         logger.exception(f"Failed to set processing state for session {session_id}")
+
+                    # Issue #1831: Track the SDK-reported model for this in-flight turn as
+                    # a fallback for when no configured override resolves a label. Skip
+                    # sub-agent (Task tool) messages — they carry parent_tool_use_id and
+                    # would otherwise clobber the top-level turn's model with whatever
+                    # model the sub-agent happened to use.
+                    _msg_meta = parsed_message.metadata or {}
+                    _msg_model = _msg_meta.get('model')
+                    if _msg_model and not _msg_meta.get('parent_tool_use_id'):
+                        self._last_turn_model_by_session[session_id] = _msg_model
 
                 # Reset processing state on interrupt_success
                 elif parsed_message.type.value == 'system' and parsed_message.metadata.get('subtype') == 'interrupt_success':

--- a/backend/tests/test_issue_1831_analytics_model_fallback.py
+++ b/backend/tests/test_issue_1831_analytics_model_fallback.py
@@ -1,0 +1,191 @@
+"""
+Tests for issue #1831: analytics records NULL model when no configured override
+resolves, even though the SDK reported a real model for that turn.
+
+The fix tracks the most recent assistant-reported model for the current
+in-flight turn (`SessionCoordinator._last_turn_model_by_session`) and uses it as
+a fallback exactly when `_resolve_analytics_model_label()` yields None. These
+tests drive `coordinator._create_message_callback(session_id)` end-to-end,
+following the `TestIssue1838...` precedent in test_session_coordinator.py.
+"""
+
+import tempfile
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.session_config import SessionConfig
+from backend.session_coordinator import SessionCoordinator
+
+
+@pytest.fixture
+async def temp_coordinator():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        coordinator = SessionCoordinator(Path(temp_dir))
+        await coordinator.initialize()
+        yield coordinator
+        await coordinator.cleanup()
+
+
+async def _make_session(coordinator, config: SessionConfig) -> str:
+    """Create a session (with a backing project) and return its session_id."""
+    project = await coordinator.project_manager.create_project(
+        name="Test Project", working_directory="/test/project"
+    )
+    session_id = str(uuid.uuid4())
+    await coordinator.create_session(
+        session_id=session_id, project_id=project.project_id, config=config
+    )
+    return session_id
+
+
+def _mock_analytics(coordinator):
+    coordinator.analytics_store = AsyncMock()
+    coordinator.analytics_store.get_turn_count.return_value = 0
+    coordinator.analytics_store.get_session_usage.return_value = None
+    coordinator.analytics_store.record_turn = AsyncMock(return_value=True)
+    return coordinator.analytics_store
+
+
+class TestIssue1831AnalyticsModelFallback:
+    @pytest.mark.asyncio
+    async def test_no_override_falls_back_to_sdk_reported_model(self, temp_coordinator):
+        """T1: no configured override → analytics uses the assistant message's model."""
+        coordinator = temp_coordinator
+        session_id = await _make_session(coordinator, SessionConfig())
+        analytics_store = _mock_analytics(coordinator)
+
+        message_callback = coordinator._create_message_callback(session_id)
+
+        await message_callback({
+            "type": "assistant",
+            "model": "claude-sonnet-4-6",
+            "session_id": session_id,
+        })
+        await message_callback({
+            "type": "result",
+            "session_id": session_id,
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+            "total_cost_usd": 1.0,
+        })
+
+        analytics_store.record_turn.assert_awaited_once()
+        _, _, model_arg, _, _ = analytics_store.record_turn.call_args.args
+        assert model_arg == "claude-sonnet-4-6"
+
+    @pytest.mark.asyncio
+    async def test_configured_override_wins_over_sdk_reported_model(self, temp_coordinator):
+        """T2: configured override still wins, unaffected by the fallback."""
+        coordinator = temp_coordinator
+        session_id = await _make_session(
+            coordinator, SessionConfig(model="claude-opus-4-configured")
+        )
+        analytics_store = _mock_analytics(coordinator)
+
+        message_callback = coordinator._create_message_callback(session_id)
+
+        await message_callback({
+            "type": "assistant",
+            "model": "claude-sonnet-4-6",
+            "session_id": session_id,
+        })
+        await message_callback({
+            "type": "result",
+            "session_id": session_id,
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+            "total_cost_usd": 1.0,
+        })
+
+        analytics_store.record_turn.assert_awaited_once()
+        _, _, model_arg, _, _ = analytics_store.record_turn.call_args.args
+        assert model_arg == "claude-opus-4-configured"
+
+    @pytest.mark.asyncio
+    async def test_genuinely_modelless_turn_records_none_no_cross_turn_leak(
+        self, temp_coordinator
+    ):
+        """T3: a result with no preceding assistant message in that turn records
+        None — both standalone, and as a second turn after a T1-style turn (to
+        prove the fallback cache doesn't leak across turns)."""
+        coordinator = temp_coordinator
+        session_id = await _make_session(coordinator, SessionConfig())
+        analytics_store = _mock_analytics(coordinator)
+
+        message_callback = coordinator._create_message_callback(session_id)
+
+        # Turn 1: assistant + result → fallback consumed and cleared.
+        await message_callback({
+            "type": "assistant",
+            "model": "claude-sonnet-4-6",
+            "session_id": session_id,
+        })
+        await message_callback({
+            "type": "result",
+            "session_id": session_id,
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+            "total_cost_usd": 1.0,
+        })
+
+        # Turn 2: immediate result, no assistant message at all this turn.
+        await message_callback({
+            "type": "result",
+            "session_id": session_id,
+            "usage": {"input_tokens": 1, "output_tokens": 1},
+            "total_cost_usd": 0.1,
+        })
+
+        assert analytics_store.record_turn.await_count == 2
+        second_call_args = analytics_store.record_turn.call_args_list[1].args
+        _, _, model_arg, _, _ = second_call_args
+        assert model_arg is None
+
+    @pytest.mark.asyncio
+    async def test_subagent_assistant_message_does_not_clobber_fallback(self, temp_coordinator):
+        """A sub-agent (Task tool) assistant message carries parent_tool_use_id and
+        must not overwrite the top-level turn's tracked model — it belongs to a
+        nested sub-conversation, not "this turn" from the top-level result's
+        perspective."""
+        coordinator = temp_coordinator
+        session_id = await _make_session(coordinator, SessionConfig())
+        analytics_store = _mock_analytics(coordinator)
+
+        message_callback = coordinator._create_message_callback(session_id)
+
+        await message_callback({
+            "type": "assistant",
+            "model": "claude-sonnet-4-6",
+            "session_id": session_id,
+        })
+        # Sub-agent message for a Task tool call — different model, tagged as a sidechain.
+        await message_callback({
+            "type": "assistant",
+            "model": "claude-haiku-4-5",
+            "parent_tool_use_id": "toolu_subagent_1",
+            "session_id": session_id,
+        })
+        await message_callback({
+            "type": "result",
+            "session_id": session_id,
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+            "total_cost_usd": 1.0,
+        })
+
+        analytics_store.record_turn.assert_awaited_once()
+        _, _, model_arg, _, _ = analytics_store.record_turn.call_args.args
+        assert model_arg == "claude-sonnet-4-6"
+
+    @pytest.mark.asyncio
+    async def test_cleanup_on_session_deletion(self, temp_coordinator):
+        """T4: deleting a session clears its tracked in-flight-turn model."""
+        coordinator = temp_coordinator
+        session_id = await _make_session(coordinator, SessionConfig())
+        coordinator.legion_system = None  # skip schedule/legion cleanup, unrelated here
+
+        coordinator._last_turn_model_by_session[session_id] = "claude-sonnet-4-6"
+
+        result = await coordinator.delete_session(session_id)
+
+        assert result["success"] is True
+        assert session_id not in coordinator._last_turn_model_by_session


### PR DESCRIPTION
## Summary

Resolves #1831

`_resolve_analytics_model_label()` only derives a model label from a session's *configured* override (direct model, single provider-catalog alias, or per-tier catalog alias). For sessions with no explicit override it fell through to `cfg.model`, which is `None` — so `turn_usage.model` was written as `NULL` even though the SDK reported a real model for that turn.

## Changes Made

- Added `SessionCoordinator._last_turn_model_by_session`, tracking the most recent assistant-reported model for the current in-flight turn (sourced from `AssistantMessageHandler`'s already-extracted `metadata["model"]`).
- Sub-agent (Task tool) assistant messages are skipped when capturing this value — they carry `parent_tool_use_id` and would otherwise overwrite the top-level turn's model with whatever model the sub-agent used (caught during self-review, not in the original plan).
- In the `'result'` handler, the tracked value is used as a fallback only when `_resolve_analytics_model_label()` returns `None`, and is popped unconditionally so it never leaks into the next turn.
- Cleared on session deletion.

Configured overrides still take priority — `_resolve_analytics_model_label()` itself is unchanged.

## Testing

New file `backend/tests/test_issue_1831_analytics_model_fallback.py`:
- No override configured → analytics uses the assistant message's model.
- Configured override still wins over the SDK-reported model.
- A result with no preceding assistant message (this turn or after a prior turn) records `NULL`, proving no cross-turn leakage.
- A sub-agent's assistant message does not clobber the top-level turn's tracked model.
- Tracked model is cleared on session deletion.

Full suite: `uv run pytest backend/tests/ src/tests/` — 2504 passed (7 pre-existing failures, confirmed present on `main` before this change and unrelated to this diff). `uv run ruff check` clean on changed files.

Manually verified the two-process test setup (Frontend API + auto-started Backend) starts and reports ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)