### PR TITLE
fix: truncate and re-own mitm.flows at proxy sidecar start

### DIFF
--- a/backend/docker/proxy/entrypoint.sh
+++ b/backend/docker/proxy/entrypoint.sh
@@ -242,9 +242,14 @@ iptables -A OUTPUT -p udp -j DROP
 # PID 1 (this shell) remains as the container's init process and forwards
 # SIGTERM/SIGINT to the child processes for clean shutdown.
 # Issue #1214: Truncate SOCKS5 log at sidecar start so each session begins clean.
+# Issue #1846: Also truncate+re-own mitm.flows — mitmdump opens it itself after
+# dropping to uid 9999, so a pre-existing file owned by another uid (e.g. after
+# a filesystem/mount migration) would otherwise fail with Permission denied.
 if [ -d "$LOG_DIR" ]; then
     : > "$LOG_DIR/socks5.log"
     chown 9999:9999 "$LOG_DIR/socks5.log"
+    : > "$LOG_DIR/mitm.flows"
+    chown 9999:9999 "$LOG_DIR/mitm.flows"
 fi
 
 echo "Starting mitmdump (transparent + SOCKS5) on :8080 / 127.0.0.1:1080..."


### PR DESCRIPTION
## Summary
- `entrypoint.sh` truncated/re-owned `socks5.log` before `mitmdump` start (issue #1214) but not `mitm.flows`
- `mitmdump` opens `mitm.flows` itself after dropping to uid 9999 via `setpriv`, so a pre-existing file owned by another uid (e.g. after a filesystem/mount migration) caused `Permission denied` and aborted sidecar startup
- Extends the existing truncate+chown block to also cover `mitm.flows`, since both are pre-mitmdump-start, same-privilege-level, same-`LOG_DIR` operations

## Test plan
- [x] `bash -n backend/docker/proxy/entrypoint.sh` — syntax OK
- [x] Diff reviewed — only the 2 intended lines (plus a comment) added, no other logic touched
- [x] Manual reasoning: block still runs before `mitmdump`, script is still root at this point (setpriv drops privileges per-process only), `MITM_EXTRA_ARGS` gating unaffected
- [ ] Live Docker verification (pre-seed wrong-uid-owned `mitm.flows`, confirm sidecar survives startup) — **not performed**, no Docker available in this sandbox

Resolves #1846

🤖 Generated with [Claude Code](https://claude.com/claude-code)