### PR TITLE
fix: classify Docker/BuildKit stderr before logging or forwarding it (#1837)

### DIFF
--- a/backend/claude_sdk.py
+++ b/backend/claude_sdk.py
@@ -16,6 +16,7 @@ from typing import Any
 from shared.logging_config import get_logger
 
 from .data_storage import DataStorageManager
+from .docker_utils import classify_docker_output
 from .message_parser import MessageParser, MessageProcessor
 from .models.messages import sdk_message_to_stored
 from .models.permission_mode import PermissionMode
@@ -1112,7 +1113,13 @@ class ClaudeSDK:
         # Add stderr handler to capture SDK CLI errors (issue #517)
         def stderr_handler(output: str) -> None:
             """Capture and log stderr output from Claude Code CLI."""
-            logger.error(f"[SDK_STDERR] {self.session_id}: {output}")
+            classification = classify_docker_output(output)
+            if classification == "failure":
+                logger.error(f"[SDK_STDERR] {self.session_id}: {output}")
+            elif classification == "routine":
+                sdk_logger.debug(f"[SDK_STDERR] {self.session_id}: {output}")
+            else:  # ambiguous
+                sdk_logger.info(f"[SDK_STDERR] {self.session_id}: {output}")
             self._stderr_buffer.append(output)
             if self.stderr_callback:
                 try:

--- a/backend/docker_utils.py
+++ b/backend/docker_utils.py
@@ -10,6 +10,7 @@ Issue #1052: prepare_session_ssh() — SSH key tmpfs delivery for proxy-mode ses
 import asyncio
 import logging
 import os
+import re
 import shutil
 import socket
 import subprocess
@@ -24,6 +25,78 @@ DEFAULT_DOCKER_IMAGE = "claude-code:local"
 # bridge network — no custom network is created — so this is the one network whose
 # gateway matters for embedded-mode Docker reachability (issue #1850).
 _DEFAULT_BRIDGE_NETWORK = "bridge"
+
+# Issue #871/#1837: this app's own claude-docker wrapper script prefixes its own
+# informational status lines with this marker (container name/image/PID, etc.).
+DOCKER_WRAPPER_PREFIX = '[claude-docker] '
+
+# Issue #871/#1837: substrings that indicate the line is reporting an actual failure,
+# whether from the wrapper script's own container-exit reporting or from raw Docker/
+# BuildKit CLI output. Kept as substring checks (not full parsing) to match the existing
+# issue #871 precedent and stay resilient to minor format drift.
+DOCKER_FAILURE_KEYWORDS = (
+    'exited with code',            # wrapper: container exit reporting
+    'was killed',                  # wrapper: container killed
+    'crashed',                     # wrapper: container crash
+    'ERROR:',                      # BuildKit step failure marker, e.g. "#5 ERROR: process ..."
+    'failed to solve',             # BuildKit terminal failure summary
+    'did not complete successfully',  # BuildKit RUN-step failure detail line
+)
+
+# Issue #1837: BuildKit's numbered build-step progress format, e.g.:
+#   "#4 CACHED"
+#   "#17 exporting manifest sha256:... done"
+#   "#17 naming to docker.io/library/claude-proxy:local done"
+#   "#17 unpacking to docker.io/library/claude-proxy:local done"
+#   "#17 DONE 6.9s"
+#   "#3 transferring dockerfile: 32B done"
+# Matches only lines whose payload signals a *completed* step ("done"/"cached", case-
+# insensitive, or the "#N DONE <time>s" summary line — "done" matches that too). A bare
+# "#N [2/8] RUN ..." step-start announcement (no completion signal yet) does NOT match —
+# it falls through to the "ambiguous" bucket below, which is still low-noise/non-error but
+# isn't asserted as known-safe.
+_BUILDKIT_ROUTINE_RE = re.compile(r'^#\d+\s.*\b(?:done|cached)\b', re.IGNORECASE)
+
+# Issue #1837: classic (non-BuildKit) `docker pull` layer-progress output, e.g.:
+#   "a2318d6c47ec: Pulling fs layer"
+#   "a2318d6c47ec: Waiting"
+#   "a2318d6c47ec: Downloading [===>   ]  3.2MB/50MB"
+#   "a2318d6c47ec: Pull complete"
+#   "latest: Pulling from library/claude-proxy"
+#   "Digest: sha256:..."
+#   "Status: Downloaded newer image for claude-proxy:local"
+_DOCKER_PULL_ROUTINE_RE = re.compile(
+    r'^[0-9a-f]{12}:\s+(?:Already exists|Pulling fs layer|Waiting|Downloading|'
+    r'Verifying Checksum|Download complete|Extracting|Pull complete)\b'
+    r'|^(?:Digest: sha256:|Status: (?:Downloaded newer image|Image is up to date)|'
+    r'.+: Pulling from )'
+)
+
+
+def classify_docker_output(output: str) -> str:
+    """Classify one line of Docker/BuildKit-sourced stderr output (issue #1837).
+
+    Returns one of:
+      - "failure": matches a known failure signal (wrapper container-exit reporting, or a
+        BuildKit build failure). Callers must log this loud (error.log/console-visible) and
+        may forward/style it as a warning/error in the UI.
+      - "routine": recognized as normal wrapper/BuildKit/pull progress — not a failure.
+        Callers should log this at low severity (e.g. DEBUG) and must NOT forward it to the
+        frontend as a warning/error-styled message.
+      - "ambiguous": matches neither known-failure nor known-routine patterns. Per issue
+        #1837's edge-case guidance this is still logged at low severity (e.g. INFO, not
+        ERROR/WARNING) to avoid re-introducing log flooding, but — unlike "routine" — is not
+        asserted as safe, so existing frontend-forwarding behavior for this bucket is left
+        unchanged (still visible to the user) rather than risking real, unrecognized failures
+        going invisible.
+    """
+    if any(kw in output for kw in DOCKER_FAILURE_KEYWORDS):
+        return "failure"
+    if output.startswith(DOCKER_WRAPPER_PREFIX):
+        return "routine"
+    if _BUILDKIT_ROUTINE_RE.match(output) or _DOCKER_PULL_ROUTINE_RE.match(output):
+        return "routine"
+    return "ambiguous"
 
 
 def get_wrapper_script_path() -> Path:

--- a/backend/session_coordinator.py
+++ b/backend/session_coordinator.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
-from backend.docker_utils import cleanup_session_tmp
+from backend.docker_utils import classify_docker_output, cleanup_session_tmp
 from backend.legion.minion_system_prompts import get_legion_guide_only
 from shared.logging_config import get_logger
 
@@ -55,10 +55,6 @@ from .timestamp_utils import get_unix_timestamp
 coord_logger = get_logger('coordinator', category='COORDINATOR')
 # Keep standard logger for errors
 logger = logging.getLogger(__name__)
-
-# Issue #871: Docker wrapper startup noise filtering
-_DOCKER_WRAPPER_PREFIX = '[claude-docker] '
-_DOCKER_ERROR_KEYWORDS = ('exited with code', 'was killed', 'crashed')
 
 # Issue #1375: Regex for ${secret:<name>} references in MCP server header values.
 _SECRET_REF_RE = re.compile(r"\$\{secret:([^}]+)\}")
@@ -5274,23 +5270,25 @@ class SessionCoordinator:
 
         Issue #517: Each stderr line becomes a system message with subtype 'stderr',
         persisted to messages.jsonl and broadcast to the frontend via WebSocket.
-        Issue #871: Docker wrapper informational lines are filtered out (they are
-        already logged) to avoid spurious red warning pills on successful Docker startup.
+        Issue #871/#1837: Routine Docker/BuildKit progress output (both this app's own
+        wrapper informational lines and raw, non-wrapper-prefixed `docker build`/`pull` CLI
+        output) is logged at low severity and never forwarded to the frontend, so it can't
+        produce spurious warning-styled pills for a successful build/run/pull. Only output
+        classified as an actual failure is logged loud and still reaches the frontend.
         """
         message_callback = self._create_message_callback(session_id)
 
         async def callback(output: str):
             try:
-                coord_logger.warning(f"[STDERR] Session {session_id}: {output}")
+                classification = classify_docker_output(output)
 
-                # Issue #871: Skip Docker wrapper informational diagnostics.
-                # Lines like "[claude-docker] Container: ..., Image: ..., PID: ..."
-                # are startup metadata, not errors. They are already logged above.
-                # Keep lines containing error keywords (exit codes, kills, crashes).
-                if output.startswith(_DOCKER_WRAPPER_PREFIX) and not any(
-                    kw in output for kw in _DOCKER_ERROR_KEYWORDS
-                ):
-                    return
+                if classification == "failure":
+                    coord_logger.warning(f"[STDERR] Session {session_id}: {output}")
+                elif classification == "routine":
+                    coord_logger.debug(f"[STDERR] Session {session_id}: {output}")
+                    return  # Issue #871/#1837: known-safe progress noise — do not forward
+                else:  # ambiguous
+                    coord_logger.info(f"[STDERR] Session {session_id}: {output}")
 
                 stderr_message = {
                     "type": "system",

--- a/backend/tests/test_claude_sdk.py
+++ b/backend/tests/test_claude_sdk.py
@@ -3,7 +3,7 @@
 import asyncio
 import contextlib
 import tempfile
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -673,3 +673,48 @@ class TestSessionState:
         assert SessionState.COMPLETED.value == "completed"
         assert SessionState.FAILED.value == "failed"
         assert SessionState.TERMINATED.value == "terminated"
+
+
+class TestStderrHandlerClassification:
+    """Issue #1837: stderr_handler severity is gated by classify_docker_output()."""
+
+    @pytest.fixture
+    def sdk_and_handler(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            sdk = ClaudeSDK(
+                session_id="test-stderr-session",
+                working_directory=temp_dir,
+                config=SessionConfig(),
+            )
+            opts = sdk._get_sdk_options()
+            yield sdk, opts.stderr
+
+    def test_routine_line_does_not_log_error(self, sdk_and_handler):
+        sdk, stderr_handler = sdk_and_handler
+
+        with patch("backend.claude_sdk.logger") as mock_logger, \
+                patch("backend.claude_sdk.sdk_logger") as mock_sdk_logger:
+            stderr_handler("#17 DONE 6.9s")
+
+        mock_logger.error.assert_not_called()
+        mock_sdk_logger.debug.assert_called_once()
+        assert sdk._stderr_buffer == ["#17 DONE 6.9s"]
+
+    def test_failure_line_logs_error_with_sdk_stderr_marker(self, sdk_and_handler):
+        sdk, stderr_handler = sdk_and_handler
+
+        with patch("backend.claude_sdk.logger") as mock_logger:
+            stderr_handler("Container exited with code 137")
+
+        mock_logger.error.assert_called_once()
+        (message,), _kwargs = mock_logger.error.call_args
+        assert "[SDK_STDERR]" in message
+        assert sdk._stderr_buffer == ["Container exited with code 137"]
+
+    def test_buffer_accumulates_both_routine_and_failure_lines(self, sdk_and_handler):
+        sdk, stderr_handler = sdk_and_handler
+
+        stderr_handler("#4 CACHED")
+        stderr_handler("Container was killed")
+
+        assert sdk._stderr_buffer == ["#4 CACHED", "Container was killed"]

--- a/backend/tests/test_docker_utils.py
+++ b/backend/tests/test_docker_utils.py
@@ -13,6 +13,7 @@ import pytest
 
 from backend.docker_utils import (
     build_embedded_sockets,
+    classify_docker_output,
     cleanup_session_tmp,
     detect_docker_bridge_gateway,
     get_session_tmp_dir,
@@ -290,3 +291,71 @@ class TestBuildEmbeddedSockets:
         finally:
             for s in sockets:
                 s.close()
+
+
+# ---------------------------------------------------------------------------
+# classify_docker_output (issue #1837)
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyDockerOutput:
+    def test_wrapper_informational_line_is_routine(self):
+        line = "[claude-docker] Container: abc123, Image: claude-code:local, PID: 123"
+        assert classify_docker_output(line) == "routine"
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "[claude-docker] Container exited with code 137",
+            "[claude-docker] Container was killed",
+            "[claude-docker] Container crashed",
+        ],
+    )
+    def test_wrapper_failure_lines_are_failure(self, line):
+        assert classify_docker_output(line) == "failure"
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "#17 exporting manifest sha256:abcd1234 done",
+            "#17 naming to docker.io/library/claude-proxy:local done",
+            "#17 unpacking to docker.io/library/claude-proxy:local done",
+            "#17 DONE 6.9s",
+            "#4 CACHED",
+        ],
+    )
+    def test_buildkit_completed_step_lines_are_routine(self, line):
+        assert classify_docker_output(line) == "routine"
+
+    def test_buildkit_step_start_without_completion_is_ambiguous(self):
+        line = "#5 [2/8] RUN pip install -r requirements.txt"
+        assert classify_docker_output(line) == "ambiguous"
+
+    def test_buildkit_failure_line_wins_over_step_prefix(self):
+        line = (
+            '#5 ERROR: process "/bin/sh -c pip install -r requirements.txt" '
+            "did not complete successfully: exit code 1"
+        )
+        assert classify_docker_output(line) == "failure"
+
+    def test_buildkit_terminal_failure_summary_is_failure(self):
+        line = "failed to solve: process \"/bin/sh -c pip install\" did not complete successfully"
+        assert classify_docker_output(line) == "failure"
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "a2318d6c47ec: Pulling fs layer",
+            "a2318d6c47ec: Waiting",
+            "a2318d6c47ec: Downloading [===>   ]  3.2MB/50MB",
+            "a2318d6c47ec: Pull complete",
+            "latest: Pulling from library/claude-proxy",
+            "Digest: sha256:abc123",
+            "Status: Downloaded newer image for claude-proxy:local",
+        ],
+    )
+    def test_docker_pull_layer_lines_are_routine(self, line):
+        assert classify_docker_output(line) == "routine"
+
+    def test_unrelated_output_is_ambiguous(self):
+        assert classify_docker_output("Traceback (most recent call last):") == "ambiguous"

--- a/backend/tests/test_session_coordinator.py
+++ b/backend/tests/test_session_coordinator.py
@@ -3301,3 +3301,52 @@ class TestIssue1842TemplateIdPatchResolutionParity:
         assert created_resolved.permission_mode == patched_resolved.permission_mode
         assert created_resolved.model == patched_resolved.model
         assert created_resolved.model_dump() == patched_resolved.model_dump()
+
+
+class TestIssue1837StderrCallbackClassification:
+    """_create_stderr_callback gates both log severity and frontend forwarding by
+    classify_docker_output()'s classification (issue #1837)."""
+
+    @pytest.mark.asyncio
+    async def test_routine_line_not_forwarded(self, temp_coordinator):
+        coordinator = temp_coordinator
+        session_id = "test-stderr-session"
+        mock_message_callback = AsyncMock()
+
+        with patch.object(coordinator, "_create_message_callback", return_value=mock_message_callback):
+            stderr_callback = coordinator._create_stderr_callback(session_id)
+            await stderr_callback("#17 DONE 6.9s")
+
+        mock_message_callback.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_failure_line_forwarded_as_stderr_message(self, temp_coordinator):
+        coordinator = temp_coordinator
+        session_id = "test-stderr-session"
+        mock_message_callback = AsyncMock()
+
+        with patch.object(coordinator, "_create_message_callback", return_value=mock_message_callback):
+            stderr_callback = coordinator._create_stderr_callback(session_id)
+            await stderr_callback("Container exited with code 137")
+
+        mock_message_callback.assert_called_once()
+        forwarded = mock_message_callback.call_args[0][0]
+        assert forwarded["subtype"] == "stderr"
+        assert forwarded["content"] == "Container exited with code 137"
+
+    @pytest.mark.asyncio
+    async def test_ambiguous_line_still_forwarded(self, temp_coordinator):
+        """Documents the deliberate judgment call: unclassified output stays visible
+        rather than risking a real, unrecognized failure going silent."""
+        coordinator = temp_coordinator
+        session_id = "test-stderr-session"
+        mock_message_callback = AsyncMock()
+
+        with patch.object(coordinator, "_create_message_callback", return_value=mock_message_callback):
+            stderr_callback = coordinator._create_stderr_callback(session_id)
+            await stderr_callback("#5 [2/8] RUN pip install -r requirements.txt")
+
+        mock_message_callback.assert_called_once()
+        forwarded = mock_message_callback.call_args[0][0]
+        assert forwarded["subtype"] == "stderr"
+        assert forwarded["content"] == "#5 [2/8] RUN pip install -r requirements.txt"


### PR DESCRIPTION
## Summary

Both stderr-handling paths logged every line unconditionally at a fixed severity with no content inspection:

- `backend/claude_sdk.py`'s `stderr_handler` called `logger.error(...)` for every line, flooding `error.log`/console.
- `backend/session_coordinator.py`'s `_create_stderr_callback` called `coord_logger.warning(...)` for every line, *before* its existing (issue #871) filter even ran. That filter only recognized this app's own `[claude-docker] `-prefixed wrapper lines, not raw `docker build`/`pull` CLI output — so routine BuildKit build progress and `docker pull` layer output was unconditionally forwarded to the frontend as a warning-styled `stderr` system message.

This adds `classify_docker_output()` to `backend/docker_utils.py` (a shared, zero-dependency leaf module both files can safely import), returning one of `"failure"` / `"routine"` / `"ambiguous"`:

- **failure**: known failure signal (wrapper container-exit/kill/crash reporting, or a BuildKit build failure — the keyword list is extended with `ERROR:`, `failed to solve`, `did not complete successfully` to cover build-time failures, not just container-runtime ones).
- **routine**: recognized wrapper/BuildKit/pull progress — logged at low severity, never forwarded to the frontend.
- **ambiguous**: matches neither — logged at low severity (avoiding the original flooding bug) but **still forwarded/visible**, so a genuinely novel failure doesn't silently disappear.

Both `stderr_handler` and `_create_stderr_callback` now gate log severity on this classification; the coordinator additionally skips frontend-forwarding entirely for `"routine"` lines.

## Judgment calls flagged for reviewer attention

**1. The "ambiguous" bucket (by design, per the approved plan).** Only `"routine"` is a *positive, known-safe* classification. `"ambiguous"` output stays visible (forwarded to frontend, `coord_logger.info` in the coordinator) rather than also being suppressed, trading a little residual noise for not hiding real, unrecognized failures. This was a deliberate call in the approved plan — flagging per its own request for review rather than silently revisiting it.

**2. A related visibility wrinkle surfaced during review, in the same spirit as #1.** In `claude_sdk.py`'s `stderr_handler` specifically, `"routine"`/`"ambiguous"` lines are logged via `sdk_logger` (`get_logger('sdk_debug', category='SDK')`), which — per `shared/logging_config.py` — has no active handler below `ERROR` unless `--debug-sdk`/`--debug-permissions` is passed. This was the plan's explicit, approved design ("remains fully retrievable in `sdk_debug.log` (with `--debug-sdk`) ... without touching error.log/console"). Net effect: a *non-Docker* session's genuine CLI stderr (e.g. a stack trace) that doesn't match the Docker-specific failure keywords is classified `"ambiguous"` and no longer unconditionally hits `error.log`/console from this module — a real behavior change from "every stderr line always in error.log" (the very flooding bug being fixed).
   - In practice this is mitigated: `_create_stderr_callback` (the sole real-world consumer of `stderr_callback`, wired at every session start) independently re-classifies the same line and logs `"ambiguous"` via `coord_logger.info`, which **is** always-enabled (`coordinator.log` + console) and still forwards the message to the frontend UI — so the line isn't actually lost system-wide, just moved off `error.log` specifically.
   - Since `classify_docker_output()`'s vocabulary is Docker/BuildKit-specific but `stderr_handler` applies it to *all* sessions' CLI stderr (no `docker_enabled` gate), this is worth a second look — not changed here since it matches the approved plan's explicit design.

## Other review notes (non-blocking)

- `classify_docker_output()` is computed independently in both `claude_sdk.py` and `session_coordinator.py` for the same line (each file owns its own severity/forwarding decision) — minor duplicated dispatch logic, not fixed here to keep the diff plan-scoped.
- `_BUILDKIT_ROUTINE_RE`'s `done`/`cached` word-boundary match could in principle match a `RUN` step's own captured stdout containing "done" as ordinary text, not just BuildKit's completion marker — a narrow, unlikely edge case.
- `DOCKER_FAILURE_KEYWORDS`' `'ERROR:'` check is an exact-case, colon-suffixed substring and won't catch e.g. `"Error response from daemon: ..."` — such lines fall to `"ambiguous"` (still visible, just not escalated to `"failure"` severity).

## Test plan

- [x] New `backend/tests/test_docker_utils.py::TestClassifyDockerOutput` — full matrix from the plan (wrapper routine/failure, BuildKit completed-step lines, BuildKit step-start-without-completion → ambiguous, BuildKit failure line proving the keyword check wins over the `#N` prefix, `docker pull` layer lines, unrelated output → ambiguous).
- [x] New `backend/tests/test_claude_sdk.py::TestStderrHandlerClassification` — routine → no `ERROR` log record, failure → `ERROR` record with `[SDK_STDERR]`, buffer still accumulates both.
- [x] New `backend/tests/test_session_coordinator.py::TestIssue1837StderrCallbackClassification` — routine → not forwarded, failure → forwarded with `subtype: "stderr"`, ambiguous → still forwarded (documents the deliberate judgment call).
- [x] `uv run ruff check` clean on all changed files.
- [x] Full suite: `uv run pytest backend/tests/ src/tests/` — 2667 passed, 46 deselected, 0 failed.
- [ ] Manual Docker-isolated build verification not attempted in this sandbox (optional per plan).

Resolves #1837

🤖 Generated with [Claude Code](https://claude.com/claude-code)