### PR TITLE
[fix]: capture subagent (Agent tool) token usage in analytics

### DIFF
--- a/backend/analytics/database.py
+++ b/backend/analytics/database.py
@@ -50,32 +50,59 @@ CREATE INDEX IF NOT EXISTS idx_audit_session_turn
     ON audit_events(session_id, turn_id);
 
 CREATE TABLE IF NOT EXISTS turn_usage (
-  id                  INTEGER PRIMARY KEY AUTOINCREMENT,
-  session_id          TEXT    NOT NULL,
-  turn_seq            INTEGER NOT NULL,
-  model               TEXT,
-  input_tokens        INTEGER NOT NULL DEFAULT 0,
-  output_tokens       INTEGER NOT NULL DEFAULT 0,
-  cache_write_tokens  INTEGER NOT NULL DEFAULT 0,
-  cache_read_tokens   INTEGER NOT NULL DEFAULT 0,
-  sdk_total_cost_usd  REAL,
-  ts                  REAL    NOT NULL,
+  id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_id            TEXT    NOT NULL,
+  turn_seq              INTEGER NOT NULL,
+  model                 TEXT,
+  input_tokens          INTEGER NOT NULL DEFAULT 0,
+  output_tokens         INTEGER NOT NULL DEFAULT 0,
+  cache_write_tokens    INTEGER NOT NULL DEFAULT 0,
+  cache_read_tokens     INTEGER NOT NULL DEFAULT 0,
+  cache_write_tokens_5m INTEGER NOT NULL DEFAULT 0,
+  cache_write_tokens_1h INTEGER NOT NULL DEFAULT 0,
+  is_subagent           INTEGER NOT NULL DEFAULT 0,
+  sdk_total_cost_usd    REAL,
+  ts                    REAL    NOT NULL,
   UNIQUE(session_id, turn_seq)
 );
 CREATE INDEX IF NOT EXISTS idx_turn_session ON turn_usage(session_id);
 
 CREATE TABLE IF NOT EXISTS session_usage (
-  session_id          TEXT PRIMARY KEY,
-  model               TEXT,
-  turn_count          INTEGER NOT NULL DEFAULT 0,
-  input_tokens        INTEGER NOT NULL DEFAULT 0,
-  output_tokens       INTEGER NOT NULL DEFAULT 0,
-  cache_write_tokens  INTEGER NOT NULL DEFAULT 0,
-  cache_read_tokens   INTEGER NOT NULL DEFAULT 0,
-  sdk_total_cost_usd  REAL,
-  last_updated        REAL    NOT NULL
+  session_id            TEXT PRIMARY KEY,
+  model                 TEXT,
+  turn_count            INTEGER NOT NULL DEFAULT 0,
+  input_tokens          INTEGER NOT NULL DEFAULT 0,
+  output_tokens         INTEGER NOT NULL DEFAULT 0,
+  cache_write_tokens    INTEGER NOT NULL DEFAULT 0,
+  cache_read_tokens     INTEGER NOT NULL DEFAULT 0,
+  cache_write_tokens_5m INTEGER NOT NULL DEFAULT 0,
+  cache_write_tokens_1h INTEGER NOT NULL DEFAULT 0,
+  sdk_total_cost_usd    REAL,
+  last_updated          REAL    NOT NULL
 );
 """
+
+# Issue #1840: columns added after the initial schema. _DDL's CREATE TABLE IF NOT
+# EXISTS only benefits brand-new database files; existing on-disk databases need
+# these ALTER TABLE statements applied explicitly, guarded so re-running on every
+# startup doesn't raise on an already-added column.
+_MIGRATIONS: tuple[tuple[str, str, str], ...] = (
+    ("turn_usage", "cache_write_tokens_5m", "INTEGER NOT NULL DEFAULT 0"),
+    ("turn_usage", "cache_write_tokens_1h", "INTEGER NOT NULL DEFAULT 0"),
+    ("turn_usage", "is_subagent", "INTEGER NOT NULL DEFAULT 0"),
+    ("session_usage", "cache_write_tokens_5m", "INTEGER NOT NULL DEFAULT 0"),
+    ("session_usage", "cache_write_tokens_1h", "INTEGER NOT NULL DEFAULT 0"),
+)
+
+
+def _migrate_add_column_if_missing(
+    conn: sqlite3.Connection, table: str, column: str, ddl_fragment: str
+) -> None:
+    """Add `column` to `table` via ALTER TABLE, unless it already exists."""
+    existing = {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+    if column in existing:
+        return
+    conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {ddl_fragment}")
 
 
 class AnalyticsDB:
@@ -119,6 +146,8 @@ class AnalyticsDB:
         self._write_conn.execute("PRAGMA journal_mode=WAL")
         self._write_conn.execute("PRAGMA busy_timeout=5000")
         self._write_conn.executescript(_DDL)
+        for table, column, ddl_fragment in _MIGRATIONS:
+            _migrate_add_column_if_missing(self._write_conn, table, column, ddl_fragment)
         self._write_conn.commit()
 
         self._read_conn = sqlite3.connect(str(self._path), check_same_thread=False)

--- a/backend/analytics_store.py
+++ b/backend/analytics_store.py
@@ -18,6 +18,7 @@ _SESSION_COLS = [
     "session_id", "model", "turn_count",
     "input_tokens", "output_tokens",
     "cache_write_tokens", "cache_read_tokens",
+    "cache_write_tokens_5m", "cache_write_tokens_1h",
     "sdk_total_cost_usd", "last_updated",
 ]
 
@@ -39,6 +40,7 @@ class AnalyticsStore:
         model: str | None,
         usage: dict,
         sdk_total_cost_usd: float | None,
+        is_subagent: bool = False,
     ) -> bool:
         """Insert a turn_usage row (idempotent) and upsert session aggregate.
 
@@ -46,6 +48,10 @@ class AnalyticsStore:
         per-turn-delta baseline needs to know this: it must not advance past
         a turn whose delta was never durably persisted, or that turn's
         contribution is lost forever instead of merged into the next delta).
+
+        `is_subagent` marks a catch-up row written by the termination-time
+        flush of leftover subagent (Task/Agent tool) usage (issue #1840) —
+        never set for a normal turn recorded from a top-level ResultMessage.
         """
         input_tokens = int(usage.get("input_tokens") or 0)
         output_tokens = int(usage.get("output_tokens") or 0)
@@ -60,6 +66,11 @@ class AnalyticsStore:
             or usage.get("cache_read_tokens")
             or 0
         )
+        # Issue #1840: subagent-derived TTL tier breakdown. Not populated from the
+        # top-level ResultMessage path — that's a pre-existing, cumulative-snapshot
+        # value untouched by this issue.
+        cache_write_tokens_5m = int(usage.get("cache_write_tokens_5m") or 0)
+        cache_write_tokens_1h = int(usage.get("cache_write_tokens_1h") or 0)
         now = time()
 
         try:
@@ -69,13 +80,15 @@ class AnalyticsStore:
                   (session_id, turn_seq, model,
                    input_tokens, output_tokens,
                    cache_write_tokens, cache_read_tokens,
+                   cache_write_tokens_5m, cache_write_tokens_1h, is_subagent,
                    sdk_total_cost_usd, ts)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     session_id, turn_seq, model,
                     input_tokens, output_tokens,
                     cache_write_tokens, cache_read_tokens,
+                    cache_write_tokens_5m, cache_write_tokens_1h, int(is_subagent),
                     sdk_total_cost_usd, now,
                 ),
             )
@@ -87,27 +100,37 @@ class AnalyticsStore:
                   (session_id, model, turn_count,
                    input_tokens, output_tokens,
                    cache_write_tokens, cache_read_tokens,
+                   cache_write_tokens_5m, cache_write_tokens_1h,
                    sdk_total_cost_usd, last_updated)
                 SELECT
                   ?,
                   ?,
-                  COUNT(*),
+                  COUNT(*) FILTER (WHERE is_subagent = 0),
                   COALESCE(SUM(input_tokens), 0),
                   COALESCE(SUM(output_tokens), 0),
                   COALESCE(SUM(cache_write_tokens), 0),
                   COALESCE(SUM(cache_read_tokens), 0),
+                  COALESCE(SUM(cache_write_tokens_5m), 0),
+                  COALESCE(SUM(cache_write_tokens_1h), 0),
                   COALESCE(SUM(COALESCE(sdk_total_cost_usd, 0)), 0),
                   ?
                 FROM turn_usage WHERE session_id = ?
                 ON CONFLICT(session_id) DO UPDATE SET
-                  model              = excluded.model,
-                  turn_count         = excluded.turn_count,
-                  input_tokens       = excluded.input_tokens,
-                  output_tokens      = excluded.output_tokens,
-                  cache_write_tokens = excluded.cache_write_tokens,
-                  cache_read_tokens  = excluded.cache_read_tokens,
-                  sdk_total_cost_usd = excluded.sdk_total_cost_usd,
-                  last_updated       = excluded.last_updated
+                  -- Issue #1840: a termination-time catch-up row (is_subagent=1) may
+                  -- carry no resolved model (its _last_turn_model_by_session fallback
+                  -- is normally already cleared by the real turn that just completed).
+                  -- COALESCE so that row can never regress a session's known model to
+                  -- NULL — only a real, non-NULL model label ever overwrites it.
+                  model                 = COALESCE(excluded.model, session_usage.model),
+                  turn_count            = excluded.turn_count,
+                  input_tokens          = excluded.input_tokens,
+                  output_tokens         = excluded.output_tokens,
+                  cache_write_tokens    = excluded.cache_write_tokens,
+                  cache_read_tokens     = excluded.cache_read_tokens,
+                  cache_write_tokens_5m = excluded.cache_write_tokens_5m,
+                  cache_write_tokens_1h = excluded.cache_write_tokens_1h,
+                  sdk_total_cost_usd    = excluded.sdk_total_cost_usd,
+                  last_updated          = excluded.last_updated
                 """,
                 (session_id, model, now, session_id),
             )
@@ -123,6 +146,7 @@ class AnalyticsStore:
             SELECT session_id, model, turn_count,
                    input_tokens, output_tokens,
                    cache_write_tokens, cache_read_tokens,
+                   cache_write_tokens_5m, cache_write_tokens_1h,
                    sdk_total_cost_usd, last_updated
             FROM session_usage WHERE session_id = ?
             """,
@@ -131,9 +155,18 @@ class AnalyticsStore:
         return rows[0] if rows else None
 
     async def get_turn_count(self, session_id: str) -> int:
-        """Return current turn count (used to seed turn_seq on restart)."""
+        """Return the next turn_seq to allocate for a session, used to reseed
+        `SessionCoordinator._turn_seq_by_session` after a restart.
+
+        Issue #1840: this must count ALL turn_usage rows including is_subagent=1
+        catch-up rows — turn_seq allocation has to stay collision-free against
+        every row ever written for this session (UNIQUE(session_id, turn_seq)),
+        not just the "real turns" subset that session_usage.turn_count displays.
+        Deliberately queries turn_usage directly rather than the aggregate
+        session_usage.turn_count column, which excludes those catch-up rows.
+        """
         val = await self._db.execute_scalar(
-            "SELECT turn_count FROM session_usage WHERE session_id = ?",
+            "SELECT COUNT(*) FROM turn_usage WHERE session_id = ?",
             (session_id,),
         )
         return int(val) if val is not None else 0

--- a/backend/message_parser.py
+++ b/backend/message_parser.py
@@ -673,6 +673,12 @@ class AssistantMessageHandler(MessageHandler):
         if parent_tool_use_id:
             extracted["metadata"]["parent_tool_use_id"] = parent_tool_use_id
 
+        # Issue #1840: extract per-message usage (needed for subagent usage accumulation;
+        # top-level assistant messages carry it too but it's not consumed by that path)
+        usage = message_data.get("usage") or getattr(message_data.get("sdk_message"), "usage", None)
+        if usage:
+            extracted["metadata"]["usage"] = dict(usage)
+
         return extracted
 
 

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -119,6 +119,8 @@ def build_router(webui) -> APIRouter:
             "output_tokens": aggregate.get("output_tokens", 0),
             "cache_write_tokens": aggregate.get("cache_write_tokens", 0),
             "cache_read_tokens": aggregate.get("cache_read_tokens", 0),
+            "cache_write_tokens_5m": aggregate.get("cache_write_tokens_5m", 0),
+            "cache_write_tokens_1h": aggregate.get("cache_write_tokens_1h", 0),
             "sdk_reported_cost_usd": aggregate.get("sdk_total_cost_usd"),
             "rates_known": rates_known,
         }

--- a/backend/session_coordinator.py
+++ b/backend/session_coordinator.py
@@ -261,6 +261,36 @@ def _delta_from_baseline(
     return delta, delta_cost, baseline
 
 
+def _accumulate_subagent_usage(
+    accum: dict[str, float] | None,
+    usage: dict,
+) -> dict[str, float]:
+    """Sum one subagent AssistantMessage's usage into a running per-session accumulator.
+
+    Unlike the main thread's cumulative-since-subprocess-start snapshots (see
+    `_delta_from_baseline`), each subagent `AssistantMessage.usage` is already a
+    per-call delta for that individual API call — it must be summed directly,
+    never baseline-diffed (diffing would silently zero out everything after the
+    first call, since there's no shared cumulative counter to diff against).
+    """
+    accum = dict(accum or {})
+    cache_creation = usage.get("cache_creation") or {}
+    cache_5m = int(cache_creation.get("ephemeral_5m_input_tokens") or 0)
+    cache_1h = int(cache_creation.get("ephemeral_1h_input_tokens") or 0)
+    accum["input_tokens"] = accum.get("input_tokens", 0) + int(usage.get("input_tokens") or 0)
+    accum["output_tokens"] = accum.get("output_tokens", 0) + int(usage.get("output_tokens") or 0)
+    accum["cache_read_input_tokens"] = accum.get("cache_read_input_tokens", 0) + int(
+        usage.get("cache_read_input_tokens") or 0
+    )
+    accum["cache_write_tokens_5m"] = accum.get("cache_write_tokens_5m", 0) + cache_5m
+    accum["cache_write_tokens_1h"] = accum.get("cache_write_tokens_1h", 0) + cache_1h
+    # Flat total, kept in sync with the two TTL tiers above so callers never need
+    # to re-derive it — AnalyticsStore.record_turn()/compute_cost() key off of this
+    # flat name (or "cache_creation_input_tokens"), not the TTL-tier split.
+    accum["cache_write_tokens"] = accum.get("cache_write_tokens", 0) + cache_5m + cache_1h
+    return accum
+
+
 def _tail_read_lines(path: "Path", limit: int) -> list[str]:
     """Read the last `limit` lines from a file efficiently using a deque."""
     from collections import deque
@@ -554,6 +584,14 @@ class SessionCoordinator:
         # synthetic/error result) correctly yields no fallback instead of a stale
         # value from a previous turn.
         self._last_turn_model_by_session: dict[str, str] = {}
+        # Issue #1840: running sum of subagent (Task/Agent tool) usage for the
+        # in-flight turn, keyed by session. Each subagent AssistantMessage's usage
+        # is a per-call delta (unlike the main thread's cumulative snapshots), so
+        # it's summed directly rather than run through _delta_from_baseline().
+        # Popped and merged into the turn's usage_delta on 'result', or flushed as
+        # a catch-up row on session termination if a run_in_background subagent
+        # outlives its originating turn.
+        self._subagent_usage_by_session: dict[str, dict[str, float]] = {}
         # Callback for broadcasting usage_updated events (injected by web_server)
         self._usage_broadcast_callback: Callable[[str, dict], None] | None = None
 
@@ -2045,6 +2083,19 @@ class SessionCoordinator:
 
             return False
 
+    async def _next_turn_seq(self, session_id: str) -> int:
+        """Return the next turn_seq for `session_id`, lazily seeding from the DB's
+        turn_count on first use after a restart (`_turn_seq_by_session` is in-memory
+        only). Shared by the normal per-turn recording path and the #1840
+        termination-time subagent-usage catch-up flush, which both need a unique
+        turn_seq from the same counter.
+        """
+        if session_id not in self._turn_seq_by_session:
+            db_count = await self.analytics_store.get_turn_count(session_id)
+            self._turn_seq_by_session[session_id] = db_count
+        self._turn_seq_by_session[session_id] += 1
+        return self._turn_seq_by_session[session_id]
+
     async def terminate_session(self, session_id: str) -> bool:
         """Terminate a session and cleanup resources"""
         try:
@@ -2080,6 +2131,31 @@ class SessionCoordinator:
             if self.litellm_proxy_manager is not None:
                 self.litellm_proxy_manager.unregister_session_key(session_id)
                 self.litellm_proxy_manager.unregister_session_routing(session_id)
+
+            # Issue #1840: flush any unflushed subagent (Task/Agent tool) usage —
+            # e.g. a run_in_background subagent still emitting usage after its
+            # originating turn's ResultMessage already fired and popped the
+            # accumulator. Termination is the last chance to persist it: no further
+            # 'result' message will ever arrive for this session to trigger the
+            # normal merge. (delete_session() doesn't need this — it wipes all
+            # analytics rows for the session immediately after, so persisting here
+            # first would accomplish nothing.)
+            _sub_accum = self._subagent_usage_by_session.pop(session_id, None)
+            if _sub_accum and self.analytics_store:
+                try:
+                    turn_seq = await self._next_turn_seq(session_id)
+                    _model = self._last_turn_model_by_session.pop(session_id, None)
+                    _flushed = await self.analytics_store.record_turn(
+                        session_id, turn_seq, _model, _sub_accum, None, is_subagent=True
+                    )
+                    if not _flushed:
+                        # Don't lose it — restore so a future flush/merge can retry.
+                        self._subagent_usage_by_session[session_id] = _sub_accum
+                except Exception:
+                    logger.exception(
+                        f"Failed to flush subagent usage on termination for session {session_id}"
+                    )
+                    self._subagent_usage_by_session[session_id] = _sub_accum
 
             # Terminate session through manager
             success = await self.session_manager.terminate_session(session_id)
@@ -2452,6 +2528,11 @@ class SessionCoordinator:
                 coord_logger.info(f"Session {session_id} deleted")
                 # Issue #1831: Clear any in-flight-turn model tracked for this session
                 self._last_turn_model_by_session.pop(session_id, None)
+                # Issue #1840: drop any unflushed subagent usage without persisting it —
+                # delete_session() wipes all analytics rows for this session a few lines
+                # below, so writing a catch-up row first would accomplish nothing. This
+                # purely avoids a stale in-memory dict entry outliving the session.
+                self._subagent_usage_by_session.pop(session_id, None)
                 # Issue #1125: Remove analytics rows for deleted session
                 if self.analytics_store:
                     try:
@@ -4983,12 +5064,7 @@ class SessionCoordinator:
                                 _model = self._last_turn_model_by_session.pop(session_id, None)
                             else:
                                 self._last_turn_model_by_session.pop(session_id, None)
-                            # Lazily initialise turn_seq from DB on first use after restart
-                            if session_id not in self._turn_seq_by_session:
-                                db_count = await self.analytics_store.get_turn_count(session_id)
-                                self._turn_seq_by_session[session_id] = db_count
-                            self._turn_seq_by_session[session_id] += 1
-                            turn_seq = self._turn_seq_by_session[session_id]
+                            turn_seq = await self._next_turn_seq(session_id)
                             # Issue #1838: usage/total_cost_usd are cumulative snapshots
                             # since subprocess start, not per-turn values — convert to
                             # true per-turn deltas before recording.
@@ -4996,11 +5072,45 @@ class SessionCoordinator:
                             usage_delta, cost_delta, new_baseline = _delta_from_baseline(
                                 usage, sdk_cost, baseline
                             )
+                            # Issue #1840: fold in any subagent (Task/Agent tool) usage
+                            # accumulated during this turn — structurally disjoint from
+                            # the top-level ResultMessage's own usage above, so this is
+                            # pure addition, never double-counted against it.
+                            _sub_accum = self._subagent_usage_by_session.pop(session_id, None)
+                            if _sub_accum:
+                                for _k, _v in _sub_accum.items():
+                                    usage_delta[_k] = usage_delta.get(_k, 0) + _v
+                                # The subagent's flat cache-write total must also fold
+                                # into the pre-existing cache_creation_input_tokens field
+                                # that record_turn()/compute_cost() key off of first —
+                                # otherwise, whenever the main thread's own turn already
+                                # has a non-zero cache_creation_input_tokens, record_turn's
+                                # `usage.get("cache_creation_input_tokens") or usage.get
+                                # ("cache_write_tokens")` fallback would never reach the
+                                # generic per-key copy above and the subagent's flat total
+                                # would be silently dropped from cost estimation.
+                                _sub_cache_write = _sub_accum.get("cache_write_tokens", 0)
+                                if _sub_cache_write:
+                                    usage_delta["cache_creation_input_tokens"] = (
+                                        usage_delta.get("cache_creation_input_tokens", 0)
+                                        + _sub_cache_write
+                                    )
                             turn_recorded = await self.analytics_store.record_turn(
                                 session_id, turn_seq, _model, usage_delta, cost_delta
                             )
                             if turn_recorded:
                                 self._usage_baseline_by_session[session_id] = new_baseline
+                            elif _sub_accum:
+                                # Don't lose the subagent's contribution on a failed
+                                # write — restore it (merged with anything that may have
+                                # accumulated during the await above) so the next
+                                # successful turn absorbs it instead of dropping it.
+                                _pending = self._subagent_usage_by_session.get(session_id)
+                                if _pending:
+                                    for _k, _v in _sub_accum.items():
+                                        _pending[_k] = _pending.get(_k, 0) + _v
+                                else:
+                                    self._subagent_usage_by_session[session_id] = _sub_accum
                             # else: leave the baseline un-advanced — the next successful
                             # write computes its delta against the stale baseline, so this
                             # turn's un-recorded usage/cost is naturally absorbed into that
@@ -5035,6 +5145,14 @@ class SessionCoordinator:
                     _msg_model = _msg_meta.get('model')
                     if _msg_model and not _msg_meta.get('parent_tool_use_id'):
                         self._last_turn_model_by_session[session_id] = _msg_model
+                    elif _msg_meta.get('parent_tool_use_id'):
+                        # Issue #1840: subagent (Task/Agent tool) message — accumulate its
+                        # usage instead of using it as a top-level model fallback.
+                        _sub_usage = _msg_meta.get('usage')
+                        if _sub_usage:
+                            self._subagent_usage_by_session[session_id] = _accumulate_subagent_usage(
+                                self._subagent_usage_by_session.get(session_id), _sub_usage
+                            )
 
                 # Reset processing state on interrupt_success
                 elif parsed_message.type.value == 'system' and parsed_message.metadata.get('subtype') == 'interrupt_success':

--- a/backend/tests/test_analytics_store.py
+++ b/backend/tests/test_analytics_store.py
@@ -158,3 +158,174 @@ async def test_record_turn_returns_false_on_write_failure(store, monkeypatch):
     # No row should have been recorded.
     agg = await store.get_session_usage("sid-9")
     assert agg is None
+
+
+# ---------------------------------------------------------------------------
+# Issue #1840: subagent usage TTL-tier columns + is_subagent flag
+# ---------------------------------------------------------------------------
+
+
+async def test_cache_write_tokens_ttl_tiers_are_persisted(store):
+    usage = {
+        "input_tokens": 10,
+        "output_tokens": 5,
+        "cache_write_tokens_5m": 20,
+        "cache_write_tokens_1h": 7,
+    }
+    await store.record_turn("sid-10", 1, "claude-sonnet-4-6", usage, None)
+
+    agg = await store.get_session_usage("sid-10")
+    assert agg["cache_write_tokens_5m"] == 20
+    assert agg["cache_write_tokens_1h"] == 7
+
+
+async def test_ttl_tiers_default_to_zero_when_absent(store):
+    """AC4: a turn with no subagent contribution must not introduce non-zero
+    TTL-tier values."""
+    await store.record_turn("sid-11", 1, None, {"input_tokens": 10}, None)
+
+    agg = await store.get_session_usage("sid-11")
+    assert agg["cache_write_tokens_5m"] == 0
+    assert agg["cache_write_tokens_1h"] == 0
+
+
+async def test_ttl_tiers_aggregate_across_multiple_turns(store):
+    usage1 = {"cache_write_tokens_5m": 10, "cache_write_tokens_1h": 1}
+    usage2 = {"cache_write_tokens_5m": 5, "cache_write_tokens_1h": 2}
+    await store.record_turn("sid-12", 1, None, usage1, None)
+    await store.record_turn("sid-12", 2, None, usage2, None)
+
+    agg = await store.get_session_usage("sid-12")
+    assert agg["cache_write_tokens_5m"] == 15
+    assert agg["cache_write_tokens_1h"] == 3
+
+
+async def test_is_subagent_catch_up_row_is_recorded(store):
+    usage = {"input_tokens": 3, "cache_write_tokens_5m": 1}
+    result = await store.record_turn(
+        "sid-13", 1, None, usage, None, is_subagent=True
+    )
+    assert result is True
+
+    rows = await store._db.execute_read(
+        "SELECT is_subagent FROM turn_usage WHERE session_id = ?", ("sid-13",)
+    )
+    assert rows[0]["is_subagent"] == 1
+
+
+async def test_is_subagent_defaults_to_false(store):
+    await store.record_turn("sid-14", 1, None, {"input_tokens": 1}, None)
+
+    rows = await store._db.execute_read(
+        "SELECT is_subagent FROM turn_usage WHERE session_id = ?", ("sid-14",)
+    )
+    assert rows[0]["is_subagent"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Issue #1840: migration of a pre-existing DB file with the old schema
+# ---------------------------------------------------------------------------
+
+
+async def test_migration_adds_missing_columns_to_existing_db(tmp_path):
+    """A DB file created before #1840 (no cache_write_tokens_5m/1h/is_subagent
+    columns) must be upgraded in place on initialize(), without raising and
+    without losing existing rows."""
+    import sqlite3
+
+    from backend.analytics.database import AnalyticsDB
+
+    db_path = tmp_path / "legacy_analytics.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(
+        """
+        CREATE TABLE turn_usage (
+          id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+          session_id          TEXT    NOT NULL,
+          turn_seq            INTEGER NOT NULL,
+          model               TEXT,
+          input_tokens        INTEGER NOT NULL DEFAULT 0,
+          output_tokens       INTEGER NOT NULL DEFAULT 0,
+          cache_write_tokens  INTEGER NOT NULL DEFAULT 0,
+          cache_read_tokens   INTEGER NOT NULL DEFAULT 0,
+          sdk_total_cost_usd  REAL,
+          ts                  REAL    NOT NULL,
+          UNIQUE(session_id, turn_seq)
+        );
+        CREATE TABLE session_usage (
+          session_id          TEXT PRIMARY KEY,
+          model               TEXT,
+          turn_count          INTEGER NOT NULL DEFAULT 0,
+          input_tokens        INTEGER NOT NULL DEFAULT 0,
+          output_tokens       INTEGER NOT NULL DEFAULT 0,
+          cache_write_tokens  INTEGER NOT NULL DEFAULT 0,
+          cache_read_tokens   INTEGER NOT NULL DEFAULT 0,
+          sdk_total_cost_usd  REAL,
+          last_updated        REAL    NOT NULL
+        );
+        """
+    )
+    conn.execute(
+        "INSERT INTO turn_usage (session_id, turn_seq, input_tokens, ts) VALUES (?, ?, ?, ?)",
+        ("legacy-sid", 1, 42, 0.0),
+    )
+    conn.execute(
+        "INSERT INTO session_usage (session_id, input_tokens, last_updated) VALUES (?, ?, ?)",
+        ("legacy-sid", 42, 0.0),
+    )
+    conn.commit()
+    conn.close()
+
+    db = AnalyticsDB(db_path)
+    await db.initialize()
+    try:
+        store = AnalyticsStore(db)
+        agg = await store.get_session_usage("legacy-sid")
+        assert agg is not None
+        assert agg["input_tokens"] == 42, "pre-existing row must survive the migration"
+        assert agg["cache_write_tokens_5m"] == 0
+        assert agg["cache_write_tokens_1h"] == 0
+
+        # New writes against the upgraded schema must work normally.
+        await store.record_turn(
+            "legacy-sid", 2, None, {"cache_write_tokens_5m": 9}, None
+        )
+        agg2 = await store.get_session_usage("legacy-sid")
+        assert agg2["cache_write_tokens_5m"] == 9
+    finally:
+        await db.close()
+
+
+async def test_get_turn_count_includes_subagent_catch_up_rows_for_turn_seq_reseed(store):
+    """Regression: get_turn_count() feeds SessionCoordinator's turn_seq reseed
+    after a restart and must count is_subagent=1 catch-up rows too, even though
+    they're excluded from the displayed session_usage.turn_count — otherwise a
+    reseeded turn_seq would collide with a turn_seq already used by a catch-up
+    row (INSERT OR IGNORE would then silently drop that turn's real usage)."""
+    await store.record_turn("sid-15", 1, "claude-sonnet-4-6", {"input_tokens": 1}, None)
+    await store.record_turn("sid-15", 2, "claude-sonnet-4-6", {"input_tokens": 1}, None)
+    await store.record_turn(
+        "sid-15", 3, None, {"input_tokens": 1}, None, is_subagent=True
+    )
+
+    agg = await store.get_session_usage("sid-15")
+    assert agg["turn_count"] == 2  # display value excludes the catch-up row
+
+    next_seq_source = await store.get_turn_count("sid-15")
+    assert next_seq_source == 3, "must count all 3 rows so the next turn_seq is 4, not 3"
+
+
+async def test_migration_is_idempotent_across_multiple_initialize_calls(tmp_path):
+    """Re-running the migration on an already-upgraded DB (e.g. process restart)
+    must not raise 'duplicate column' errors."""
+    from backend.analytics.database import AnalyticsDB
+
+    db_path = tmp_path / "analytics.db"
+    db = AnalyticsDB(db_path)
+    await db.initialize()
+    await db.close()
+
+    # Second initialize() against the same file, simulating a restart.
+    db2 = AnalyticsDB(db_path)
+    await db2.initialize()
+    await db2.close()

--- a/backend/tests/test_issue_1840_subagent_usage.py
+++ b/backend/tests/test_issue_1840_subagent_usage.py
@@ -1,0 +1,513 @@
+"""
+Tests for issue #1840: capture subagent (Agent/Task tool) token usage in analytics.
+
+Subagent `AssistantMessage`s carry `parent_tool_use_id` and their own per-call
+`usage`. Before this fix, `AssistantMessageHandler` never extracted `usage` at
+all, so every subagent call's tokens were silently dropped from analytics.
+
+These tests drive `coordinator._create_message_callback(session_id)` end-to-end,
+following the `TestIssue1831...` precedent in test_issue_1831_analytics_model_fallback.py.
+"""
+
+import tempfile
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from backend.analytics.database import AnalyticsDB
+from backend.analytics_store import AnalyticsStore
+from backend.session_config import SessionConfig
+from backend.session_coordinator import SessionCoordinator, _accumulate_subagent_usage
+
+
+@pytest.fixture
+async def temp_coordinator():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        coordinator = SessionCoordinator(Path(temp_dir))
+        await coordinator.initialize()
+        yield coordinator
+        await coordinator.cleanup()
+
+
+async def _make_session(coordinator, config: SessionConfig) -> str:
+    """Create a session (with a backing project) and return its session_id."""
+    project = await coordinator.project_manager.create_project(
+        name="Test Project", working_directory="/test/project"
+    )
+    session_id = str(uuid.uuid4())
+    await coordinator.create_session(
+        session_id=session_id, project_id=project.project_id, config=config
+    )
+    return session_id
+
+
+def _mock_analytics(coordinator):
+    coordinator.analytics_store = AsyncMock()
+    coordinator.analytics_store.get_turn_count.return_value = 0
+    coordinator.analytics_store.get_session_usage.return_value = None
+    coordinator.analytics_store.record_turn = AsyncMock(return_value=True)
+    return coordinator.analytics_store
+
+
+def _subagent_usage(input_tokens, output_tokens, cache_5m=0, cache_1h=0):
+    return {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "cache_read_input_tokens": 0,
+        "cache_creation": {
+            "ephemeral_5m_input_tokens": cache_5m,
+            "ephemeral_1h_input_tokens": cache_1h,
+        },
+    }
+
+
+class TestIssue1840SubagentUsageCapture:
+    @pytest.mark.asyncio
+    async def test_t1_single_subagent_call_merged_into_turn(self, temp_coordinator):
+        """AC1/AC2: one subagent AssistantMessage's usage is added to the turn's
+        recorded totals, including the TTL-tier breakdown."""
+        coordinator = temp_coordinator
+        session_id = await _make_session(coordinator, SessionConfig())
+        analytics_store = _mock_analytics(coordinator)
+
+        message_callback = coordinator._create_message_callback(session_id)
+
+        await message_callback({
+            "type": "assistant",
+            "model": "claude-sonnet-4-6",
+            "session_id": session_id,
+        })
+        await message_callback({
+            "type": "assistant",
+            "model": "claude-haiku-4-5",
+            "parent_tool_use_id": "toolu_subagent_1",
+            "usage": _subagent_usage(100, 20, cache_5m=15, cache_1h=3),
+            "session_id": session_id,
+        })
+        await message_callback({
+            "type": "result",
+            "session_id": session_id,
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+            "total_cost_usd": 1.0,
+        })
+
+        analytics_store.record_turn.assert_awaited_once()
+        call_args = analytics_store.record_turn.call_args.args
+        usage_delta = call_args[3]
+        assert usage_delta["input_tokens"] == 10 + 100
+        assert usage_delta["output_tokens"] == 5 + 20
+        assert usage_delta["cache_write_tokens_5m"] == 15
+        assert usage_delta["cache_write_tokens_1h"] == 3
+
+    @pytest.mark.asyncio
+    async def test_t3_no_double_counting_against_top_level_result(self, temp_coordinator):
+        """AC3: the top-level ResultMessage's own usage and the subagent's usage
+        are structurally disjoint inputs merged by addition, never derived from
+        each other."""
+        coordinator = temp_coordinator
+        session_id = await _make_session(coordinator, SessionConfig())
+        analytics_store = _mock_analytics(coordinator)
+
+        message_callback = coordinator._create_message_callback(session_id)
+
+        await message_callback({
+            "type": "assistant",
+            "parent_tool_use_id": "toolu_subagent_1",
+            "usage": _subagent_usage(50, 10),
+            "session_id": session_id,
+        })
+        await message_callback({
+            "type": "result",
+            "session_id": session_id,
+            "usage": {"input_tokens": 200, "output_tokens": 80},
+            "total_cost_usd": 2.0,
+        })
+
+        usage_delta = analytics_store.record_turn.call_args.args[3]
+        # Both contributions present, neither overwritten by the other.
+        assert usage_delta["input_tokens"] == 250
+        assert usage_delta["output_tokens"] == 90
+
+    @pytest.mark.asyncio
+    async def test_multiple_subagent_calls_sum_not_diff(self, temp_coordinator):
+        """Simulates the issue's real scenario (many subagent calls in one turn) —
+        each call's usage is a per-call delta and must be summed, not baselined."""
+        coordinator = temp_coordinator
+        session_id = await _make_session(coordinator, SessionConfig())
+        analytics_store = _mock_analytics(coordinator)
+
+        message_callback = coordinator._create_message_callback(session_id)
+
+        for _ in range(5):
+            await message_callback({
+                "type": "assistant",
+                "parent_tool_use_id": "toolu_subagent_1",
+                "usage": _subagent_usage(10, 2, cache_5m=1),
+                "session_id": session_id,
+            })
+        await message_callback({
+            "type": "result",
+            "session_id": session_id,
+            "usage": {"input_tokens": 0, "output_tokens": 0},
+            "total_cost_usd": 0.1,
+        })
+
+        usage_delta = analytics_store.record_turn.call_args.args[3]
+        assert usage_delta["input_tokens"] == 50
+        assert usage_delta["output_tokens"] == 10
+        assert usage_delta["cache_write_tokens_5m"] == 5
+
+    @pytest.mark.asyncio
+    async def test_ac4_session_without_subagents_unaffected(self, temp_coordinator):
+        """AC4: a turn with no subagent messages must be byte-identical to
+        pre-#1840 behaviour."""
+        coordinator = temp_coordinator
+        session_id = await _make_session(coordinator, SessionConfig())
+        analytics_store = _mock_analytics(coordinator)
+
+        message_callback = coordinator._create_message_callback(session_id)
+
+        await message_callback({
+            "type": "assistant",
+            "model": "claude-sonnet-4-6",
+            "session_id": session_id,
+        })
+        await message_callback({
+            "type": "result",
+            "session_id": session_id,
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+            "total_cost_usd": 1.0,
+        })
+
+        usage_delta = analytics_store.record_turn.call_args.args[3]
+        assert usage_delta == {
+            "input_tokens": 10.0,
+            "output_tokens": 5.0,
+            "cache_creation_input_tokens": 0.0,
+            "cache_read_input_tokens": 0.0,
+        }
+        assert session_id not in coordinator._subagent_usage_by_session
+
+    @pytest.mark.asyncio
+    async def test_subagent_cache_write_folds_into_flat_total_for_cost_estimation(
+        self, temp_coordinator
+    ):
+        """Regression: the subagent's TTL-tier cache-write usage must also fold into
+        the pre-existing flat cache_creation_input_tokens field that
+        record_turn()/compute_cost() key off of — otherwise cost estimation and the
+        plain cache_write_tokens total would silently undercount whenever a turn
+        used subagents, even though the dedicated TTL columns look correct."""
+        coordinator = temp_coordinator
+        session_id = await _make_session(coordinator, SessionConfig())
+        analytics_store = _mock_analytics(coordinator)
+
+        message_callback = coordinator._create_message_callback(session_id)
+
+        await message_callback({
+            "type": "assistant",
+            "parent_tool_use_id": "toolu_subagent_1",
+            "usage": _subagent_usage(1, 1, cache_5m=15, cache_1h=3),
+            "session_id": session_id,
+        })
+        await message_callback({
+            "type": "result",
+            "session_id": session_id,
+            "usage": {"input_tokens": 0, "output_tokens": 0},
+            "total_cost_usd": 0.0,
+        })
+
+        usage_delta = analytics_store.record_turn.call_args.args[3]
+        assert usage_delta["cache_write_tokens_5m"] == 15
+        assert usage_delta["cache_write_tokens_1h"] == 3
+        assert usage_delta["cache_creation_input_tokens"] == 18
+
+    @pytest.mark.asyncio
+    async def test_subagent_cache_write_adds_to_nonzero_main_thread_value(
+        self, temp_coordinator
+    ):
+        """The fold-in must add to the main thread's own cache_creation_input_tokens,
+        not overwrite it — both contributions are real and distinct."""
+        coordinator = temp_coordinator
+        session_id = await _make_session(coordinator, SessionConfig())
+        analytics_store = _mock_analytics(coordinator)
+
+        message_callback = coordinator._create_message_callback(session_id)
+
+        await message_callback({
+            "type": "assistant",
+            "parent_tool_use_id": "toolu_subagent_1",
+            "usage": _subagent_usage(1, 1, cache_5m=10, cache_1h=0),
+            "session_id": session_id,
+        })
+        await message_callback({
+            "type": "result",
+            "session_id": session_id,
+            "usage": {"input_tokens": 0, "output_tokens": 0, "cache_creation_input_tokens": 100},
+            "total_cost_usd": 0.0,
+        })
+
+        usage_delta = analytics_store.record_turn.call_args.args[3]
+        assert usage_delta["cache_creation_input_tokens"] == 110
+
+    @pytest.mark.asyncio
+    async def test_subagent_message_does_not_clobber_model_fallback(self, temp_coordinator):
+        """Regression guard: #1840's new elif branch must not break #1831's
+        existing model-fallback skip guard for subagent messages."""
+        coordinator = temp_coordinator
+        session_id = await _make_session(coordinator, SessionConfig())
+        analytics_store = _mock_analytics(coordinator)
+
+        message_callback = coordinator._create_message_callback(session_id)
+
+        await message_callback({
+            "type": "assistant",
+            "model": "claude-sonnet-4-6",
+            "session_id": session_id,
+        })
+        await message_callback({
+            "type": "assistant",
+            "model": "claude-haiku-4-5",
+            "parent_tool_use_id": "toolu_subagent_1",
+            "usage": _subagent_usage(1, 1),
+            "session_id": session_id,
+        })
+        await message_callback({
+            "type": "result",
+            "session_id": session_id,
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+            "total_cost_usd": 1.0,
+        })
+
+        model_arg = analytics_store.record_turn.call_args.args[2]
+        assert model_arg == "claude-sonnet-4-6"
+
+
+class TestIssue1840TerminationAndDeletionLifecycle:
+    @pytest.mark.asyncio
+    async def test_termination_flushes_leftover_subagent_usage(self, temp_coordinator):
+        """§2c.2: a run_in_background subagent whose usage arrives after the
+        session's last 'result' must be flushed as a catch-up row on
+        terminate_session(), not silently discarded."""
+        coordinator = temp_coordinator
+        session_id = await _make_session(coordinator, SessionConfig())
+        coordinator.legion_system = None  # skip schedule/legion cleanup, unrelated here
+        analytics_store = _mock_analytics(coordinator)
+
+        # Simulate a still-running background subagent's leftover usage, built via
+        # the real accumulator helper (production code never hand-rolls this dict).
+        coordinator._subagent_usage_by_session[session_id] = _accumulate_subagent_usage(
+            None,
+            {
+                "input_tokens": 42,
+                "cache_creation": {"ephemeral_5m_input_tokens": 3, "ephemeral_1h_input_tokens": 0},
+            },
+        )
+
+        result = await coordinator.terminate_session(session_id)
+
+        assert result is True
+        analytics_store.record_turn.assert_awaited_once()
+        call = analytics_store.record_turn.call_args
+        assert call.args[0] == session_id
+        assert call.args[3] == {
+            "input_tokens": 42,
+            "output_tokens": 0,
+            "cache_read_input_tokens": 0,
+            "cache_write_tokens_5m": 3,
+            "cache_write_tokens_1h": 0,
+            "cache_write_tokens": 3,
+        }
+        assert call.kwargs.get("is_subagent") is True
+        assert session_id not in coordinator._subagent_usage_by_session
+
+    @pytest.mark.asyncio
+    async def test_termination_without_leftover_usage_does_not_write_extra_row(
+        self, temp_coordinator
+    ):
+        coordinator = temp_coordinator
+        session_id = await _make_session(coordinator, SessionConfig())
+        coordinator.legion_system = None
+        analytics_store = _mock_analytics(coordinator)
+
+        result = await coordinator.terminate_session(session_id)
+
+        assert result is True
+        analytics_store.record_turn.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_deletion_drops_leftover_usage_without_persisting(self, temp_coordinator):
+        """§2c.2: delete_session() wipes all analytics rows immediately after, so
+        it must drop any leftover accumulator without writing a catch-up row —
+        persisting first would accomplish nothing."""
+        coordinator = temp_coordinator
+        session_id = await _make_session(coordinator, SessionConfig())
+        coordinator.legion_system = None
+        analytics_store = _mock_analytics(coordinator)
+
+        coordinator._subagent_usage_by_session[session_id] = {"input_tokens": 99}
+
+        result = await coordinator.delete_session(session_id)
+
+        assert result["success"] is True
+        analytics_store.record_turn.assert_not_awaited()
+        assert session_id not in coordinator._subagent_usage_by_session
+
+
+class TestIssue1840UsageEndpointExposesTtlTiers:
+    """Regression: GET /api/sessions/{id}/usage explicitly reshapes the aggregate
+    dict field-by-field rather than passing it through verbatim — the new TTL-tier
+    columns must be added to that reshaping or they silently never reach the API."""
+
+    @pytest.fixture
+    async def app_and_db(self, tmp_path):
+        from fastapi import FastAPI
+
+        from backend.routers.sessions import build_router
+
+        db = AnalyticsDB(tmp_path / "analytics.db")
+        await db.initialize()
+        store = AnalyticsStore(db)
+
+        webui = MagicMock()
+        webui.coordinator.analytics_store = store
+        webui.config_file = tmp_path / "nonexistent_config.json"
+
+        app = FastAPI()
+        app.include_router(build_router(webui))
+
+        yield app, store
+        await db.close()
+
+    @pytest.mark.asyncio
+    async def test_usage_endpoint_returns_ttl_tier_fields(self, app_and_db):
+        from httpx import ASGITransport, AsyncClient
+
+        app, store = app_and_db
+        await store.record_turn(
+            "sid-endpoint-1", 1, "claude-sonnet-4-6",
+            {"input_tokens": 10, "cache_write_tokens_5m": 20, "cache_write_tokens_1h": 5},
+            None,
+        )
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/api/sessions/sid-endpoint-1/usage")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["cache_write_tokens_5m"] == 20
+        assert body["cache_write_tokens_1h"] == 5
+
+
+class TestIssue1840RecordTurnFailureSafetyNet:
+    """Regression: a failed record_turn() write must not silently drop the
+    subagent's contribution — the accumulator must be restored so a later turn
+    or flush can retry, mirroring how _usage_baseline_by_session is left
+    un-advanced on failure."""
+
+    @pytest.mark.asyncio
+    async def test_result_branch_restores_accumulator_on_write_failure(
+        self, temp_coordinator
+    ):
+        coordinator = temp_coordinator
+        session_id = await _make_session(coordinator, SessionConfig())
+        analytics_store = _mock_analytics(coordinator)
+        analytics_store.record_turn = AsyncMock(return_value=False)
+
+        message_callback = coordinator._create_message_callback(session_id)
+
+        await message_callback({
+            "type": "assistant",
+            "parent_tool_use_id": "toolu_subagent_1",
+            "usage": _subagent_usage(10, 5, cache_5m=2),
+            "session_id": session_id,
+        })
+        await message_callback({
+            "type": "result",
+            "session_id": session_id,
+            "usage": {"input_tokens": 1, "output_tokens": 1},
+            "total_cost_usd": 0.0,
+        })
+
+        restored = coordinator._subagent_usage_by_session.get(session_id)
+        assert restored is not None
+        assert restored["input_tokens"] == 10
+        assert restored["cache_write_tokens_5m"] == 2
+
+    @pytest.mark.asyncio
+    async def test_termination_flush_restores_accumulator_on_write_failure(
+        self, temp_coordinator
+    ):
+        coordinator = temp_coordinator
+        session_id = await _make_session(coordinator, SessionConfig())
+        coordinator.legion_system = None
+        analytics_store = _mock_analytics(coordinator)
+        analytics_store.record_turn = AsyncMock(return_value=False)
+
+        expected = _accumulate_subagent_usage(None, {"input_tokens": 7})
+        coordinator._subagent_usage_by_session[session_id] = expected
+
+        result = await coordinator.terminate_session(session_id)
+
+        assert result is True
+        assert coordinator._subagent_usage_by_session.get(session_id) == expected
+
+
+class TestIssue1840SessionUsageModelNotClobbered:
+    """Regression: record_turn()'s session_usage UPSERT must not overwrite a
+    session's known model with NULL just because a later row (e.g. a
+    termination-time subagent catch-up flush) doesn't know the model."""
+
+    @pytest.fixture
+    async def store(self, tmp_path):
+        db = AnalyticsDB(tmp_path / "analytics.db")
+        await db.initialize()
+        s = AnalyticsStore(db)
+        yield s
+        await db.close()
+
+    @pytest.mark.asyncio
+    async def test_null_model_turn_does_not_clobber_known_model(self, store):
+        await store.record_turn("sid-model-1", 1, "claude-sonnet-4-6", {"input_tokens": 1}, None)
+        await store.record_turn(
+            "sid-model-1", 2, None, {"input_tokens": 1}, None, is_subagent=True
+        )
+
+        agg = await store.get_session_usage("sid-model-1")
+        assert agg["model"] == "claude-sonnet-4-6"
+
+    @pytest.mark.asyncio
+    async def test_non_null_model_turn_still_updates_model(self, store):
+        await store.record_turn("sid-model-2", 1, "claude-sonnet-4-6", {"input_tokens": 1}, None)
+        await store.record_turn("sid-model-2", 2, "claude-haiku-4-5", {"input_tokens": 1}, None)
+
+        agg = await store.get_session_usage("sid-model-2")
+        assert agg["model"] == "claude-haiku-4-5"
+
+
+class TestIssue1840TurnCountExcludesSubagentCatchUpRows:
+    """Regression: turn_count must reflect real conversation turns, not be
+    inflated by termination-time subagent catch-up rows (is_subagent=1)."""
+
+    @pytest.fixture
+    async def store(self, tmp_path):
+        db = AnalyticsDB(tmp_path / "analytics.db")
+        await db.initialize()
+        s = AnalyticsStore(db)
+        yield s
+        await db.close()
+
+    @pytest.mark.asyncio
+    async def test_subagent_catch_up_row_not_counted_as_a_turn(self, store):
+        await store.record_turn("sid-count-1", 1, "claude-sonnet-4-6", {"input_tokens": 1}, None)
+        await store.record_turn("sid-count-1", 2, "claude-sonnet-4-6", {"input_tokens": 1}, None)
+        await store.record_turn(
+            "sid-count-1", 3, None, {"input_tokens": 1}, None, is_subagent=True
+        )
+
+        agg = await store.get_session_usage("sid-count-1")
+        assert agg["turn_count"] == 2
+        # Token totals still include the catch-up row's contribution.
+        assert agg["input_tokens"] == 3

--- a/backend/tests/test_message_parser.py
+++ b/backend/tests/test_message_parser.py
@@ -1000,3 +1000,94 @@ class TestIssue1486MessageIdPropagation:
         }
         parsed = handler.parse(message_data)
         assert parsed.metadata.get("message_id") == "msg_stored456"
+
+
+class TestIssue1840UsageExtraction:
+    """Regression tests for issue #1840: subagent (Task/Agent tool) usage capture.
+
+    `claude_agent_sdk.claude_sdk._convert_sdk_message()` already copies `usage` off
+    every raw SDK message dict that has it, including subagent AssistantMessages
+    (tagged with `parent_tool_use_id`) — the only gap was that
+    AssistantMessageHandler never extracted it into parsed metadata.
+    """
+
+    def test_usage_extracted_for_top_level_assistant_message(self):
+        handler = AssistantMessageHandler()
+        usage = {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_read_input_tokens": 5,
+            "cache_creation": {
+                "ephemeral_5m_input_tokens": 20,
+                "ephemeral_1h_input_tokens": 0,
+            },
+        }
+        message_data = {
+            "type": "assistant",
+            "model": "claude-sonnet-4-6",
+            "usage": usage,
+            "session_id": "sess-1",
+            "timestamp": time.time(),
+        }
+        parsed = handler.parse(message_data)
+        assert parsed.metadata.get("usage") == usage
+
+    def test_usage_extracted_for_subagent_assistant_message(self):
+        """A parent_tool_use_id-tagged message extracts usage the same way — no
+        subagent-specific parsing path, just the same field the handler already
+        has access to."""
+        handler = AssistantMessageHandler()
+        usage = {
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "cache_read_input_tokens": 0,
+            "cache_creation": {
+                "ephemeral_5m_input_tokens": 3,
+                "ephemeral_1h_input_tokens": 7,
+            },
+        }
+        message_data = {
+            "type": "assistant",
+            "model": "claude-haiku-4-5",
+            "parent_tool_use_id": "toolu_subagent_1",
+            "usage": usage,
+            "session_id": "sess-1",
+            "timestamp": time.time(),
+        }
+        parsed = handler.parse(message_data)
+        assert parsed.metadata.get("parent_tool_use_id") == "toolu_subagent_1"
+        assert parsed.metadata.get("usage") == usage
+        assert parsed.metadata["usage"]["cache_creation"]["ephemeral_1h_input_tokens"] == 7
+
+    def test_usage_extracted_from_sdk_message_object(self):
+        """usage is also read off a real AssistantMessage SDK object, not just the
+        top-level dict copy claude_sdk.py makes."""
+        from claude_agent_sdk import AssistantMessage
+        from claude_agent_sdk.types import TextBlock
+
+        usage = {"input_tokens": 1, "output_tokens": 1}
+        sdk_msg = AssistantMessage(
+            content=[TextBlock(text="hi")],
+            model="claude-sonnet-4-6",
+            usage=usage,
+        )
+        message_data = {
+            "type": "assistant",
+            "sdk_message": sdk_msg,
+            "session_id": "sess-1",
+            "timestamp": time.time(),
+        }
+        handler = AssistantMessageHandler()
+        parsed = handler.parse(message_data)
+        assert parsed.metadata.get("usage") == usage
+
+    def test_usage_absent_when_not_present(self):
+        handler = AssistantMessageHandler()
+        message_data = {
+            "type": "assistant",
+            "model": "claude-sonnet-4-6",
+            "session_id": "sess-1",
+            "timestamp": time.time(),
+        }
+        parsed = handler.parse(message_data)
+        assert "usage" not in parsed.metadata

--- a/backend/tests/test_session_coordinator_usage.py
+++ b/backend/tests/test_session_coordinator_usage.py
@@ -1,5 +1,9 @@
 """Unit tests for usage normalisation against SDK 0.1.72+ (issue #1287)."""
-from backend.session_coordinator import _delta_from_baseline, _normalize_result_usage
+from backend.session_coordinator import (
+    _accumulate_subagent_usage,
+    _delta_from_baseline,
+    _normalize_result_usage,
+)
 
 
 def test_prefers_usage_when_populated():
@@ -196,3 +200,94 @@ def test_none_baseline_treated_as_all_zero():
         "output_tokens": 5.0,
         "total_cost_usd": 1.5,
     }
+
+
+# --- Issue #1840: subagent (Task/Agent tool) usage accumulation ---
+
+
+def test_accumulate_single_subagent_message():
+    usage = {
+        "input_tokens": 100,
+        "output_tokens": 50,
+        "cache_read_input_tokens": 5,
+        "cache_creation": {
+            "ephemeral_5m_input_tokens": 20,
+            "ephemeral_1h_input_tokens": 3,
+        },
+    }
+    accum = _accumulate_subagent_usage(None, usage)
+    assert accum == {
+        "input_tokens": 100,
+        "output_tokens": 50,
+        "cache_read_input_tokens": 5,
+        "cache_write_tokens_5m": 20,
+        "cache_write_tokens_1h": 3,
+        "cache_write_tokens": 23,
+    }
+
+
+def test_accumulate_multiple_subagent_messages_sums_not_diffs():
+    """Each subagent AssistantMessage.usage is a per-call delta, not a cumulative
+    snapshot — repeated calls must sum directly, never be baselined/diffed (which
+    would zero out everything after the first call)."""
+    accum = None
+    for _ in range(3):
+        accum = _accumulate_subagent_usage(
+            accum,
+            {
+                "input_tokens": 10,
+                "output_tokens": 4,
+                "cache_read_input_tokens": 1,
+                "cache_creation": {
+                    "ephemeral_5m_input_tokens": 2,
+                    "ephemeral_1h_input_tokens": 0,
+                },
+            },
+        )
+    assert accum == {
+        "input_tokens": 30,
+        "output_tokens": 12,
+        "cache_read_input_tokens": 3,
+        "cache_write_tokens_5m": 6,
+        "cache_write_tokens_1h": 0,
+        "cache_write_tokens": 6,
+    }
+
+
+def test_accumulate_missing_cache_creation_defaults_to_zero():
+    accum = _accumulate_subagent_usage(None, {"input_tokens": 5, "output_tokens": 2})
+    assert accum["cache_write_tokens_5m"] == 0
+    assert accum["cache_write_tokens_1h"] == 0
+    assert accum["cache_write_tokens"] == 0
+
+
+def test_merge_accumulator_into_usage_delta_adds_not_overwrites():
+    """Mirrors the merge logic in the 'result' branch: subagent contributions must
+    be added on top of the main thread's own usage_delta, not overwrite it."""
+    usage_delta = {"input_tokens": 200.0, "output_tokens": 80.0}
+    sub_accum = _accumulate_subagent_usage(
+        None,
+        {
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "cache_creation": {"ephemeral_5m_input_tokens": 1, "ephemeral_1h_input_tokens": 0},
+        },
+    )
+    for k, v in sub_accum.items():
+        usage_delta[k] = usage_delta.get(k, 0) + v
+
+    assert usage_delta["input_tokens"] == 210.0
+    assert usage_delta["output_tokens"] == 85.0
+    assert usage_delta["cache_write_tokens_5m"] == 1
+
+
+def test_ac4_no_subagent_usage_leaves_usage_delta_unchanged():
+    """AC4: sessions without any subagent messages must be byte-identical to
+    pre-#1840 behaviour — an absent/empty accumulator is a strict no-op."""
+    usage_delta = {"input_tokens": 200.0, "output_tokens": 80.0}
+    original = dict(usage_delta)
+    sub_accum = None
+    if sub_accum:
+        for k, v in sub_accum.items():
+            usage_delta[k] = usage_delta.get(k, 0) + v
+    assert usage_delta == original


### PR DESCRIPTION
## Summary
Resolves #1840

Subagent (Agent/Task tool) API calls carry their own per-call `usage`, but `AssistantMessageHandler` never extracted it, so every subagent call's tokens (input/output/cache) were silently dropped from turn and session analytics — undercounting cost and usage for any turn that used the Agent tool.

## Changes Made
- **`backend/message_parser.py`**: extract `usage` into parsed metadata for every assistant message (top-level and subagent alike — no separate parsing path needed).
- **`backend/session_coordinator.py`**:
  - New `_subagent_usage_by_session` accumulator sums subagent usage as messages stream in during a turn (summed directly, never baseline-diffed — each subagent call's usage is already a per-call delta, unlike the main thread's cumulative-since-subprocess-start snapshots).
  - Merged into the turn's `usage_delta` on `'result'`, including folding the TTL-tier cache-write split into the flat total `record_turn()`/`compute_cost()` key off of, so cost estimation isn't silently undercounted when a turn used subagents.
  - A `run_in_background` subagent that outlives its originating turn is flushed as a catch-up row on session **termination** instead of being lost (chosen over deletion-time flush since `delete_session()` wipes all analytics rows immediately after anyway — persisting first would be pointless).
  - A failed `record_turn()` write restores the accumulator instead of silently losing the subagent's contribution (mirrors the existing baseline-non-advancement pattern for the main thread's usage).
- **`backend/analytics/database.py`**: adds `cache_write_tokens_5m`, `cache_write_tokens_1h` (both tables) and `is_subagent` (`turn_usage` only) columns, with an `ALTER TABLE ... ADD COLUMN`-if-missing migration helper for pre-existing on-disk databases (this codebase had no prior migration precedent).
- **`backend/analytics_store.py`**: `record_turn()`/`get_session_usage()` extended for the new columns. `turn_count` excludes `is_subagent` catch-up rows (they're bookkeeping, not real conversation turns), while the separate turn_seq-reseed counter still counts them (avoiding a `turn_seq` collision against `UNIQUE(session_id, turn_seq)` after a restart). `session_usage.model` is preserved via `COALESCE` instead of being clobbered to `NULL` by a catch-up row that doesn't know the model.
- **`backend/routers/sessions.py`**: `GET /api/sessions/{id}/usage` now also returns the two new TTL-tier fields (this endpoint reshapes the aggregate dict field-by-field rather than passing it through verbatim, which the original plan had assumed).

## Testing
- New/extended unit + integration tests across `test_message_parser.py`, `test_session_coordinator_usage.py`, `test_analytics_store.py`, and a new `test_issue_1840_subagent_usage.py` (fixture-driven end-to-end callback tests, termination/deletion lifecycle tests, a migration test against a pre-existing legacy-schema DB, and a live-REST-endpoint test).
- Ran an internal 8-angle correctness/quality review pass against the diff and fixed everything it confirmed: the `turn_seq` collision, the `model`-clobbering bug, the `turn_count` inflation, the failed-write data-loss gap, and duplicated fold-in logic (consolidated into a shared `_next_turn_seq()` helper and into `_accumulate_subagent_usage()` itself).
- `uv run ruff check` clean on all changed files.
- Full suite: `uv run pytest backend/tests/ src/tests/` — 2563 passed, 3 pre-existing failures unrelated to this change (confirmed against a clean `origin/main` checkout).
- Manually verified end-to-end against a live running instance: seeded real `record_turn()` calls (including an `is_subagent=True` catch-up row) directly against the actual on-disk `analytics.db` used by a running Frontend API + Backend pair, then confirmed `GET /api/sessions/{id}/usage` correctly aggregates and returns `cache_write_tokens`, `cache_write_tokens_5m`, `cache_write_tokens_1h`.

**Known limitation, disclosed rather than assumed away**: the exact `usage.cache_creation.{ephemeral_5m,ephemeral_1h}_input_tokens` key names were confirmed against a real `--debug-sdk` dump of the installed SDK. However, whether raw subagent `AssistantMessage`s still stream through the message callback for `run_in_background=True` Agent calls could **not** be verified live — this sandbox has no authenticated Anthropic API access, and no credential workaround was attempted. The design degrades gracefully either way (a documented coverage gap for that specific dispatch mode, not a crash or double-count) — see the code comments in `session_coordinator.py` around `_subagent_usage_by_session` for the accepted tradeoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)