### PR TITLE
[test]: fix 3 pre-existing failing tests (fixture key + mismatched scenario)

### DIFF
--- a/backend/tests/integration/test_api_links.py
+++ b/backend/tests/integration/test_api_links.py
@@ -29,7 +29,7 @@ class TestGetSessionLinks:
     async def test_issue_1530_get_links_returns_registered(self, api_integration_env):
         """After upsert_link on the coordinator, GET returns the link."""
         client = api_integration_env["client"]
-        coordinator = api_integration_env["session_coordinator"]
+        coordinator = api_integration_env["coordinator"]
         session = await _create_session(api_integration_env)
         sid = session["session_id"]
 
@@ -51,7 +51,7 @@ class TestGetSessionLinks:
 
     async def test_issue_1530_links_survive_message_clear(self, api_integration_env):
         """Links on session_info are not affected by clearing messages.jsonl directly."""
-        coordinator = api_integration_env["session_coordinator"]
+        coordinator = api_integration_env["coordinator"]
         client = api_integration_env["client"]
         session = await _create_session(api_integration_env)
         sid = session["session_id"]

--- a/backend/tests/integration/test_issue_1598_poll_viewed_timing.py
+++ b/backend/tests/integration/test_issue_1598_poll_viewed_timing.py
@@ -52,23 +52,41 @@ class TestPollViewedTiming:
             queue.wait_for_events = original_wait
 
     async def test_completion_during_poll_window_stays_unread(self, api_integration_env):
-        """Issue #1598: Completion arriving after mark_viewed surfaces as unread."""
+        """Issue #1598: a NEW completion arriving after a session was already caught up
+        (last_viewed_at >= last_completion_at) must still surface as unread once the
+        poll whose wait window overlaps it returns.
+
+        Note: this scenario requires prior completion+view history. A session with NO
+        prior completion at all cannot be used here — mark_viewed()'s no-op guard for
+        that case is intentional (see test_no_prior_completion_mark_viewed_is_noop in
+        this same file, and the equivalent guard tests in TestMarkUnread/TestMarkRead in
+        test_session_manager.py) and mark_viewed() cannot retroactively record a baseline
+        for a completion that hasn't happened yet.
+        """
         client = api_integration_env["client"]
         webui = api_integration_env["webui"]
         project = await api_integration_env["create_test_project"]()
         session = await api_integration_env["create_test_session"](project["project_id"])
         sid = session["session_id"]
 
-        # Simulate: completion arrives AFTER mark_viewed runs but BEFORE wait returns.
-        # Patch wait_for_events to inject the completion mid-poll.
+        session_mgr = webui.coordinator.session_manager
         queue = webui.session_queues[sid]
         original_wait = queue.wait_for_events
-        session_mgr = webui.coordinator.session_manager
 
+        # Establish baseline: an initial completion, then a poll that catches
+        # last_viewed_at up to it (guard B's "already caught up" state).
+        first_ts = datetime.now(UTC)
+        await session_mgr.mark_completion(sid, first_ts)
+        resp = await client.get(f"/api/poll/session/{sid}?since=0&timeout=0")
+        assert resp.status_code == 200
+        baseline_viewed_at = session_mgr._active_sessions[sid].last_viewed_at
+        assert baseline_viewed_at is not None
+
+        # Simulate: a NEW completion arrives after mark_viewed runs (no-ops, since the
+        # session is already caught up) but before wait_for_events returns.
         async def patched_wait_with_completion(since, timeout):
-            # Record a completion now — after mark_viewed has already recorded viewed_at
-            future_ts = datetime.now(UTC)
-            await session_mgr.mark_completion(sid, future_ts)
+            new_ts = datetime.now(UTC)
+            await session_mgr.mark_completion(sid, new_ts)
             return await original_wait(since, timeout)
 
         queue.wait_for_events = patched_wait_with_completion
@@ -79,7 +97,10 @@ class TestPollViewedTiming:
             info = session_mgr._active_sessions.get(sid)
             assert info is not None
             assert info.last_completion_at is not None, "Expected last_completion_at to be set"
-            assert info.last_viewed_at is not None, "Expected last_viewed_at to be set"
+            assert info.last_viewed_at == baseline_viewed_at, (
+                "mark_viewed must no-op mid-poll: the session was already caught up "
+                "when it ran, before the new completion landed"
+            )
             assert info.last_completion_at > info.last_viewed_at, (
                 "Completion after mark_viewed must be unread: "
                 f"last_completion_at={info.last_completion_at}, "


### PR DESCRIPTION
## Summary
- Fixed a fixture-key typo in `test_api_links.py`: two tests read `api_integration_env["session_coordinator"]`, a key copy-pasted from the unrelated `legion_test_env` fixture; the correct key is `"coordinator"`.
- Rewrote `test_completion_during_poll_window_stays_unread` in `test_issue_1598_poll_viewed_timing.py`: the old version used a session with zero prior completion history, which `mark_viewed()`'s intentional no-op guard can never produce a `last_viewed_at` for. The new version establishes a completion+view baseline first, then injects a new completion mid-poll — matching issue #1598's actual race condition.
- Zero production code changes — all three were test-side bugs, confirmed by tracing `mark_viewed()`/`mark_completion()` in `backend/session_manager.py` and cross-referencing the three neighboring guard tests (`test_no_prior_completion_mark_viewed_is_noop`, `TestMarkUnread`, `TestMarkRead`) that already rely on the same guard behavior as intentional.

## Test plan
- [x] `uv run pytest backend/tests/integration/test_api_links.py backend/tests/integration/test_issue_1598_poll_viewed_timing.py -v` — 8/8 passed
- [x] `uv run pytest backend/tests/ src/tests/ -q` — 2590 passed, 0 failed, 46 deselected
- [x] `uv run pytest backend/tests/test_session_manager.py -k "TestMarkUnread or TestMarkRead"` — 8/8 passed, unaffected
- [x] `uv run ruff check backend/ src/` — zero violations
- [x] builder-review pass — no correctness findings

Resolves #1860