### PR TITLE
[docs]: auth hardening review — remote-backend token guidance + restart logging (#1847 stage 3/3: auth hardening review)

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,25 @@ Remote access is disabled by default. You must enable it via the following proce
 2. Launch the app via `uv run python main.py --host=0.0.0.0`
 3. When starting up, it'll output a token to use to authenticate the web app and API. Once networking listening is active, it'll require entering the randomized token to authenticate to the server, preventing open network access. NOTE: This can be set to a specific value with `--token=` CLI argument.
 
+### Remote Backend Deployment
+
+`--remote-backend-url`/`--remote-backend-token` point Frontend at a manually-run or
+genuinely remote Backend instead of auto-starting one locally.
+
+- **Backend-scoped token.** The value passed to `--remote-backend-token` grants full
+  control of Backend's entire API surface — every session, every project, all config,
+  and server restarts. Generate it the same way `main.py` generates its own browser
+  auth token (`secrets.token_urlsafe(32)` or equivalent), and rotate it the same way
+  you'd rotate any other deployment secret.
+- **Binding Frontend to localhost with a remote Backend.** Frontend's own
+  authentication is disabled by default when `--host` is `127.0.0.1`/`localhost`/`::1`
+  (see "Network Access" above), independently of whether it's pointed at a remote
+  Backend. Binding Frontend to localhost while `--remote-backend-url` points at a
+  genuinely remote host leaves that Frontend's browser-facing auth **disabled by
+  default**, the same as the fully-local case — anyone who can reach it can trigger
+  restarts and other actions against the remote Backend. Pass `--force-auth` for this
+  specific combination.
+
 ---
 
 **Key technologies**: Vue 3.4 · Pinia 2.1 · Vite 7.1 · Bootstrap 5.3 · FastAPI · uvicorn · JSONL/JSON storage · HTTP long-polling

--- a/main.py
+++ b/main.py
@@ -62,7 +62,9 @@ def main():
     )
     parser.add_argument(
         '--remote-backend-token', type=str, default=None,
-        help='Backend-scoped bearer token for --remote-backend-url.'
+        help='Backend-scoped bearer token for --remote-backend-url. Grants full control '
+             'of the Backend API — generate with secrets.token_urlsafe(32) or equivalent '
+             'and rotate it like any other deployment secret. See README.md.'
     )
 
     # Experimental features / mock SDK — passed through to an auto-started Backend

--- a/src/routers/system.py
+++ b/src/routers/system.py
@@ -376,12 +376,23 @@ def build_router(webui) -> APIRouter:
         backend_outcome = None
         if webui.backend_supervisor is None:
             outcome = await _restart_remote_backend(webui, payload)
+            backend_outcome = {"status": outcome.status, "detail": outcome.detail}
+            logger.info(
+                "Restart requested (frontend: branch=%s commit=%s | backend: branch=%s "
+                "commit=%s) — backend outcome: %s",
+                payload.branch, payload.commit, payload.backend_branch, payload.backend_commit,
+                backend_outcome,
+            )
             if not outcome.ok:
                 raise HTTPException(
                     status_code=502,
                     detail=f"Backend restart failed ({outcome.status}): {outcome.detail}",
                 )
-            backend_outcome = {"status": outcome.status, "detail": outcome.detail}
+        else:
+            logger.info(
+                "Restart requested (frontend: branch=%s commit=%s)",
+                payload.branch, payload.commit,
+            )
 
         if not has_custom_target:
             try:

--- a/src/tests/test_system_router.py
+++ b/src/tests/test_system_router.py
@@ -14,6 +14,7 @@ so they always described Backend's repo, never Frontend's own — in embedded mo
 this happened to look correct only because it's the same checkout.
 """
 
+import logging
 import subprocess
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -424,6 +425,68 @@ class TestRestartRemoteBackendOrchestration:
         webui.backend_client.health.assert_not_awaited()
         webui.backend_client.ready.assert_not_awaited()
         webui.backend_client.request_json.assert_not_awaited()
+
+
+class TestRestartLogging:
+    """Regression coverage for the observability gap (#1847 finding 4): before this,
+    restart_server() never logged what was requested or, in remote mode, what Backend
+    reported back — that information only ever reached the HTTP response body."""
+
+    @pytest.mark.asyncio
+    async def test_embedded_mode_logs_requested_target(self, caplog):
+        webui = _make_webui()
+
+        with (
+            patch("src.routers.system.subprocess.run", side_effect=_default_run_side_effect),
+            caplog.at_level(logging.INFO, logger="src.routers.system"),
+        ):
+            async with AsyncClient(transport=ASGITransport(app=webui.app), base_url="http://test") as client:
+                resp = await client.post("/api/system/restart")
+
+        assert resp.status_code == 202
+        assert any(
+            "Restart requested" in r.message and "branch=None commit=None" in r.message
+            for r in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_remote_mode_success_logs_backend_outcome(self, caplog):
+        webui = _make_webui(backend_supervisor=None)
+
+        with (
+            patch("src.routers.system._BACKEND_RESTART_GRACE_SECONDS", 0),
+            patch("src.routers.system.subprocess.run", side_effect=_default_run_side_effect),
+            caplog.at_level(logging.INFO, logger="src.routers.system"),
+        ):
+            async with AsyncClient(transport=ASGITransport(app=webui.app), base_url="http://test") as client:
+                resp = await client.post("/api/system/restart")
+
+        assert resp.status_code == 202
+        assert any(
+            "backend outcome" in r.message and "'status': 'restarted'" in r.message
+            for r in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_remote_mode_failure_still_logs_backend_outcome(self, caplog):
+        webui = _make_webui(backend_supervisor=None)
+        webui.backend_client.health = AsyncMock(return_value=True)
+        webui.backend_client.request_json = AsyncMock(
+            side_effect=_http_status_error(409, "Uncommitted changes present.")
+        )
+
+        with (
+            patch("src.routers.system.subprocess.run", side_effect=_no_subprocess_expected),
+            caplog.at_level(logging.INFO, logger="src.routers.system"),
+        ):
+            async with AsyncClient(transport=ASGITransport(app=webui.app), base_url="http://test") as client:
+                resp = await client.post("/api/system/restart")
+
+        assert resp.status_code == 502
+        assert any(
+            "backend outcome" in r.message and "'status': 'failed'" in r.message
+            for r in caplog.records
+        )
 
 
 def _fake_async_proc(returncode=0):


### PR DESCRIPTION
## Summary
Closes #1847 (final stage — 3 of 3: backend orchestration → UI drift/trigger → **auth hardening**)

An audit of #1847's merged code (backend orchestration in #1863, UI drift/trigger in #1865) found **no gap that justifies a new checkpoint, confirmation step, auth-default change, or CSRF/RBAC mechanism**. Three low-cost, zero-friction improvements were recommended instead — documentation and logging only, nothing in the restart request/response contract changes shape or requires extra steps.

## Changes Made
- **README.md**: new "Remote Backend Deployment" section documenting:
  - Backend-scoped token (`--remote-backend-token`) generation (`secrets.token_urlsafe(32)`) and rotation guidance — it grants full remote control of Backend's entire API surface.
  - That binding Frontend to `127.0.0.1` while pointed at a genuinely remote Backend leaves Frontend's own browser-facing auth **disabled by default** (same as the fully-local case) — recommends `--force-auth` for that specific combination. This is a documentation callout only; `main.py`'s `auth_enabled` logic is unchanged.
- **main.py**: expanded the `--remote-backend-token` `--help` string to match the README guidance.
- **src/routers/system.py**: added one `logger.info` line in `restart_server()` capturing the resolved restart target(s) and, in remote mode, Backend's reported outcome — previously that information only ever reached the HTTP response body, never a log file. Pure observability; no request/response contract change.

## Explicitly not done (and why)
- No auth-default change for the localhost+remote-Backend combination — would add friction across the *entire* API for that host combination, isn't required by any of #1847's acceptance criteria, and the narrower gap is covered by the new README callout instead. Full reasoning is in the stage's audit.
- No new confirmation dialog, CSRF token, re-auth step, or RBAC gate — nothing in the audit surfaced a concrete driver for any of these.

## Testing
- Added `TestRestartLogging` (3 new tests) to `src/tests/test_system_router.py`, asserting the new log line fires with correct target/outcome content on:
  - the embedded-mode path,
  - the remote-mode success path,
  - the remote-mode Backend-failure path.
- `uv run pytest src/tests/ -q` — 162 passed.
- `uv run ruff check src/ main.py` — zero violations.
- Ran `builder-review` (medium-effort correctness pass) — no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)