### PR TITLE
[fix]: orchestrate remote Backend restart before Frontend restarts (#1847 stage 1/3: backend orchestration)

### DIFF
--- a/backend/routers/system.py
+++ b/backend/routers/system.py
@@ -116,6 +116,38 @@ async def _restart_to_target(webui, project_root: Path, payload: "RestartRequest
     return f"Switched to {branch} @ {short_hash or reset_target}"
 
 
+async def _do_restart(webui) -> None:
+    """Clean up, then re-exec this process via os.execv.
+
+    Runs as a fire-and-forget background task after the HTTP response has already
+    been sent — extracted to a standalone function so it's directly awaitable from
+    tests instead of only reachable via the scheduled task (mirrors
+    src/routers/system.py's _finish_restart for the same reason).
+
+    Reconstructs a module-mode (`-m backend.main`) invocation rather than reusing
+    `sys.argv` as-is (issue #1847 review finding, found via a live remote-mode
+    smoke test — not caught by mocked-os.execv unit tests, since none of them let
+    the re-exec'd process actually start). When originally launched via
+    `-m backend.main`, `sys.argv[0]` is main.py's resolved absolute path, not
+    `-m backend.main` — re-exec'ing with that argv as-is runs main.py as a plain
+    script instead, which makes Python prepend *its own* directory (`backend/`) to
+    sys.path before backend/main.py's own `sys.path.insert(0, project_root)` runs.
+    `backend/mcp/` (a real subpackage of this repo) then shadows the third-party
+    `mcp` distribution `claude_agent_sdk` needs, crash-looping the restarted
+    process with `ModuleNotFoundError: No module named 'mcp.types'`. This is only
+    reachable via this endpoint completing its own restart — src/backend_supervisor.py
+    always spawns Backend fresh via `[sys.executable, "-m", "backend.main", ...]`
+    (_build_command()), never through this path, so embedded mode was never affected.
+    """
+    await asyncio.sleep(0.5)
+    logger.info("Executing os.execv restart...")
+    try:
+        await webui.coordinator.cleanup()
+    except Exception as e:
+        logger.warning(f"Cleanup error during restart: {e}")
+    os.execv(sys.executable, [sys.executable, "-m", "backend.main"] + sys.argv[1:])
+
+
 def build_router(webui) -> APIRouter:
     router = APIRouter()
 
@@ -418,16 +450,7 @@ def build_router(webui) -> APIRouter:
         webui._broadcast_server_restarting(pull_output, sync_output)
 
         # Schedule the actual restart after response is sent
-        async def _do_restart():
-            await asyncio.sleep(0.5)
-            logger.info("Executing os.execv restart...")
-            try:
-                await webui.coordinator.cleanup()
-            except Exception as e:
-                logger.warning(f"Cleanup error during restart: {e}")
-            os.execv(sys.executable, [sys.executable] + sys.argv)
-
-        asyncio.get_event_loop().create_task(_do_restart())
+        asyncio.get_event_loop().create_task(_do_restart(webui))
 
         return {
             "status": "restarting",

--- a/backend/tests/integration/test_api_system.py
+++ b/backend/tests/integration/test_api_system.py
@@ -27,6 +27,8 @@ Tests:
 import subprocess
 from unittest.mock import AsyncMock, patch
 
+from backend.routers.system import _do_restart
+
 
 class TestHealth:
     async def test_health_check(self, api_integration_env):
@@ -464,6 +466,49 @@ class TestRestartCustomPath:
         finally:
             for p in patches:
                 p.stop()
+
+
+class TestDoRestartReExec:
+    """Issue #1847 review finding: found via a live remote-mode smoke test, not by
+    any mocked-os.execv unit test (none of the existing ones let the re-exec'd
+    process actually start). _do_restart must reconstruct a module-mode
+    (`-m backend.main`) invocation — reusing `sys.argv` as-is re-execs as a plain
+    script instead, whose auto-prepended own directory (`backend/`) shadows the
+    third-party `mcp` package with this repo's own `backend/mcp/` subpackage,
+    crash-looping the restarted process. See _do_restart's docstring for detail."""
+
+    async def test_reexecs_via_module_mode_not_raw_argv(self, api_integration_env):
+        webui = api_integration_env["webui"]
+
+        with (
+            patch("backend.routers.system.asyncio.sleep", AsyncMock()),
+            patch("backend.routers.system.os.execv") as mock_execv,
+            patch.object(webui.coordinator, "cleanup", AsyncMock()),
+            patch(
+                "backend.routers.system.sys.argv",
+                ["/repo/backend/main.py", "--host", "127.0.0.1", "--port", "58471", "--embedded"],
+            ),
+            patch("backend.routers.system.sys.executable", "/venv/bin/python3"),
+        ):
+            await _do_restart(webui)
+
+        mock_execv.assert_called_once_with(
+            "/venv/bin/python3",
+            ["/venv/bin/python3", "-m", "backend.main",
+             "--host", "127.0.0.1", "--port", "58471", "--embedded"],
+        )
+
+    async def test_cleanup_failure_does_not_block_reexec(self, api_integration_env):
+        webui = api_integration_env["webui"]
+
+        with (
+            patch("backend.routers.system.asyncio.sleep", AsyncMock()),
+            patch("backend.routers.system.os.execv") as mock_execv,
+            patch.object(webui.coordinator, "cleanup", AsyncMock(side_effect=RuntimeError("boom"))),
+        ):
+            await _do_restart(webui)
+
+        mock_execv.assert_called_once()
 
 
 class TestFilesystem:

--- a/src/backend_client.py
+++ b/src/backend_client.py
@@ -93,10 +93,23 @@ class BackendClient:
         resp.raise_for_status()
         return resp.json()
 
-    async def request_json(self, method: str, path: str, json: dict | None = None) -> dict:
-        """Call a JSON endpoint on Backend and return the decoded body. Raises on non-2xx."""
+    async def request_json(
+        self, method: str, path: str, json: dict | None = None, timeout: float | None = None
+    ) -> dict:
+        """Call a JSON endpoint on Backend and return the decoded body. Raises on non-2xx.
+
+        Pass `timeout` explicitly for callers awaiting a Backend operation with its own
+        long synchronous work budget (e.g. the restart endpoint's git operations + uv
+        sync, up to ~180s) — the client-side timeout must have margin above that budget,
+        same discipline as get_json() (issue #498 review finding). Omitted entirely
+        (not just falsy) when not given, so existing callers keep this client's normal
+        per-request default instead of an explicit `timeout=None` disabling it outright.
+        """
+        kwargs = {"json": json, "headers": self._auth_headers()}
+        if timeout is not None:
+            kwargs["timeout"] = timeout
         try:
-            resp = await self._client.request(method, path, json=json, headers=self._auth_headers())
+            resp = await self._client.request(method, path, **kwargs)
         except httpx.RequestError as e:
             self.reachability.record_failure(e)
             raise

--- a/src/routers/system.py
+++ b/src/routers/system.py
@@ -20,8 +20,10 @@ import os
 import subprocess
 import sys
 import time
+from dataclasses import dataclass
 from pathlib import Path
 
+import httpx
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
@@ -30,10 +32,117 @@ from shared.git_restart import run_git_command, validate_git_ref_component
 
 logger = logging.getLogger(__name__)
 
+# Per-phase timeout for polling a remote Backend back to healthy, then ready, after
+# triggering its restart. Each phase gets its OWN full budget below (not one shared
+# deadline) — mirrors BackendSupervisor.wait_ready()'s own two-phase-deadline fix in
+# src/backend_supervisor.py: a shared deadline can starve the second phase for a
+# Backend slow to pass the first. Matches the 60s ceiling RestartModal.vue already
+# uses for its own post-restart health poll, for consistency.
+_BACKEND_RESTART_TIMEOUT = 60.0
+_BACKEND_RESTART_POLL_INTERVAL = 0.5
+# Grace period before the first poll. Backend's own restart re-execs ~0.5s after
+# responding (backend/routers/system.py's _do_restart), so polling immediately risks
+# observing the still-alive pre-restart process and declaring success without ever
+# having seen it go down and come back.
+_BACKEND_RESTART_GRACE_SECONDS = 1.0
+# Margin above Backend's own worst-case synchronous restart-trigger work (git
+# checkout/fetch/reset up to ~75s, then uv sync up to 120s — both run before Backend
+# even responds). The client-side timeout for triggering the restart must have
+# headroom above that budget, not equal or below it — same discipline as
+# BackendClient.get_json()'s own docstring (issue #498 review finding).
+_BACKEND_RESTART_TRIGGER_TIMEOUT = 210.0
+
 
 class RestartRequest(BaseModel):
-    branch: str | None = None
-    commit: str | None = None
+    branch: str | None = None       # Frontend's own target (unchanged meaning)
+    commit: str | None = None       # Frontend's own target (unchanged meaning)
+    backend_branch: str | None = None   # remote mode only — Backend's target
+    backend_commit: str | None = None   # remote mode only — Backend's target
+
+
+@dataclass
+class BackendRestartOutcome:
+    status: str  # "restarted" | "failed" | "unreachable"
+    detail: str
+
+    @property
+    def ok(self) -> bool:
+        return self.status == "restarted"
+
+
+async def _restart_remote_backend(webui, payload: "RestartRequest") -> BackendRestartOutcome:
+    """Orchestrate a remote Backend's own restart before Frontend restarts itself.
+
+    Only called in remote mode (webui.backend_supervisor is None). Backend's own
+    POST /api/system/restart (backend/routers/system.py) already fully implements
+    this exact {branch, commit} target contract, already validates/fetches/
+    checks-out/resets against its own repo, and already waits, re-execs, and comes
+    back up on its own — this is orchestration glue, not new restart machinery.
+
+    Note: Backend's own git checkout/reset runs synchronously, before it even
+    responds to the trigger request below — so once Backend accepts the request at
+    all, its repo has already changed regardless of what happens next. A "failed"/
+    "unreachable" outcome from this function only guarantees Frontend hasn't touched
+    its own state; it does not mean Backend's is unchanged too.
+    """
+    if not await webui.backend_client.health():
+        return BackendRestartOutcome(
+            status="unreachable",
+            detail="Backend was already unreachable before this restart was attempted.",
+        )
+
+    backend_payload = {"branch": payload.backend_branch, "commit": payload.backend_commit}
+    try:
+        await webui.backend_client.request_json(
+            "POST", "/api/system/restart", json=backend_payload,
+            timeout=_BACKEND_RESTART_TRIGGER_TIMEOUT,
+        )
+    except httpx.HTTPStatusError as e:
+        detail = e.response.text
+        try:
+            detail = e.response.json().get("detail", detail)
+        except (ValueError, AttributeError, TypeError):
+            pass
+        return BackendRestartOutcome(status="failed", detail=detail)
+    except httpx.RequestError as e:
+        return BackendRestartOutcome(
+            status="unreachable",
+            detail=f"Backend became unreachable while triggering its restart: {e}",
+        )
+
+    # Backend returned 202 and is now restarting asynchronously (fire-and-forget,
+    # same pattern as Frontend's own _finish_restart). Give it a moment to actually
+    # start tearing down before polling (see _BACKEND_RESTART_GRACE_SECONDS), then
+    # poll it back to healthy, then ready. health()/ready() route connection failures
+    # through BackendReachabilityTracker automatically, so repeated failures during
+    # the expected outage window collapse into the existing suppressed-warning
+    # behavior (#1844) instead of spamming error.log.
+    await asyncio.sleep(_BACKEND_RESTART_GRACE_SECONDS)
+
+    async def _poll_until(check) -> bool:
+        deadline = time.monotonic() + _BACKEND_RESTART_TIMEOUT
+        while time.monotonic() < deadline:
+            if await check():
+                return True
+            await asyncio.sleep(_BACKEND_RESTART_POLL_INTERVAL)
+        return False
+
+    if not await _poll_until(webui.backend_client.health):
+        return BackendRestartOutcome(
+            status="failed",
+            detail=f"Backend did not become healthy within {int(_BACKEND_RESTART_TIMEOUT)}s of restarting.",
+        )
+
+    if not await _poll_until(webui.backend_client.ready):
+        return BackendRestartOutcome(
+            status="failed",
+            detail=(
+                f"Backend became healthy but did not report ready within the "
+                f"{int(_BACKEND_RESTART_TIMEOUT)}s restart window."
+            ),
+        )
+
+    return BackendRestartOutcome(status="restarted", detail="Backend restarted and is ready.")
 
 
 async def _restart_to_target(project_root: Path, payload: "RestartRequest") -> str:
@@ -180,10 +289,19 @@ def build_router(webui) -> APIRouter:
         would keep running under a supervisor that's about to stop watching
         it, orphaned, while a second, fresh Backend also starts on re-exec.)
 
-        Remote mode (webui.backend_supervisor is None): only Frontend is
-        restarted. A remote Backend is a separate deployment this action does
-        not attempt to manage — coordinated split-repo restart/rollback for
-        that case is tracked separately.
+        Remote mode (webui.backend_supervisor is None): Backend is restarted
+        first via _restart_remote_backend() — defaulting to "pull latest" on
+        Backend too when backend_branch/backend_commit are both absent, or an
+        explicit independent target otherwise. Frontend's own restart only
+        proceeds once Backend reports healthy+ready again; a Backend-side
+        failure reported by that step (already unreachable, rejected target,
+        never came back healthy+ready) aborts before Frontend touches its own
+        git state or restarts. Note this guarantees Frontend is untouched on
+        such a failure, not that Backend is too: Backend's own git checkout/
+        reset runs synchronously before it even responds, so a request Backend
+        *accepts* has already changed Backend's repo regardless of what
+        happens afterward — full two-tier atomicity (e.g. if Frontend's own
+        subsequent git operations then fail) is out of scope for this stage.
         """
         now = time.time()
         if now - webui._last_restart_time < 30:
@@ -194,8 +312,29 @@ def build_router(webui) -> APIRouter:
             )
         webui._last_restart_time = now
 
+        payload = payload or RestartRequest()
         project_root = Path(__file__).parent.parent.parent
-        has_custom_target = payload is not None and (payload.branch or payload.commit)
+
+        # Validate Frontend's own target up front, before Backend is touched at all —
+        # a malformed/malicious ref here must not trigger Backend's restart only to
+        # then have Frontend itself reject the request (also re-checked inside
+        # _restart_to_target(), which remains the authoritative check for its own
+        # direct callers/tests).
+        for value, field_name in ((payload.branch, "branch"), (payload.commit, "commit")):
+            if value is not None:
+                validate_git_ref_component(value, field_name)
+
+        has_custom_target = bool(payload.branch or payload.commit)
+
+        backend_outcome = None
+        if webui.backend_supervisor is None:
+            outcome = await _restart_remote_backend(webui, payload)
+            if not outcome.ok:
+                raise HTTPException(
+                    status_code=502,
+                    detail=f"Backend restart failed ({outcome.status}): {outcome.detail}",
+                )
+            backend_outcome = {"status": outcome.status, "detail": outcome.detail}
 
         if not has_custom_target:
             try:
@@ -257,6 +396,7 @@ def build_router(webui) -> APIRouter:
             "message": "Server is pulling latest code and restarting...",
             "pull_output": pull_output,
             "sync_output": sync_output,
+            "backend": backend_outcome,
         }
 
     return router

--- a/src/tests/test_backend_client.py
+++ b/src/tests/test_backend_client.py
@@ -142,6 +142,39 @@ async def test_issue_1844_request_json_records_success_before_raise_for_status()
     assert client.reachability.is_unreachable is False
 
 
+@pytest.mark.asyncio
+async def test_issue_1847_request_json_omits_timeout_kwarg_when_not_given():
+    """Existing callers (e.g. config.py's PUT /api/config) must keep this client's
+    normal per-request default — explicitly passing `timeout=None` to httpx disables
+    the timeout entirely rather than falling back to the client default, so the
+    kwarg must be omitted outright, not passed as None."""
+    client = _make_client()
+    resp = MagicMock()
+    resp.json.return_value = {"ok": True}
+    client._client.request = AsyncMock(return_value=resp)
+
+    await client.request_json("PUT", "/api/config", json={"a": 1})
+
+    _, kwargs = client._client.request.call_args
+    assert "timeout" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_issue_1847_request_json_forwards_explicit_timeout():
+    """Callers awaiting a Backend operation with its own long synchronous work
+    budget (e.g. the restart endpoint's git operations + uv sync) must be able to
+    give the client-side call matching headroom."""
+    client = _make_client()
+    resp = MagicMock()
+    resp.json.return_value = {"ok": True}
+    client._client.request = AsyncMock(return_value=resp)
+
+    await client.request_json("POST", "/api/system/restart", json={}, timeout=210.0)
+
+    _, kwargs = client._client.request.call_args
+    assert kwargs["timeout"] == 210.0
+
+
 # --- health() / ready() ---
 
 

--- a/src/tests/test_system_router.py
+++ b/src/tests/test_system_router.py
@@ -11,6 +11,7 @@ intercepts this one route itself instead of falling through to the generic relay
 import subprocess
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
@@ -27,6 +28,12 @@ def _make_webui(backend_supervisor=None):
     webui.backend_supervisor = backend_supervisor
     webui.poll_relay.stop = AsyncMock()
     webui.backend_client.aclose = AsyncMock()
+    # Remote-mode Backend orchestration defaults (#1847) — sane "everything's fine"
+    # mocks so pre-existing tests exercising remote mode (backend_supervisor=None)
+    # without caring about Backend orchestration don't need to know about it.
+    webui.backend_client.health = AsyncMock(return_value=True)
+    webui.backend_client.ready = AsyncMock(return_value=True)
+    webui.backend_client.request_json = AsyncMock(return_value={"status": "restarting"})
     webui.ui_queue.append = MagicMock()
     return webui
 
@@ -102,6 +109,10 @@ class TestRestartCustomTarget:
             resp = await client.post("/api/system/restart", json={"branch": "--upload-pack=/bin/sh"})
 
         assert resp.status_code == 400
+        # Malformed Frontend target must be rejected before Backend is touched at
+        # all (issue #1847 review finding) — not just before Frontend's own git ops.
+        webui.backend_client.health.assert_not_awaited()
+        webui.backend_client.request_json.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_uncommitted_changes_returns_409(self):
@@ -220,3 +231,190 @@ class TestFinishRestart:
         mock_execv.assert_called_once_with(
             "/usr/bin/python3", ["/usr/bin/python3", "main.py", "--port", "8000"]
         )
+
+
+def _http_status_error(status_code, detail):
+    request = httpx.Request("POST", "http://backend/api/system/restart")
+    response = httpx.Response(status_code, json={"detail": detail}, request=request)
+    return httpx.HTTPStatusError(str(status_code), request=request, response=response)
+
+
+def _default_run_side_effect(cmd, **kwargs):
+    if cmd == ["git", "pull"]:
+        return _fake_completed(stdout="Already up to date.\n")
+    if cmd == ["uv", "sync"]:
+        return _fake_completed(stdout="Synced\n")
+    raise AssertionError(f"Unexpected subprocess.run call: {cmd}")
+
+
+def _no_subprocess_expected(cmd, **kwargs):
+    raise AssertionError(f"Frontend must not touch its own git state: {cmd}")
+
+
+class TestRestartRemoteBackendOrchestration:
+    """Remote mode (webui.backend_supervisor is None) Backend-orchestration step (#1847)."""
+
+    @pytest.mark.asyncio
+    async def test_no_explicit_targets_both_tiers_restart(self):
+        webui = _make_webui(backend_supervisor=None)
+        # health/ready/request_json defaults ("everything's fine") come from _make_webui.
+
+        with (
+            patch("src.routers.system._BACKEND_RESTART_GRACE_SECONDS", 0),
+            patch("src.routers.system.subprocess.run", side_effect=_default_run_side_effect),
+        ):
+            async with AsyncClient(transport=ASGITransport(app=webui.app), base_url="http://test") as client:
+                resp = await client.post("/api/system/restart")
+
+        assert resp.status_code == 202
+        body = resp.json()
+        assert body["backend"] == {"status": "restarted", "detail": "Backend restarted and is ready."}
+        assert body["pull_output"] == "Already up to date."
+        webui.backend_client.request_json.assert_awaited_once_with(
+            "POST", "/api/system/restart", json={"branch": None, "commit": None}, timeout=210.0,
+        )
+
+    @pytest.mark.asyncio
+    async def test_independent_per_tier_targets(self):
+        webui = _make_webui(backend_supervisor=None)
+        # health/ready/request_json defaults ("everything's fine") come from _make_webui.
+
+        async def run_git_command_side_effect(args, cwd, allow_nonzero=False):
+            if args == ["git", "status", "--porcelain"]:
+                return ""
+            if args == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
+                return "main"
+            if args == ["git", "rev-parse", "--verify", "--quiet", "refs/heads/frontend-branch"]:
+                return "abc123"
+            if args == ["git", "rev-parse", "--short", "HEAD"]:
+                return "def4567"
+            raise AssertionError(f"Unexpected run_git_command call: {args}")
+
+        def run_side_effect(cmd, **kwargs):
+            if cmd == ["git", "checkout", "frontend-branch"]:
+                return _fake_completed()
+            if cmd == ["git", "reset", "--hard", "origin/frontend-branch"]:
+                return _fake_completed()
+            if cmd == ["uv", "sync"]:
+                return _fake_completed(stdout="Synced\n")
+            raise AssertionError(f"Unexpected subprocess.run call: {cmd}")
+
+        with (
+            patch("src.routers.system.run_git_command", AsyncMock(side_effect=run_git_command_side_effect)),
+            patch("src.routers.system.subprocess.run", side_effect=run_side_effect),
+            patch("src.routers.system.asyncio.create_subprocess_exec", AsyncMock()),
+            patch("src.routers.system._BACKEND_RESTART_GRACE_SECONDS", 0),
+        ):
+            async with AsyncClient(transport=ASGITransport(app=webui.app), base_url="http://test") as client:
+                resp = await client.post(
+                    "/api/system/restart",
+                    json={"branch": "frontend-branch", "backend_branch": "backend-branch"},
+                )
+
+        assert resp.status_code == 202
+        assert "Switched to frontend-branch" in resp.json()["pull_output"]
+        webui.backend_client.request_json.assert_awaited_once_with(
+            "POST", "/api/system/restart", json={"branch": "backend-branch", "commit": None}, timeout=210.0,
+        )
+
+    @pytest.mark.asyncio
+    async def test_backend_rejects_target_synchronously(self):
+        webui = _make_webui(backend_supervisor=None)
+        webui.backend_client.health = AsyncMock(return_value=True)
+        webui.backend_client.request_json = AsyncMock(
+            side_effect=_http_status_error(409, "Uncommitted changes present.")
+        )
+
+        with patch("src.routers.system.subprocess.run", side_effect=_no_subprocess_expected):
+            async with AsyncClient(transport=ASGITransport(app=webui.app), base_url="http://test") as client:
+                resp = await client.post("/api/system/restart")
+
+        assert resp.status_code == 502
+        assert "Uncommitted changes present." in resp.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_backend_already_unreachable_fails_fast(self):
+        webui = _make_webui(backend_supervisor=None)
+        webui.backend_client.health = AsyncMock(return_value=False)
+        webui.backend_client.request_json = AsyncMock()
+
+        with patch("src.routers.system.subprocess.run", side_effect=_no_subprocess_expected):
+            async with AsyncClient(transport=ASGITransport(app=webui.app), base_url="http://test") as client:
+                resp = await client.post("/api/system/restart")
+
+        assert resp.status_code == 502
+        assert "already unreachable" in resp.json()["detail"]
+        webui.backend_client.request_json.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_backend_never_becomes_healthy_times_out(self):
+        webui = _make_webui(backend_supervisor=None)
+
+        # health() is called once for the initial "already unreachable?" fail-fast
+        # check (must be True/reachable here) and then repeatedly inside the poll
+        # loop (must stay False forever to exercise the timeout path).
+        calls = {"n": 0}
+
+        async def health_side_effect():
+            calls["n"] += 1
+            return calls["n"] == 1
+
+        webui.backend_client.health = AsyncMock(side_effect=health_side_effect)
+        webui.backend_client.request_json = AsyncMock(return_value={"status": "restarting"})
+
+        with (
+            patch("src.routers.system._BACKEND_RESTART_TIMEOUT", 0.2),
+            patch("src.routers.system._BACKEND_RESTART_POLL_INTERVAL", 0.05),
+            patch("src.routers.system._BACKEND_RESTART_GRACE_SECONDS", 0),
+            patch("src.routers.system.subprocess.run", side_effect=_no_subprocess_expected),
+        ):
+            async with AsyncClient(transport=ASGITransport(app=webui.app), base_url="http://test") as client:
+                resp = await client.post("/api/system/restart")
+
+        assert resp.status_code == 502
+        assert "did not become healthy" in resp.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_health_and_ready_each_get_independent_timeout_budget(self):
+        """Regression guard (#1847 review finding): health and ready must each get
+        their OWN full timeout budget, not one shared deadline split between them —
+        mirrors the bug BackendSupervisor.wait_ready() already fixed for startup."""
+        webui = _make_webui(backend_supervisor=None)
+        # First health() call is the initial "already unreachable?" fail-fast check
+        # (True/reachable); the next 4 are the health-poll phase, taking ~4 polls
+        # (~0.2s) to succeed — enough to exhaust a *shared* 0.3s deadline before
+        # ready() ever got a turn under the old (buggy) design.
+        webui.backend_client.health = AsyncMock(side_effect=[True, False, False, False, True])
+        webui.backend_client.ready = AsyncMock(side_effect=[False, False, True])
+        webui.backend_client.request_json = AsyncMock(return_value={"status": "restarting"})
+
+        with (
+            patch("src.routers.system._BACKEND_RESTART_TIMEOUT", 0.3),
+            patch("src.routers.system._BACKEND_RESTART_POLL_INTERVAL", 0.05),
+            patch("src.routers.system._BACKEND_RESTART_GRACE_SECONDS", 0),
+            patch("src.routers.system.subprocess.run", side_effect=_default_run_side_effect),
+        ):
+            async with AsyncClient(transport=ASGITransport(app=webui.app), base_url="http://test") as client:
+                resp = await client.post("/api/system/restart")
+
+        assert resp.status_code == 202
+        assert resp.json()["backend"] == {"status": "restarted", "detail": "Backend restarted and is ready."}
+
+    @pytest.mark.asyncio
+    async def test_embedded_mode_regression_unaffected(self):
+        """Regression: embedded mode must not execute any of the new remote-mode
+        orchestration code — no Backend health/ready/request_json calls at all."""
+        webui = _make_webui(backend_supervisor=MagicMock(stop=AsyncMock()))
+        webui.backend_client.health = AsyncMock()
+        webui.backend_client.ready = AsyncMock()
+        webui.backend_client.request_json = AsyncMock()
+
+        with patch("src.routers.system.subprocess.run", side_effect=_default_run_side_effect):
+            async with AsyncClient(transport=ASGITransport(app=webui.app), base_url="http://test") as client:
+                resp = await client.post("/api/system/restart")
+
+        assert resp.status_code == 202
+        assert resp.json()["backend"] is None
+        webui.backend_client.health.assert_not_awaited()
+        webui.backend_client.ready.assert_not_awaited()
+        webui.backend_client.request_json.assert_not_awaited()


### PR DESCRIPTION
## Summary

Progress on #1847 — stage 1 of 3 (backend orchestration). Stages 2 (#1847-ui:
UI drift/trigger surfacing) and 3 (#1847-auth: auth hardening for this now
more sensitive remote action) are tracked separately and will follow in their
own PRs against their own worktrees — this PR intentionally does not close
the parent issue.

`POST /api/system/restart` previously only managed Backend in embedded mode
(`webui.backend_supervisor is not None`); in remote mode (`--remote-backend-url`)
it silently restarted Frontend only, leaving a remote Backend deployment on
stale code forever. This PR wires up Backend's own restart endpoint to be
triggered and awaited before Frontend restarts itself — plus a required
fix to that endpoint's own restart mechanism, found via live testing (see
below), without which the new orchestration could detect and report a
Backend restart failure but Backend could never actually come back up.

## Changes Made

**Remote-mode orchestration** (`src/routers/system.py`, `src/backend_client.py`):
- New `_restart_remote_backend()` helper, called from `restart_server()` only
  when `webui.backend_supervisor is None`
- `RestartRequest` gains optional `backend_branch`/`backend_commit` fields
  (remote mode only, independent of Frontend's own `branch`/`commit` target);
  response gains a `"backend"` outcome key (`status`/`detail`)
- Any Backend-side failure (already unreachable, rejected target, never came
  back healthy+ready within a bounded window) aborts before Frontend touches
  its own git state or restarts
- Health/ready polling uses independent per-phase timeout budgets, mirroring
  `BackendSupervisor.wait_ready()`'s own fix for a shared-deadline-starves-
  the-second-phase bug, plus a short grace period before the first poll so a
  still-alive pre-restart Backend process isn't mistaken for a completed one
- Frontend's own branch/commit format validation now runs before Backend is
  ever triggered, so a malformed request can't cause a real Backend restart
  only to then be rejected locally
- `BackendClient.request_json()` gains an optional `timeout` override so the
  restart-trigger call can have headroom above Backend's own up to ~180s of
  synchronous git+uv work (existing callers unaffected — the kwarg is
  omitted, not passed as `None`, when not given)

**Required dependency fix, found via live testing** (`backend/routers/system.py`):
- A manual two-process remote-mode smoke test (standalone Backend +
  Frontend with `--remote-backend-url` pointed at it) showed the new
  orchestration correctly detecting a Backend restart failure — but Backend
  itself never actually came back up. Root cause: `_do_restart()`'s
  `os.execv(sys.executable, [sys.executable] + sys.argv)` re-executes as a
  plain script (not `-m backend.main`) whenever Backend was originally
  launched via `-m backend.main` (since `sys.argv[0]` becomes main.py's
  resolved path, not `-m backend.main`), letting Python's script-mode
  sys.path prepending shadow the third-party `mcp` package with this repo's
  own `backend/mcp/` subpackage — `ModuleNotFoundError: No module named
  'mcp.types'`, crash-looping the restarted process.
  - Fixed by reconstructing the module-mode invocation explicitly:
    `[sys.executable, "-m", "backend.main"] + sys.argv[1:]`.
  - Confirmed `src/backend_supervisor.py`'s embedded-mode spawn path
    (`_build_command()`) always launches fresh via `-m backend.main` and
    never goes through this function — embedded mode was never affected,
    and needed no changes.
  - This was pre-existing, untested-in-practice code (nothing had ever
    previously called Backend's own restart endpoint and let it complete
    end-to-end) — a required dependency for this stage to be functional,
    not scope creep.

Embedded mode is completely unaffected by either change — regression-tested.

## Testing
- `uv run ruff check src/ backend/` — zero violations
- `uv run pytest backend/tests/ src/tests/` — 2541 passed (run twice to rule
  out flakiness); the same 3 pre-existing failures (`test_api_links.py` x2,
  `test_issue_1598_poll_viewed_timing.py`) reproduce identically on a clean
  `main` checkout, confirmed unrelated
- New/updated tests cover all 6 of the plan's testing-strategy scenarios
  (default-pull-both-tiers, independent per-tier targets, Backend synchronous
  rejection, Backend already unreachable, Backend restart timeout,
  embedded-mode regression), two additional regressions found in review
  (independent per-phase poll timeout budgets, Frontend validation running
  before Backend is touched), and a direct regression test for the
  `os.execv` fix (`backend/tests/integration/test_api_system.py::TestDoRestartReExec`,
  asserting the reconstructed argv)
- **Live end-to-end verification**: ran a real standalone Backend process
  plus a real Frontend process in genuine remote mode
  (`--remote-backend-url`/`--remote-backend-token`), triggered
  `POST /api/system/restart`, and confirmed both processes actually restart
  and come back healthy+ready (`{"backend":{"status":"restarted","detail":
  "Backend restarted and is ready."}}`) — this is what caught the
  `os.execv` bug above in the first place, and confirms the fix
- Self-review via `builder-review` skill (8-angle diff review) on the
  orchestration change; all confirmed findings applied and verified above

🤖 Generated with [Claude Code](https://claude.com/claude-code)