### PR TITLE
[fix]: propagate auto-start failure reason through send_comm errors

### DIFF
--- a/backend/legion/comm_router.py
+++ b/backend/legion/comm_router.py
@@ -356,12 +356,27 @@ class CommRouter:
                 )
 
                 if not success:
-                    legion_logger.error(f"Failed to auto-start minion {comm.to_minion_id}")
+                    reason = None
+                    try:
+                        failed_info = await self.system.session_coordinator.session_manager.get_session_info(
+                            comm.to_minion_id
+                        )
+                        reason = failed_info.error_message if failed_info else None
+                    except Exception:
+                        legion_logger.exception(
+                            f"Failed to retrieve failure reason for minion {comm.to_minion_id}"
+                        )
+
+                    detail = reason or f"state: {target_minion.state}"
+                    legion_logger.error(
+                        f"Failed to auto-start minion {comm.to_minion_id}: {detail}"
+                    )
                     # Send error comm back to sender
                     if comm.from_minion_id:
+                        comm.metadata["delivery_failure_reason"] = reason
                         await self._send_system_error_comm(
                             to_minion_id=comm.from_minion_id,
-                            error_message=f"Failed to deliver message: Could not auto-start target minion (state: {target_minion.state})",
+                            error_message=f"Failed to deliver message: Could not auto-start target minion ({detail})",
                             original_comm_id=comm.comm_id
                         )
                     return False

--- a/backend/legion/mcp/legion_mcp_tools.py
+++ b/backend/legion/mcp/legion_mcp_tools.py
@@ -745,6 +745,9 @@ class LegionMCPTools:
                     "is_error": False
                 }
             else:
+                reason = comm.metadata.get("delivery_failure_reason")
+                if reason:
+                    return self._err(f"Failed to send message to {to_minion_name}: {reason}")
                 return self._err(f"Failed to send message to {to_minion_name}")
         except Exception as e:
             return self._err(f"Error sending message: {str(e)}")

--- a/backend/tests/test_comm_router.py
+++ b/backend/tests/test_comm_router.py
@@ -515,3 +515,206 @@ class TestCommRouter:
         assert not (tmp_path / "sessions" / "nonexistent-minion").exists(), (
             "No attachment directory should be created for a nonexistent target minion"
         )
+
+
+class TestAutoStartFailureReason:
+    """Issue #1839: auto-start failure should surface the real error_message
+    (re-fetched from SessionInfo) instead of only the generic state text."""
+
+    def _make_minion(self, state, error_message=None):
+        from backend.session_manager import SessionInfo, SessionState
+
+        mock = Mock(spec=SessionInfo)
+        mock.session_id = "test-minion-123"
+        mock.name = "TestMinion"
+        mock.project_id = "test-legion-456"
+        mock.state = state if state is not None else SessionState.CREATED
+        mock.error_message = error_message
+        return mock
+
+    @pytest.mark.asyncio
+    async def test_auto_start_failure_surfaces_error_message(self, comm_router):
+        """T1-equivalent: a freshly computed error_message on the re-fetched
+        SessionInfo is included in both the error Comm and the log line."""
+        from backend.session_manager import SessionState
+
+        sm = comm_router.system.session_coordinator.session_manager
+        initial_minion = self._make_minion(SessionState.CREATED)
+        failed_minion = self._make_minion(
+            SessionState.ERROR, error_message="Docker sandbox unavailable: image not found"
+        )
+        sm.get_session_info = AsyncMock(side_effect=[initial_minion, failed_minion])
+        comm_router.system.session_coordinator.start_session = AsyncMock(return_value=False)
+
+        comm = Comm(
+            comm_id=str(uuid.uuid4()),
+            from_minion_id="sender-minion",
+            to_minion_id="test-minion-123",
+            content="Test message",
+            comm_type=CommType.TASK,
+        )
+
+        with patch.object(comm_router, '_send_system_error_comm', new=AsyncMock()) as mock_error_comm, \
+                patch('backend.legion.comm_router.legion_logger') as mock_logger:
+            result = await comm_router._send_to_minion(comm)
+
+        assert result is False
+        mock_error_comm.assert_called_once()
+        error_message_arg = mock_error_comm.call_args.kwargs["error_message"]
+        assert "Docker sandbox unavailable: image not found" in error_message_arg
+        assert comm.metadata["delivery_failure_reason"] == "Docker sandbox unavailable: image not found"
+
+        logged = "".join(str(call) for call in mock_logger.error.call_args_list)
+        assert "Docker sandbox unavailable: image not found" in logged
+
+    @pytest.mark.asyncio
+    async def test_auto_start_failure_surfaces_stale_error_message(self, comm_router):
+        """T2-equivalent: session already in ERROR state from a prior failure
+        (no fresh error computed this call) still surfaces its stale-but-relevant
+        error_message via the re-fetch."""
+        from backend.session_manager import SessionState
+
+        sm = comm_router.system.session_coordinator.session_manager
+        initial_minion = self._make_minion(SessionState.CREATED)
+        failed_minion = self._make_minion(
+            SessionState.ERROR, error_message="Previous failure: connection refused"
+        )
+        sm.get_session_info = AsyncMock(side_effect=[initial_minion, failed_minion])
+        comm_router.system.session_coordinator.start_session = AsyncMock(return_value=False)
+
+        comm = Comm(
+            comm_id=str(uuid.uuid4()),
+            from_minion_id="sender-minion",
+            to_minion_id="test-minion-123",
+            content="Test message",
+            comm_type=CommType.TASK,
+        )
+
+        with patch.object(comm_router, '_send_system_error_comm', new=AsyncMock()) as mock_error_comm:
+            result = await comm_router._send_to_minion(comm)
+
+        assert result is False
+        error_message_arg = mock_error_comm.call_args.kwargs["error_message"]
+        assert "Previous failure: connection refused" in error_message_arg
+
+    @pytest.mark.asyncio
+    async def test_auto_start_failure_degrades_gracefully_when_session_info_none(self, comm_router):
+        """Degrade-gracefully case: get_session_info() returns None on the
+        re-fetch — falls back to the existing state-based text, no exception."""
+        from backend.session_manager import SessionState
+
+        sm = comm_router.system.session_coordinator.session_manager
+        initial_minion = self._make_minion(SessionState.CREATED)
+        sm.get_session_info = AsyncMock(side_effect=[initial_minion, None])
+        comm_router.system.session_coordinator.start_session = AsyncMock(return_value=False)
+
+        comm = Comm(
+            comm_id=str(uuid.uuid4()),
+            from_minion_id="sender-minion",
+            to_minion_id="test-minion-123",
+            content="Test message",
+            comm_type=CommType.TASK,
+        )
+
+        with patch.object(comm_router, '_send_system_error_comm', new=AsyncMock()) as mock_error_comm:
+            result = await comm_router._send_to_minion(comm)
+
+        assert result is False
+        error_message_arg = mock_error_comm.call_args.kwargs["error_message"]
+        assert f"state: {SessionState.CREATED}" in error_message_arg
+        assert comm.metadata["delivery_failure_reason"] is None
+
+    @pytest.mark.asyncio
+    async def test_auto_start_failure_degrades_gracefully_when_lookup_raises(self, comm_router):
+        """Degrade-gracefully case: get_session_info() raises on the re-fetch —
+        falls back to the existing state-based text, no exception escapes."""
+        from backend.session_manager import SessionState
+
+        sm = comm_router.system.session_coordinator.session_manager
+        initial_minion = self._make_minion(SessionState.CREATED)
+
+        async def raise_on_second_call(*_args, **_kwargs):
+            raise RuntimeError("db unavailable")
+
+        call_count = {"n": 0}
+
+        async def side_effect(*args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return initial_minion
+            return await raise_on_second_call()
+
+        sm.get_session_info = AsyncMock(side_effect=side_effect)
+        comm_router.system.session_coordinator.start_session = AsyncMock(return_value=False)
+
+        comm = Comm(
+            comm_id=str(uuid.uuid4()),
+            from_minion_id="sender-minion",
+            to_minion_id="test-minion-123",
+            content="Test message",
+            comm_type=CommType.TASK,
+        )
+
+        with patch.object(comm_router, '_send_system_error_comm', new=AsyncMock()) as mock_error_comm:
+            result = await comm_router._send_to_minion(comm)
+
+        assert result is False
+        error_message_arg = mock_error_comm.call_args.kwargs["error_message"]
+        assert f"state: {SessionState.CREATED}" in error_message_arg
+        assert comm.metadata["delivery_failure_reason"] is None
+
+    @pytest.mark.asyncio
+    async def test_target_not_found_message_unchanged(self, comm_router):
+        """AC4 regression: target-not-found failure keeps its existing
+        generic message, byte-for-byte, untouched by this change."""
+        sm = comm_router.system.session_coordinator.session_manager
+        sm.get_session_info = AsyncMock(return_value=None)
+
+        comm = Comm(
+            comm_id=str(uuid.uuid4()),
+            from_minion_id="sender-minion",
+            to_minion_id="nonexistent-minion",
+            content="Test message",
+            comm_type=CommType.TASK,
+        )
+
+        with patch.object(comm_router, '_send_system_error_comm', new=AsyncMock()) as mock_error_comm:
+            result = await comm_router._send_to_minion(comm)
+
+        assert result is False
+        mock_error_comm.assert_called_once_with(
+            to_minion_id="sender-minion",
+            error_message="Failed to deliver message: Target minion not found",
+            original_comm_id=comm.comm_id,
+        )
+        assert "delivery_failure_reason" not in comm.metadata
+
+    @pytest.mark.asyncio
+    async def test_send_message_rejection_message_unchanged(self, comm_router):
+        """AC4 regression: send_message() rejection (post auto-start-success
+        path) keeps its existing generic message unchanged."""
+        from backend.session_manager import SessionState
+
+        sm = comm_router.system.session_coordinator.session_manager
+        active_minion = self._make_minion(SessionState.ACTIVE)
+        sm.get_session_info = AsyncMock(return_value=active_minion)
+        comm_router.system.session_coordinator.send_message = AsyncMock(return_value=False)
+
+        comm = Comm(
+            comm_id=str(uuid.uuid4()),
+            from_minion_id="sender-minion",
+            to_minion_id="test-minion-123",
+            content="Test message",
+            comm_type=CommType.TASK,
+        )
+
+        with patch.object(comm_router, '_send_system_error_comm', new=AsyncMock()) as mock_error_comm:
+            result = await comm_router._send_to_minion(comm)
+
+        assert result is False
+        mock_error_comm.assert_called_once_with(
+            to_minion_id="sender-minion",
+            error_message="Failed to deliver message: SDK rejected the message",
+            original_comm_id=comm.comm_id,
+        )
+        assert "delivery_failure_reason" not in comm.metadata

--- a/backend/tests/test_legion_mcp_tools.py
+++ b/backend/tests/test_legion_mcp_tools.py
@@ -611,6 +611,71 @@ async def test_issue_1730_same_filename_resolves_distinct_resource_ids_across_ca
     assert resolved_ids == ["res-v1", "res-v2", "res-v3"]
 
 
+# ── send_comm delivery-failure-reason tests (Issue #1839) ──
+
+
+@pytest.mark.asyncio
+async def test_issue_1839_send_comm_surfaces_delivery_failure_reason(tmp_path):
+    """When route_comm() fails and stamps comm.metadata['delivery_failure_reason'],
+    _handle_send_comm's error text includes that reason."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from backend.legion.mcp.legion_mcp_tools import LegionMCPTools
+
+    session_id = "sender-session-failure"
+    mock_system = _make_send_comm_system(session_id, docker_enabled=False, data_dir=tmp_path)
+
+    async def failing_route_comm(comm, **kwargs):
+        comm.metadata["delivery_failure_reason"] = "Docker sandbox unavailable: image not found"
+        return False
+
+    mock_system.comm_router = MagicMock()
+    mock_system.comm_router.route_comm = AsyncMock(side_effect=failing_route_comm)
+    mcp_tools = LegionMCPTools(mock_system)
+
+    result = await mcp_tools._handle_send_comm({
+        "_from_minion_id": session_id,
+        "to_minion_name": "user",
+        "summary": "test",
+        "content": "body",
+        "comm_type": "report",
+    })
+
+    assert result["is_error"] is True
+    text = result["content"][0]["text"]
+    assert "Failed to send message to user" in text
+    assert "Docker sandbox unavailable: image not found" in text
+
+
+@pytest.mark.asyncio
+async def test_issue_1839_send_comm_generic_text_unchanged_without_reason(tmp_path):
+    """AC4 regression: when route_comm() fails without setting
+    delivery_failure_reason (a non-auto-start failure), the original generic
+    error text is preserved byte-for-byte."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from backend.legion.mcp.legion_mcp_tools import LegionMCPTools
+
+    session_id = "sender-session-failure-generic"
+    mock_system = _make_send_comm_system(session_id, docker_enabled=False, data_dir=tmp_path)
+
+    mock_system.comm_router = MagicMock()
+    mock_system.comm_router.route_comm = AsyncMock(return_value=False)
+    mcp_tools = LegionMCPTools(mock_system)
+
+    result = await mcp_tools._handle_send_comm({
+        "_from_minion_id": session_id,
+        "to_minion_name": "user",
+        "summary": "test",
+        "content": "body",
+        "comm_type": "report",
+    })
+
+    assert result["is_error"] is True
+    text = result["content"][0]["text"]
+    assert text == "Failed to send message to user"
+
+
 # ── queue_task handler tests (Issue #1114) ──
 
 


### PR DESCRIPTION
## Summary
Resolves #1839

`send_comm` failures caused by a target minion's session failing to auto-start previously surfaced only generic, detail-free text (e.g. `state: created`) to both the calling minion (via the error Comm) and the MCP tool's returned result — even though `SessionCoordinator.start_session()` already computes a specific, cleaned `error_message` internally on failure. That detail was discarded because `start_session()` returns a bare `bool`.

Per confirmed design: no return-type changes to `start_session()`/`route_comm()`/`_send_to_minion()` anywhere. `SessionManager.get_session_info()` returns the live in-memory `SessionInfo` object, so re-fetching it after a failed `start_session()` call recovers the reason without touching the 7+ other call sites of `start_session()`.

## Changes Made
- `backend/legion/comm_router.py`: `_send_to_minion()`'s auto-start failure block now re-fetches `SessionInfo` after a failed `start_session()` call, extracts `.error_message` (wrapped in try/except with graceful fallback to the existing `state: {target_minion.state}` text), stamps `comm.metadata["delivery_failure_reason"]`, and includes the detail in both the error Comm text and the log line.
- `backend/legion/mcp/legion_mcp_tools.py`: `_handle_send_comm()` reads `comm.metadata.get("delivery_failure_reason")` after a failed `route_comm()` and includes it in the returned error text when present, otherwise keeps the existing generic text unchanged.
- Unrelated failure branches (target not found, readiness timeouts, `send_message()` rejection) are untouched and keep byte-for-byte identical text.

## Testing
- Added unit tests in `backend/tests/test_comm_router.py` (`TestAutoStartFailureReason`): fresh error surfaced, stale error surfaced, graceful degradation when the re-fetch returns `None` or raises, and regression tests confirming the target-not-found and send_message-rejection paths keep unchanged text.
- Added unit tests in `backend/tests/test_legion_mcp_tools.py`: `delivery_failure_reason` is surfaced when present, and the original generic text is preserved when absent.
- Full suite: `uv run pytest backend/tests/ src/tests/` — 2641 passed.
- `builder-review` correctness pass run; findings triaged (see review notes below).
- Rebased onto latest `origin/main`, re-ran full suite post-rebase — all green.

## Review Notes
A `builder-review` pass surfaced one finding outside this issue's scope worth a follow-up decision: `SessionInfo.error_message` is never cleared anywhere in the codebase, and `SessionManager.start_session()`'s `STARTABLE_STATES` rejection branch (reachable via a benign concurrent-auto-start race through the per-session lock) returns `False` without computing a fresh error. In that narrow race, a much older, unrelated `error_message` could be surfaced as if it explains a current benign race. Flagging for a follow-up rather than expanding this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)