### PR TITLE
[fix]: collapse Backend-unreachable log cascade into one suppressed notice

### DIFF
--- a/src/backend_client.py
+++ b/src/backend_client.py
@@ -11,6 +11,8 @@ import httpx
 from fastapi import Request
 from fastapi.responses import Response
 
+from .backend_reachability import BackendReachabilityTracker
+
 logger = logging.getLogger(__name__)
 
 # Headers that must not be forwarded verbatim between the two hops.
@@ -25,6 +27,7 @@ class BackendClient:
         self.base_url = base_url.rstrip("/")
         self._token = token
         self._client = httpx.AsyncClient(base_url=self.base_url, timeout=timeout)
+        self.reachability = BackendReachabilityTracker()
 
     async def aclose(self) -> None:
         await self._client.aclose()
@@ -48,13 +51,18 @@ class BackendClient:
         headers = self._auth_headers(headers)
         body = await request.body()
 
-        backend_resp = await self._client.request(
-            request.method,
-            path,
-            params=request.query_params,
-            content=body,
-            headers=headers,
-        )
+        try:
+            backend_resp = await self._client.request(
+                request.method,
+                path,
+                params=request.query_params,
+                content=body,
+                headers=headers,
+            )
+        except httpx.RequestError as e:
+            self.reachability.record_failure(e)
+            raise
+        self.reachability.record_success()
 
         response_headers = {
             k: v for k, v in backend_resp.headers.items()
@@ -76,13 +84,23 @@ class BackendClient:
         network latency/scheduling jitter on top of an at-the-ceiling server response
         turns a normal idle poll into a client-side ReadTimeout (issue #498 review finding).
         """
-        resp = await self._client.get(path, params=params, headers=self._auth_headers(), timeout=timeout)
+        try:
+            resp = await self._client.get(path, params=params, headers=self._auth_headers(), timeout=timeout)
+        except httpx.RequestError as e:
+            self.reachability.record_failure(e)
+            raise
+        self.reachability.record_success()
         resp.raise_for_status()
         return resp.json()
 
     async def request_json(self, method: str, path: str, json: dict | None = None) -> dict:
         """Call a JSON endpoint on Backend and return the decoded body. Raises on non-2xx."""
-        resp = await self._client.request(method, path, json=json, headers=self._auth_headers())
+        try:
+            resp = await self._client.request(method, path, json=json, headers=self._auth_headers())
+        except httpx.RequestError as e:
+            self.reachability.record_failure(e)
+            raise
+        self.reachability.record_success()
         resp.raise_for_status()
         return resp.json()
 
@@ -90,14 +108,18 @@ class BackendClient:
         """Best-effort liveness check — never raises."""
         try:
             resp = await self._client.get("/health", timeout=2.0)
-            return resp.status_code == 200
-        except httpx.HTTPError:
+        except httpx.RequestError as e:
+            self.reachability.record_failure(e)
             return False
+        self.reachability.record_success()
+        return resp.status_code == 200
 
     async def ready(self) -> bool:
         """Best-effort readiness check — never raises."""
         try:
             resp = await self._client.get("/ready", timeout=2.0)
-            return resp.status_code == 200 and resp.json().get("ready") is True
-        except httpx.HTTPError:
+        except httpx.RequestError as e:
+            self.reachability.record_failure(e)
             return False
+        self.reachability.record_success()
+        return resp.status_code == 200 and resp.json().get("ready") is True

--- a/src/backend_reachability.py
+++ b/src/backend_reachability.py
@@ -1,0 +1,97 @@
+"""Backend reachability tracking — shared "is Backend currently unreachable?"
+signal for Frontend-side code that talks to Backend (issue #1844).
+
+Without this, every route handler's own `httpx.RequestError` (Backend down,
+still starting, crashed, genuinely remote and network-partitioned) propagates
+into `shared/exception_handlers.py`'s generic `except Exception` and gets a
+full ERROR-level traceback logged once per request — indistinguishable from a
+genuine bug, and multiplied by however many concurrent requests hit the relay
+while Backend is down. `BackendReachabilityTracker` collapses that into one
+concise warning per outage (plus an occasional reminder during a long one)
+regardless of which code path or which of the three windows (startup,
+crash, manual stop) noticed first.
+
+Deliberately generic/reusable groundwork for #1847 (coordinated
+restart/rollback needs this same signal) — nothing restart-specific lives
+here. Lives under `src/` only; must not import from `backend/` (see
+`src/tests/test_import_boundary.py`).
+"""
+
+import logging
+import time
+
+from fastapi import HTTPException
+
+from shared.logging_config import get_debug_flag
+
+logger = logging.getLogger(__name__)
+
+# How long an ongoing outage stays silent before a reminder warning is logged
+# again — long enough to avoid flooding error.log on every failed request,
+# short enough that a genuine multi-minute outage doesn't go completely quiet.
+_COOLDOWN_SECONDS = 30.0
+
+
+class BackendReachabilityTracker:
+    """Tracks whether Backend is currently believed unreachable.
+
+    Plain instance state, no locking — same single-event-loop assumption as
+    `web_server.py`'s existing `_last_restart_time`.
+    """
+
+    def __init__(self, cooldown_seconds: float = _COOLDOWN_SECONDS):
+        self._cooldown_seconds = cooldown_seconds
+        self._unreachable = False
+        self._last_logged: float = 0.0
+
+    @property
+    def is_unreachable(self) -> bool:
+        return self._unreachable
+
+    def record_failure(self, exc: Exception) -> None:
+        """Call on a connection-level failure (httpx.RequestError) talking to Backend.
+
+        Logs once on the transition into the unreachable state, then again only
+        after the cooldown elapses while the outage continues.
+
+        Uses logger.error() (not .warning()) deliberately: this module's plain
+        `logging.getLogger(__name__)` propagates only to the root logger, whose
+        only handlers (shared/logging_config.py's error_handler and
+        console_error_handler) are filtered to ERROR+ — a .warning() call here
+        would be silently dropped, reaching neither error.log nor the console
+        (confirmed via manual verification, issue #1844). This is still a single
+        concise line, never a traceback (no logger.exception), so it stays
+        distinguishable from a genuine bug despite sharing the same level.
+        """
+        now = time.monotonic()
+        should_log = not self._unreachable or now - self._last_logged >= self._cooldown_seconds
+        self._unreachable = True
+        if should_log:
+            self._last_logged = now
+            logger.error(
+                "Backend unreachable (%s: %s); suppressing repeat notices for %ds",
+                type(exc).__name__, exc, int(self._cooldown_seconds),
+            )
+
+    def record_success(self) -> None:
+        """Call on any successful connection to Backend (status code irrelevant).
+
+        No-op unless a prior failure was recorded. See record_failure() for why
+        this logs at ERROR rather than WARNING.
+        """
+        if self._unreachable:
+            self._unreachable = False
+            self._last_logged = 0.0
+            logger.error("Backend reachable again")
+
+
+def to_http_exception(exc: Exception) -> HTTPException:
+    """Build the same HTTPException `shared/exception_handlers.py`'s
+    `handle_exceptions` decorator would have built for this exception, so a
+    route handler can pre-empt the decorator (which would otherwise log a
+    second, full-traceback copy of the same failure already recorded by
+    `BackendReachabilityTracker.record_failure`). Response contract to the
+    browser is byte-for-byte unchanged — only logging changes.
+    """
+    detail = str(exc) if get_debug_flag('debug_error_handler') else "An internal error occurred"
+    return HTTPException(status_code=500, detail=detail)

--- a/src/poll_relay.py
+++ b/src/poll_relay.py
@@ -103,8 +103,13 @@ class PollRelay:
                 cursor = next_cursor
             except asyncio.CancelledError:
                 raise
-            except httpx.HTTPError:
-                logger.warning("Poll-relay for %s: Backend unreachable, retrying", path)
+            except httpx.RequestError:
+                # No local log here — BackendClient.get_json() already recorded this
+                # failure via its shared reachability tracker (issue #1844); logging
+                # it again here on every 2s retry would just re-flood error.log.
+                await asyncio.sleep(_ERROR_BACKOFF_SECONDS)
+            except httpx.HTTPStatusError:
+                logger.exception("Poll-relay for %s: Backend returned an error response", path)
                 await asyncio.sleep(_ERROR_BACKOFF_SECONDS)
             except Exception:
                 logger.exception("Poll-relay for %s: unexpected error, retrying", path)

--- a/src/routers/config.py
+++ b/src/routers/config.py
@@ -9,10 +9,12 @@ Frontend-owned and Backend-owned keys in one request; each half is routed to
 wherever it's actually written.
 """
 
+import httpx
 from fastapi import APIRouter, Request
 
 from shared.exception_handlers import handle_exceptions
 
+from ..backend_reachability import to_http_exception
 from ..frontend_config import load_frontend_config, save_frontend_config
 
 _FRONTEND_OWNED_KEYS = {"networking", "backend_connection"}
@@ -22,7 +24,10 @@ def build_router(webui) -> APIRouter:
     router = APIRouter()
 
     async def _merged_config() -> dict:
-        backend_result = await webui.backend_client.get_json("/api/config")
+        try:
+            backend_result = await webui.backend_client.get_json("/api/config")
+        except httpx.RequestError as e:
+            raise to_http_exception(e) from e
         merged = backend_result["config"]
         frontend_cfg = (
             load_frontend_config(webui.config_file) if webui.config_file else load_frontend_config()
@@ -66,7 +71,10 @@ def build_router(webui) -> APIRouter:
                 save_frontend_config(frontend_cfg)
 
         if backend_body:
-            await webui.backend_client.request_json("PUT", "/api/config", json=backend_body)
+            try:
+                await webui.backend_client.request_json("PUT", "/api/config", json=backend_body)
+            except httpx.RequestError as e:
+                raise to_http_exception(e) from e
 
         return {"config": await _merged_config()}
 

--- a/src/routers/poll.py
+++ b/src/routers/poll.py
@@ -20,6 +20,8 @@ from fastapi import APIRouter, HTTPException
 from shared.exception_handlers import handle_exceptions
 from shared.logging_config import get_logger
 
+from ..backend_reachability import to_http_exception
+
 _polling_logger = get_logger('polling', category='POLL')
 
 
@@ -58,6 +60,8 @@ def build_router(webui) -> APIRouter:
                 if e.response.status_code == 404:
                     raise HTTPException(status_code=404, detail="Session not found") from e
                 raise
+            except httpx.RequestError as e:
+                raise to_http_exception(e) from e
             return {"cursor": 0}  # session exists but queue not yet initialized
         return {"cursor": webui.session_queues[session_id].current_cursor}
 
@@ -72,6 +76,8 @@ def build_router(webui) -> APIRouter:
                 if e.response.status_code == 404:
                     raise HTTPException(status_code=404, detail="Session not found") from e
                 raise
+            except httpx.RequestError as e:
+                raise to_http_exception(e) from e
         webui.poll_relay.ensure_session_relay(session_id)
         queue = webui.session_queues[session_id]
 

--- a/src/routers/relay.py
+++ b/src/routers/relay.py
@@ -8,9 +8,12 @@ with genuine process separation, a single generic proxy achieves the same
 from Backend's contract by forgetting to mirror a new route.
 """
 
+import httpx
 from fastapi import APIRouter, Request
 
 from shared.exception_handlers import handle_exceptions
+
+from ..backend_reachability import to_http_exception
 
 # Mutating an MCP config can add/change/remove its custom OAuth callback path on
 # Backend — resync Frontend's dynamic relay routes (webui.resync_oauth_callback_paths,
@@ -28,7 +31,10 @@ def build_router(webui) -> APIRouter:
     )
     @handle_exceptions("relay to backend")
     async def relay_to_backend(full_path: str, request: Request):
-        response = await webui.backend_client.relay(request, f"/api/{full_path}")
+        try:
+            response = await webui.backend_client.relay(request, f"/api/{full_path}")
+        except httpx.RequestError as e:
+            raise to_http_exception(e) from e
         if full_path.startswith("mcp-configs") and request.method in _MCP_CONFIG_MUTATION_METHODS:
             await webui.resync_oauth_callback_paths()
         return response
@@ -42,6 +48,9 @@ def build_router(webui) -> APIRouter:
     @router.get("/oauth/callback")
     @handle_exceptions("relay oauth callback")
     async def relay_oauth_callback(request: Request):
-        return await webui.backend_client.relay(request, "/oauth/callback")
+        try:
+            return await webui.backend_client.relay(request, "/oauth/callback")
+        except httpx.RequestError as e:
+            raise to_http_exception(e) from e
 
     return router

--- a/src/tests/test_backend_client.py
+++ b/src/tests/test_backend_client.py
@@ -1,0 +1,188 @@
+"""Tests for src/backend_client.py's Backend reachability wiring (issue #1844).
+
+BackendClient's relay()/get_json()/request_json() must feed the shared
+BackendReachabilityTracker on both the failure path (httpx.RequestError —
+connection-level, i.e. Backend is actually unreachable) and the success path
+(any response received, even a 4xx/5xx body — that's a genuine backend-side
+error, not an unreachable-backend condition), while leaving existing
+raise/return behavior for callers completely unchanged. Follows the existing
+convention of `side_effect=httpx.ConnectError("refused")` seen in
+test_oauth_callback_relay.py.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from starlette.requests import Request
+
+from src.backend_client import BackendClient
+
+
+def _make_client() -> BackendClient:
+    client = BackendClient.__new__(BackendClient)  # bypass __init__ (no real AsyncClient/socket)
+    from src.backend_reachability import BackendReachabilityTracker
+    client.base_url = "http://backend.test"
+    client._token = "token"
+    client._client = MagicMock()
+    client.reachability = BackendReachabilityTracker()
+    return client
+
+
+def _make_request(method: str = "GET", path: str = "/api/sessions", body: bytes = b"") -> Request:
+    scope = {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "query_string": b"",
+        "headers": [],
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return Request(scope, receive)
+
+
+# --- relay() ---
+
+
+@pytest.mark.asyncio
+async def test_issue_1844_relay_records_failure_and_reraises_on_request_error():
+    client = _make_client()
+    client._client.request = AsyncMock(side_effect=httpx.ConnectError("refused"))
+
+    with pytest.raises(httpx.ConnectError):
+        await client.relay(_make_request(), "/api/sessions")
+
+    assert client.reachability.is_unreachable is True
+
+
+@pytest.mark.asyncio
+async def test_issue_1844_relay_records_success_even_on_error_status_body():
+    """A response body carrying a 4xx/5xx is a genuine backend-side error, not an
+    unreachable backend — relay() never calls raise_for_status() at all, so this
+    must still clear reachability."""
+    client = _make_client()
+    client.reachability.record_failure(httpx.ConnectError("refused"))
+    assert client.reachability.is_unreachable is True
+
+    backend_resp = MagicMock()
+    backend_resp.status_code = 500
+    backend_resp.headers = {}
+    backend_resp.content = b'{"detail": "boom"}'
+    client._client.request = AsyncMock(return_value=backend_resp)
+
+    await client.relay(_make_request(), "/api/sessions")
+
+    assert client.reachability.is_unreachable is False
+
+
+# --- get_json() ---
+
+
+@pytest.mark.asyncio
+async def test_issue_1844_get_json_records_failure_and_reraises_on_request_error():
+    client = _make_client()
+    client._client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+
+    with pytest.raises(httpx.ConnectError):
+        await client.get_json("/api/config")
+
+    assert client.reachability.is_unreachable is True
+
+
+@pytest.mark.asyncio
+async def test_issue_1844_get_json_records_success_before_raise_for_status():
+    """A successful connection that gets back a 4xx/5xx must still clear
+    reachability, even though raise_for_status() subsequently raises."""
+    client = _make_client()
+    client.reachability.record_failure(httpx.ConnectError("refused"))
+
+    resp = MagicMock()
+    resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "500", request=MagicMock(), response=MagicMock(status_code=500)
+    )
+    client._client.get = AsyncMock(return_value=resp)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await client.get_json("/api/config")
+
+    assert client.reachability.is_unreachable is False
+
+
+# --- request_json() ---
+
+
+@pytest.mark.asyncio
+async def test_issue_1844_request_json_records_failure_and_reraises_on_request_error():
+    client = _make_client()
+    client._client.request = AsyncMock(side_effect=httpx.ConnectError("refused"))
+
+    with pytest.raises(httpx.ConnectError):
+        await client.request_json("PUT", "/api/config", json={"a": 1})
+
+    assert client.reachability.is_unreachable is True
+
+
+@pytest.mark.asyncio
+async def test_issue_1844_request_json_records_success_before_raise_for_status():
+    client = _make_client()
+    client.reachability.record_failure(httpx.ConnectError("refused"))
+
+    resp = MagicMock()
+    resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "400", request=MagicMock(), response=MagicMock(status_code=400)
+    )
+    client._client.request = AsyncMock(return_value=resp)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await client.request_json("PUT", "/api/config", json={"a": 1})
+
+    assert client.reachability.is_unreachable is False
+
+
+# --- health() / ready() ---
+
+
+@pytest.mark.asyncio
+async def test_issue_1844_health_records_failure_and_returns_false():
+    client = _make_client()
+    client._client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+
+    assert await client.health() is False
+    assert client.reachability.is_unreachable is True
+
+
+@pytest.mark.asyncio
+async def test_issue_1844_health_records_success_and_returns_true():
+    client = _make_client()
+    client.reachability.record_failure(httpx.ConnectError("refused"))
+    resp = MagicMock()
+    resp.status_code = 200
+    client._client.get = AsyncMock(return_value=resp)
+
+    assert await client.health() is True
+    assert client.reachability.is_unreachable is False
+
+
+@pytest.mark.asyncio
+async def test_issue_1844_ready_records_failure_and_returns_false():
+    client = _make_client()
+    client._client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+
+    assert await client.ready() is False
+    assert client.reachability.is_unreachable is True
+
+
+@pytest.mark.asyncio
+async def test_issue_1844_ready_records_success_and_returns_true():
+    client = _make_client()
+    client.reachability.record_failure(httpx.ConnectError("refused"))
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"ready": True}
+    client._client.get = AsyncMock(return_value=resp)
+
+    assert await client.ready() is True
+    assert client.reachability.is_unreachable is False

--- a/src/tests/test_backend_reachability.py
+++ b/src/tests/test_backend_reachability.py
@@ -1,0 +1,103 @@
+"""Unit tests for src/backend_reachability.py (issue #1844).
+
+No network — exercises BackendReachabilityTracker's log-suppression state
+machine directly, and to_http_exception()'s response-contract parity with
+shared/exception_handlers.py's handle_exceptions decorator.
+"""
+
+import logging
+import time
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+import shared.logging_config as logging_config
+from src.backend_reachability import BackendReachabilityTracker, to_http_exception
+
+
+def test_issue_1844_first_failure_logs_once(caplog):
+    tracker = BackendReachabilityTracker()
+
+    with caplog.at_level(logging.WARNING, logger="src.backend_reachability"):
+        tracker.record_failure(httpx.ConnectError("refused"))
+
+    assert tracker.is_unreachable is True
+    assert caplog.text.count("Backend unreachable") == 1
+    assert "ConnectError" in caplog.text
+    assert "refused" in caplog.text
+
+
+def test_issue_1844_repeated_failures_within_cooldown_log_only_once(caplog):
+    tracker = BackendReachabilityTracker(cooldown_seconds=60)
+
+    with caplog.at_level(logging.WARNING, logger="src.backend_reachability"):
+        for _ in range(5):
+            tracker.record_failure(httpx.ConnectError("refused"))
+
+    assert caplog.text.count("Backend unreachable") == 1
+
+
+def test_issue_1844_failure_logs_again_after_cooldown_elapses(caplog):
+    tracker = BackendReachabilityTracker(cooldown_seconds=0.05)
+
+    with caplog.at_level(logging.WARNING, logger="src.backend_reachability"):
+        tracker.record_failure(httpx.ConnectError("refused"))
+        time.sleep(0.1)
+        tracker.record_failure(httpx.ConnectError("refused"))
+
+    assert caplog.text.count("Backend unreachable") == 2
+
+
+def test_issue_1844_record_success_after_failure_logs_recovery_and_resets(caplog):
+    tracker = BackendReachabilityTracker()
+    tracker.record_failure(httpx.ConnectError("refused"))
+
+    with caplog.at_level(logging.WARNING, logger="src.backend_reachability"):
+        tracker.record_success()
+
+    assert tracker.is_unreachable is False
+    assert "Backend reachable again" in caplog.text
+    assert caplog.text.count("Backend reachable again") == 1
+
+
+def test_issue_1844_record_success_with_no_prior_failure_logs_nothing(caplog):
+    tracker = BackendReachabilityTracker()
+
+    with caplog.at_level(logging.WARNING, logger="src.backend_reachability"):
+        tracker.record_success()
+
+    assert tracker.is_unreachable is False
+    assert caplog.text == ""
+
+
+def test_issue_1844_recovery_then_new_failure_logs_again(caplog):
+    """A second outage after a full recovery must log again immediately —
+    the cooldown only applies within a single ongoing outage."""
+    tracker = BackendReachabilityTracker(cooldown_seconds=60)
+
+    with caplog.at_level(logging.WARNING, logger="src.backend_reachability"):
+        tracker.record_failure(httpx.ConnectError("refused"))
+        tracker.record_success()
+        tracker.record_failure(httpx.ConnectError("refused again"))
+
+    assert caplog.text.count("Backend unreachable") == 2
+    assert caplog.text.count("Backend reachable again") == 1
+
+
+@pytest.mark.asyncio
+async def test_issue_1844_to_http_exception_sanitized_when_debug_off():
+    with patch.object(logging_config, '_log_config', {'debug_error_handler': False}):
+        exc = to_http_exception(httpx.ConnectError("internal/path/secret"))
+
+    assert exc.status_code == 500
+    assert exc.detail == "An internal error occurred"
+
+
+@pytest.mark.asyncio
+async def test_issue_1844_to_http_exception_full_detail_when_debug_on():
+    with patch.object(logging_config, '_log_config', {'debug_error_handler': True}):
+        exc = to_http_exception(httpx.ConnectError("refused"))
+
+    assert exc.status_code == 500
+    assert "refused" in exc.detail

--- a/src/tests/test_config_router.py
+++ b/src/tests/test_config_router.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
@@ -98,6 +99,33 @@ async def test_put_config_mixed_body_splits_between_both(tmp_path):
     )
     on_disk = json.loads(config_file.read_text())
     assert on_disk["networking"]["acknowledged_risk"] is True
+
+
+@pytest.mark.asyncio
+async def test_issue_1844_get_config_backend_unreachable_returns_500(tmp_path):
+    """A connection failure to Backend must still surface as a 500 to the
+    browser with the same detail-construction as before (issue #1844) —
+    only the logging behind the scenes changed, not the response contract."""
+    app, _, webui = _make_app(tmp_path)
+    webui.backend_client.get_json = AsyncMock(side_effect=httpx.ConnectError("refused"))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/config")
+
+    assert resp.status_code == 500
+    assert resp.json() == {"detail": "An internal error occurred"}
+
+
+@pytest.mark.asyncio
+async def test_issue_1844_put_config_backend_unreachable_returns_500(tmp_path):
+    app, _, webui = _make_app(tmp_path)
+    webui.backend_client.request_json = AsyncMock(side_effect=httpx.ConnectError("refused"))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.put("/api/config", json={"features": {"skill_sync_enabled": False}})
+
+    assert resp.status_code == 500
+    assert resp.json() == {"detail": "An internal error occurred"}
 
 
 @pytest.mark.asyncio

--- a/src/tests/test_oauth_callback_relay.py
+++ b/src/tests/test_oauth_callback_relay.py
@@ -173,6 +173,28 @@ async def test_dynamic_callback_route_actually_relays():
     assert call_args[0][1] == "/custom/callback"
 
 
+@pytest.mark.asyncio
+async def test_issue_1844_dynamic_callback_route_backend_unreachable_returns_500():
+    """This handler is a raw Starlette Route, not a FastAPI route — it isn't
+    wrapped by @handle_exceptions, so it must pre-empt a Backend-unreachable
+    failure itself (like the default /oauth/callback path in
+    src/routers/relay.py) or an httpx.RequestError falls straight through to
+    Starlette's default unhandled-exception traceback logging on every hit
+    (builder-review finding for issue #1844)."""
+    import httpx
+
+    webui = _make_webui()
+    webui.backend_client.relay = AsyncMock(side_effect=httpx.ConnectError("refused"))
+
+    webui._add_oauth_callback_relay_route("/custom/callback")
+
+    async with AsyncClient(transport=ASGITransport(app=webui.app), base_url="http://test") as client:
+        resp = await client.get("/custom/callback?code=abc123")
+
+    assert resp.status_code == 500
+    assert resp.json() == {"detail": "An internal error occurred"}
+
+
 class TestReservedPathCollision:
     """Regression tests for issue #498 review finding: Backend's own OAuth
     callback path collision guard (oauth_callback_path_conflicts_with_app_route,

--- a/src/tests/test_poll_relay.py
+++ b/src/tests/test_poll_relay.py
@@ -13,8 +13,10 @@ Includes regression tests for two bugs found during builder-review:
 """
 
 import asyncio
+import logging
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
 
 from shared.event_queue import EventQueue
@@ -164,3 +166,69 @@ async def test_ui_relay_has_no_idle_timeout():
         assert call_count > 1  # kept polling — no idle timeout applies to the UI stream
 
         await relay.stop()
+
+
+# --- issue #1844: RequestError vs HTTPStatusError split ---
+
+
+@pytest.mark.asyncio
+async def test_issue_1844_request_error_retries_silently_without_local_log(caplog):
+    """A connection-level failure (Backend unreachable) must retry without a
+    local log line — BackendClient.get_json() already recorded it via the
+    shared reachability tracker; logging it again here on every 2s retry
+    would re-flood error.log for the whole outage."""
+    call_count = 0
+
+    async def side_effect(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise httpx.ConnectError("refused")
+        await asyncio.sleep(100)
+
+    relay, backend_client, ui_queue, _ = _make_relay(get_json_side_effect=side_effect)
+
+    with caplog.at_level(logging.WARNING, logger="src.poll_relay"):
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("src.poll_relay._ERROR_BACKOFF_SECONDS", 0.01)
+            relay.start_ui_relay()
+            for _ in range(200):
+                if call_count >= 2:
+                    break
+                await asyncio.sleep(0.01)
+            await relay.stop()
+
+    assert call_count >= 2  # retried past the failure
+    assert "unreachable" not in caplog.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_issue_1844_http_status_error_logs_full_traceback_and_retries(caplog):
+    """A genuine backend-side error response (Backend up, but its own poll
+    endpoint 500ing) is not a reachability concern — keep today's
+    full-traceback treatment so it stays visible as a real bug."""
+    call_count = 0
+
+    async def side_effect(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise httpx.HTTPStatusError(
+                "500", request=MagicMock(), response=MagicMock(status_code=500)
+            )
+        await asyncio.sleep(100)
+
+    relay, backend_client, ui_queue, _ = _make_relay(get_json_side_effect=side_effect)
+
+    with caplog.at_level(logging.ERROR, logger="src.poll_relay"):
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("src.poll_relay._ERROR_BACKOFF_SECONDS", 0.01)
+            relay.start_ui_relay()
+            for _ in range(200):
+                if call_count >= 2:
+                    break
+                await asyncio.sleep(0.01)
+            await relay.stop()
+
+    assert call_count >= 2  # retried past the failure
+    assert "Backend returned an error response" in caplog.text

--- a/src/tests/test_relay_router.py
+++ b/src/tests/test_relay_router.py
@@ -1,0 +1,48 @@
+"""Tests for src/routers/relay.py's Backend-unreachable handling (issue #1844).
+
+Before this fix, a connection failure from backend_client.relay() propagated
+straight through handle_exceptions' generic `except Exception`, logging a
+full ERROR-level traceback per request. Now relay.py pre-empts the decorator
+with to_http_exception() so only the shared BackendReachabilityTracker logs
+(covered separately in test_backend_reachability.py / test_backend_client.py)
+— this file proves the response contract to the browser is unchanged (500,
+same detail-construction) and that no unhandled exception escapes the ASGI
+test client.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from src.routers.relay import build_router
+
+
+def _make_app():
+    webui = MagicMock()
+    webui.backend_client.relay = AsyncMock(side_effect=httpx.ConnectError("refused"))
+    app = FastAPI()
+    app.include_router(build_router(webui))
+    return app, webui
+
+
+@pytest.mark.asyncio
+async def test_issue_1844_relay_to_backend_connect_error_returns_500():
+    app, _ = _make_app()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/sessions")
+
+    assert resp.status_code == 500
+    assert resp.json() == {"detail": "An internal error occurred"}
+
+
+@pytest.mark.asyncio
+async def test_issue_1844_relay_oauth_callback_connect_error_returns_500():
+    app, _ = _make_app()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/oauth/callback?code=abc")
+
+    assert resp.status_code == 500
+    assert resp.json() == {"detail": "An internal error occurred"}

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -27,6 +27,7 @@ from starlette.routing import Route
 from shared.event_queue import EventQueue
 
 from .backend_client import BackendClient
+from .backend_reachability import to_http_exception
 from .backend_supervisor import BackendSupervisor
 from .poll_relay import PollRelay
 
@@ -213,7 +214,15 @@ class ClaudeWebUI:
             return False
 
         async def _handler(request: Request):
-            return await self.backend_client.relay(request, path)
+            # Not wrapped by @handle_exceptions (this is a raw Starlette Route, not
+            # a FastAPI route handler) — must pre-empt a Backend-unreachable failure
+            # itself, same as the default /oauth/callback path in src/routers/relay.py,
+            # or it falls straight through to Starlette's default unhandled-exception
+            # traceback logging on every hit (issue #1844 review finding).
+            try:
+                return await self.backend_client.relay(request, path)
+            except httpx.RequestError as e:
+                raise to_http_exception(e) from e
 
         self.app.router.routes.insert(0, Route(path, _handler, methods=["GET"]))
         AuthMiddleware.EXEMPT_PATHS.add(path)
@@ -240,7 +249,13 @@ class ClaudeWebUI:
         """
         try:
             body = await self.backend_client.get_json("/api/internal/oauth-callback-paths")
-        except httpx.HTTPError:
+        except httpx.RequestError:
+            # No local log here — BackendClient.get_json() already recorded this
+            # failure via its shared reachability tracker (issue #1844); this runs
+            # every _OAUTH_RESYNC_INTERVAL_SECONDS, so logging it again here too
+            # would re-flood error.log with a full traceback for the whole outage.
+            return
+        except httpx.HTTPStatusError:
             logger.exception("Failed to resync OAuth callback paths from Backend")
             return
         desired = set(body.get("paths", [])) - {"/oauth/callback"}


### PR DESCRIPTION
## Summary
Resolves #1844

Every Frontend-side path that talks to Backend (generic relay, config merge/write, poll session lookups, the dynamic OAuth callback relay, poll-relay background tasks, and the OAuth-path resync loop) used to log a full ERROR-level traceback per request/attempt whenever Backend was unreachable — indistinguishable from a genuine bug, and multiplied by however many concurrent requests hit the relay during an outage. This collapses that into one concise, no-traceback log line per outage transition (plus an occasional reminder during a long outage), regardless of *why* Backend became unreachable (startup still booting, crash, manual stop) or *which* code path noticed first.

## Changes Made
- New `src/backend_reachability.py`: `BackendReachabilityTracker` (`record_failure()`/`record_success()`/`is_unreachable`) collapses repeated `httpx.RequestError` failures into a single log line on the transition into/out of the unreachable state (30s cooldown for reminders during an ongoing outage). `to_http_exception()` builds the exact same `HTTPException` `shared/exception_handlers.py`'s decorator would have, so a route handler can pre-empt it without changing the response contract to the browser.
- `src/backend_client.py`: wires `record_failure()`/`record_success()` into `relay()`, `get_json()`, `request_json()`, `health()`, `ready()`.
- `src/routers/relay.py`, `src/routers/config.py`, `src/routers/poll.py`: catch `httpx.RequestError` and re-raise via `to_http_exception()` instead of letting it fall through to the generic exception decorator's full-traceback log.
- `src/web_server.py`: the dynamically-registered custom OAuth callback relay handler (a raw Starlette `Route`, not decorated by `@handle_exceptions`) gets the same treatment — a gap found during review that the original wiring list missed entirely. Also splits `resync_oauth_callback_paths()`'s blanket `except httpx.HTTPError` into a silent `RequestError` branch (already logged via the tracker) and an unchanged full-traceback `HTTPStatusError` branch for genuine backend-side error responses.
- `src/poll_relay.py`: same `RequestError`/`HTTPStatusError` split in the background poll-relay retry loop.
- Tests: new `test_backend_reachability.py`, `test_backend_client.py`, `test_relay_router.py`; extended `test_config_router.py`, `test_poll_relay.py`, `test_oauth_callback_relay.py`.

`shared/exception_handlers.py` is intentionally untouched — it's shared by both the Frontend API and Backend tiers, and a Backend-side route's own unrelated `httpx.RequestError` (e.g. talking to Docker/OAuth/an MCP server) must keep getting full-traceback treatment.

## Testing
- `uv run ruff check src/` — zero violations.
- `uv run pytest src/tests/` — 143 passed.
- `uv run pytest backend/tests/ src/tests/` — full suite passes except 3 pre-existing failures unrelated to this change (confirmed failing identically on an unmodified checkout of this branch, in `backend/tests/integration/test_api_links.py` and `test_issue_1598_poll_viewed_timing.py`).
- Manual: started the Frontend API against an auto-started Backend, killed the Backend process, fired 5 concurrent requests at a relayed endpoint — got exactly **one** ERROR line in `data/logs/error.log` (not 5 tracebacks). Backend's supervisor auto-restarted it; confirmed exactly **one** "Backend reachable again" line once it came back, and `/api/config` returned 200 again.
- Ran `builder-review` against the full diff (8 finder angles + verification). Applied the one confirmed correctness gap (the OAuth callback handler above) and one safe simplification (deduplicated `record_failure()`'s duplicate log call). Dismissed several simplification/reuse findings that would require touching `shared/exception_handlers.py` or restructuring the per-call-site wrapping the plan deliberately chose to keep the two tiers' exception handling decoupled — noted below for visibility.

## Notes for reviewer
- Two review angles independently flagged that `BackendClient.health()`/`ready()` now feed the reachability tracker on every call, including `BackendSupervisor`'s own startup-readiness polling — meaning a normal, healthy startup now logs one "Backend unreachable" + one "Backend reachable again" pair while Backend's child process is still booting. I verified this happens in practice (see manual testing above, first log pair was from ordinary startup, not the induced outage). This matches the plan's explicit design goal ("behavior consistent regardless of why Backend became unreachable... startup still booting" is one of the three named windows), so I left it as designed rather than special-casing startup — flagging here in case that tradeoff should be revisited.
- `src/poll_relay.py`'s `HTTPStatusError` branch now logs a full traceback every 2s if Backend's own poll endpoint returns a persistent error response — before this change that case only produced a low-noise warning (which, separately, turned out to never actually reach any log file under this app's current logging config — see next point). This is what the plan explicitly asked for ("unchanged full-detail treatment for a genuine backend-side error response"), so implemented as specified.
- Discovered while doing the required manual verification: this codebase's root logger only attaches ERROR-level handlers (`error.log` + console) — a bare `logging.getLogger(__name__).warning(...)` call anywhere in `src/`/`shared/` is silently dropped, reaching neither a file nor the console. The plan called for `logger.warning()`; I used `logger.error()` instead (still single-line, no traceback) so the message actually reaches `error.log` as the plan's own acceptance criteria require. This also means several pre-existing `.warning()` calls elsewhere in the codebase (e.g. the old `poll_relay.py` retry warning, `web_server.py`'s pre-existing startup connectivity warnings) have likely never been visible either — out of scope to fix here, but worth knowing about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)