### PR TITLE
fix: use model_fields_set to detect genuine session config customization

### DIFF
--- a/backend/session_coordinator.py
+++ b/backend/session_coordinator.py
@@ -5947,41 +5947,42 @@ class SessionCoordinator:
             logger.exception("Error during session coordinator cleanup")
 
     async def _init_session_overrides(self, session_id: str, config: "SessionConfig") -> None:
-        """Compute and store initial session_overrides for a template-linked session.
+        """Compute and store initial session.config overrides for a template-linked session.
 
-        Called at create time so that fields the user customised in the Create Session
-        dialog (before hitting Create) survive restarts instead of being overwritten
-        by the template defaults at resolve_effective_config time (#1079).
+        Called at create time so that fields the caller explicitly customised (present in
+        config.model_fields_set) survive restarts and later template edits, instead of being
+        silently dropped or, conversely, having merely-inherited values incorrectly frozen
+        (#1875). Always runs (even producing an empty override set) so it also clears out any
+        false-positive CONFIG_FIELDS entries create_session()'s cruder class-default-only
+        heuristic may have just written into session.config moments earlier.
         """
         if not config.template_id:
             return
         try:
             from backend.config_resolution import CONFIG_FIELDS, resolve_template_config
+            from backend.session_config import DEFAULTS
 
             template = await self.template_manager.get_template(config.template_id)
-            if template is None:
-                return
-
-            template_values = await resolve_template_config(template, self.profile_manager)
+            template_values = (
+                await resolve_template_config(template, self.profile_manager)
+                if template is not None
+                else {}  # invalid/deleted template_id — nothing to inherit from, fall
+                # through so the loop below still clears create_session()'s false positives
+            )
 
             overrides: dict = {}
             for field_name in CONFIG_FIELDS:
-                if not hasattr(config, field_name):
-                    continue
+                if field_name not in config.model_fields_set:
+                    continue  # caller never touched this field — not a customization
                 config_value = getattr(config, field_name)
                 if config_value is None:
-                    continue  # None = not set by user; never freeze as an override
-                template_value = template_values.get(field_name)
+                    continue  # explicit None = "inherit"; never freeze as an override
+                template_value = template_values.get(field_name, DEFAULTS.get(field_name))
                 if config_value != template_value:
                     overrides[field_name] = config_value
 
+            await self.session_manager.update_session(session_id, _replace_config=overrides)
             if overrides:
-                # Write directly — no template_manager so _track_overrides is skipped
-                # (we ARE the source of truth here, not a field mutation to track).
-                await self.session_manager.update_session(
-                    session_id,
-                    session_overrides=overrides,
-                )
                 coord_logger.debug(
                     f"Session {session_id} initial overrides computed: {list(overrides.keys())}"
                 )

--- a/backend/tests/integration/test_api_sessions_crud.py
+++ b/backend/tests/integration/test_api_sessions_crud.py
@@ -95,6 +95,42 @@ class TestCreateSession:
         })
         assert resp.status_code == 404
 
+    async def test_issue_1875_template_customization_matching_class_default_survives(
+        self, api_integration_env
+    ):
+        """POST /api/sessions with template_id + one explicit customized CONFIG_FIELDS
+        value must survive the full SessionCreateRequest -> model_copy() ->
+        coordinator.create_session() -> _init_session_overrides() chain, even when the
+        customization coincides with SessionConfig's class default (issue #1875 Case A)."""
+        client = api_integration_env["client"]
+        coordinator = api_integration_env["coordinator"]
+        create_project = api_integration_env["create_test_project"]
+
+        project = await create_project("Router 1875")
+        pid = project["project_id"]
+
+        template = await coordinator.template_manager.create_template(
+            name="Router Template 1875",
+            config=SessionConfig(permission_mode="plan"),
+        )
+
+        resp = await client.post("/api/sessions", json={
+            "project_id": pid,
+            "name": "Router Customized Session",
+            "template_id": template.template_id,
+            # Coincides with the SessionConfig class default, differs from the
+            # template's "plan" — the Case A regression, exercised end-to-end.
+            "permission_mode": "acceptEdits",
+        })
+        assert resp.status_code == 200
+        sid = resp.json()["session_id"]
+
+        resp2 = await client.get(f"/api/sessions/{sid}")
+        session = resp2.json()["session"]
+        assert session["config"].get("permission_mode") == "acceptEdits", (
+            "Explicit customization via the router must survive the full request chain"
+        )
+
 
 class TestListSessions:
     async def test_list_empty(self, api_integration_env):

--- a/backend/tests/test_session_coordinator.py
+++ b/backend/tests/test_session_coordinator.py
@@ -1546,6 +1546,237 @@ class TestIssue1115SessionConfigStorage:
 
 
 # ---------------------------------------------------------------------------
+# Issue #1875 — _init_session_overrides() false-negative/false-positive fix
+# ---------------------------------------------------------------------------
+
+
+class TestIssue1875InitSessionOverrides:
+    """Regression tests for issue #1875 — _init_session_overrides() must use
+    model_fields_set to detect genuine customization, not is-not-None / class-default
+    comparisons, and must persist via _replace_config (not the dead session_overrides=
+    kwarg)."""
+
+    async def _make_project(self, coordinator, suffix=""):
+        return await coordinator.project_manager.create_project(
+            name=f"Test Project {suffix}", working_directory="/tmp/test_1875"
+        )
+
+    async def test_false_negative_customization_matching_class_default_survives(
+        self, temp_coordinator
+    ):
+        """Case A: an explicit customization that happens to equal SessionConfig's class
+        default (but differs from the template's value) must be stored immediately, and
+        must still be honored after a later template edit."""
+        import uuid
+
+        coordinator = temp_coordinator
+        project = await self._make_project(coordinator, "case-a")
+
+        # Template sets permission_mode="plan" (differs from class default "acceptEdits").
+        template = await coordinator.template_manager.create_template(
+            name="Case A Template",
+            config=SessionConfig(permission_mode="plan"),
+        )
+
+        session_id = str(uuid.uuid4())
+        # Caller explicitly customizes permission_mode to "acceptEdits" — coincides with
+        # the SessionConfig class default, but is a real, explicit customization.
+        await coordinator.create_session(
+            session_id=session_id,
+            project_id=project.project_id,
+            config=SessionConfig(
+                template_id=template.template_id, permission_mode="acceptEdits"
+            ),
+        )
+
+        session_info = await coordinator.session_manager.get_session_info(session_id)
+        assert session_info.config.get("permission_mode") == "acceptEdits", (
+            "Explicit customization coinciding with the class default must survive "
+            "immediately at creation time"
+        )
+        resolved = await resolve_effective_config(session_info, coordinator.template_manager)
+        assert resolved.permission_mode == "acceptEdits"
+
+        # Editing the template afterward must NOT clobber the stored customization.
+        await coordinator.template_manager.update_template(
+            template.template_id, config={"permission_mode": "bypassPermissions"}
+        )
+        session_info2 = await coordinator.session_manager.get_session_info(session_id)
+        resolved2 = await resolve_effective_config(session_info2, coordinator.template_manager)
+        assert resolved2.permission_mode == "acceptEdits", (
+            "Customization must still win over the template's new value after a later edit"
+        )
+
+    async def test_invalid_template_id_still_clears_create_session_false_positives(
+        self, temp_coordinator
+    ):
+        """A template_id that doesn't resolve to a real template (deleted/invalid) must
+        not leave create_session()'s cruder class-default-diff false positives stuck in
+        session.config. Reproduces the real trigger: a request subclass like
+        MinionCreateRequest overrides permission_mode's own default away from
+        SessionConfig's ("manual" vs "acceptEdits"), so a value the caller never touched
+        (absent from model_fields_set) still differs from DEFAULTS and gets written by
+        session_manager.create_session()'s heuristic — model_construct with an empty
+        _fields_set reproduces that exact shape without needing the real subclass."""
+        import uuid
+
+        coordinator = temp_coordinator
+        project = await self._make_project(coordinator, "invalid-template")
+
+        session_id = str(uuid.uuid4())
+        config = SessionConfig.model_construct(
+            _fields_set=set(), permission_mode="manual", template_id="nonexistent-template-id"
+        )
+        await coordinator.create_session(
+            session_id=session_id,
+            project_id=project.project_id,
+            config=config,
+        )
+
+        session_info = await coordinator.session_manager.get_session_info(session_id)
+        assert "permission_mode" not in session_info.config, (
+            "An invalid template_id must not leave create_session()'s false-positive "
+            f"permission_mode frozen in session.config; got: {session_info.config}"
+        )
+
+    async def test_pure_inheritance_unaffected(self, temp_coordinator):
+        """A session created with template_id set and no CONFIG_FIELDS passed must not
+        have any CONFIG_FIELDS keys frozen into session.config, and must track template
+        edits automatically."""
+        import uuid
+
+        coordinator = temp_coordinator
+        project = await self._make_project(coordinator, "pure-inherit")
+
+        template = await coordinator.template_manager.create_template(
+            name="Pure Inherit Template",
+            config=SessionConfig(permission_mode="plan", model="opus"),
+        )
+
+        session_id = str(uuid.uuid4())
+        await coordinator.create_session(
+            session_id=session_id,
+            project_id=project.project_id,
+            config=SessionConfig(template_id=template.template_id),
+        )
+
+        session_info = await coordinator.session_manager.get_session_info(session_id)
+        from backend.config_resolution import CONFIG_FIELDS
+        stored_config_fields = set(session_info.config or {}) & CONFIG_FIELDS
+        assert stored_config_fields == set(), (
+            f"Pure inheritance must not freeze any CONFIG_FIELDS, got: {stored_config_fields}"
+        )
+
+        resolved = await resolve_effective_config(session_info, coordinator.template_manager)
+        assert resolved.permission_mode == "plan"
+        assert resolved.model == "opus"
+
+        # Template edit must propagate since nothing is frozen.
+        await coordinator.template_manager.update_template(
+            template.template_id, config={"permission_mode": "plan", "model": "haiku"}
+        )
+        session_info2 = await coordinator.session_manager.get_session_info(session_id)
+        resolved2 = await resolve_effective_config(session_info2, coordinator.template_manager)
+        assert resolved2.model == "haiku"
+
+    async def test_false_positive_value_matching_template_not_recorded_as_override(
+        self, temp_coordinator
+    ):
+        """Case B: a CONFIG_FIELDS value explicitly passed that happens to equal the
+        template's own value is not a real customization — it must not be frozen, and a
+        later template edit to that field must propagate."""
+        import uuid
+
+        coordinator = temp_coordinator
+        project = await self._make_project(coordinator, "case-b")
+
+        template = await coordinator.template_manager.create_template(
+            name="Case B Template",
+            config=SessionConfig(docker_enabled=True),
+        )
+
+        session_id = str(uuid.uuid4())
+        # Caller passes docker_enabled=True explicitly — matches the template's own
+        # value, so it is NOT a real customization.
+        await coordinator.create_session(
+            session_id=session_id,
+            project_id=project.project_id,
+            config=SessionConfig(template_id=template.template_id, docker_enabled=True),
+        )
+
+        session_info = await coordinator.session_manager.get_session_info(session_id)
+        assert "docker_enabled" not in session_info.config, (
+            "A value merely matching the template must not be recorded as an override"
+        )
+
+        # Editing the template must propagate since nothing was frozen.
+        await coordinator.template_manager.update_template(
+            template.template_id, config={"docker_enabled": False}
+        )
+        session_info2 = await coordinator.session_manager.get_session_info(session_id)
+        resolved2 = await resolve_effective_config(session_info2, coordinator.template_manager)
+        assert resolved2.docker_enabled is False, (
+            "Template edit must propagate to a session with no real override recorded"
+        )
+
+    async def test_spawn_minion_only_genuine_divergence_frozen(self, temp_coordinator):
+        """OverseerController.spawn_minion() passes nearly every CONFIG_FIELDS name
+        explicitly (by design). Only fields that genuinely diverge from the resolved
+        template value (parent-inheritance fallbacks) should end up in the child's
+        session.config — not every field spawn_minion happened to pass."""
+        import uuid
+
+        from backend.session_config import DEFAULTS
+
+        coordinator = temp_coordinator
+        project = await self._make_project(coordinator, "spawn-minion")
+
+        # Template sets docker_enabled=True; leaves thinking_mode unset (class default None).
+        template = await coordinator.template_manager.create_template(
+            name="Spawn Template",
+            config=SessionConfig(docker_enabled=True),
+        )
+
+        # Parent session (plain, no template) that can spawn minions.
+        parent_id = str(uuid.uuid4())
+        await coordinator.create_session(
+            session_id=parent_id,
+            project_id=project.project_id,
+            config=SessionConfig(),
+        )
+
+        # Mirror legion_mcp_tools.py's spawn_minion construction: pass essentially every
+        # CONFIG_FIELDS name explicitly. docker_enabled=True matches the template's own
+        # value (should be pruned); thinking_mode="think" is a genuine parent-inheritance
+        # fallback that diverges from the template's (class-default) value and must be
+        # frozen.
+        spawn_kwargs = dict(DEFAULTS)
+        spawn_kwargs["docker_enabled"] = True
+        spawn_kwargs["thinking_mode"] = "think"
+        spawn_config = SessionConfig(**spawn_kwargs, template_id=template.template_id)
+
+        result = await coordinator.legion_system.overseer_controller.spawn_minion(
+            parent_overseer_id=parent_id,
+            name="Child Minion",
+            role="Worker",
+            config=spawn_config,
+        )
+        child_id = result["minion_id"]
+
+        child_info = await coordinator.session_manager.get_session_info(child_id)
+        from backend.config_resolution import CONFIG_FIELDS
+        stored_config_fields = set(child_info.config or {}) & CONFIG_FIELDS
+        assert stored_config_fields == {"thinking_mode"}, (
+            "Only the genuine parent-inheritance-fallback field (thinking_mode) should be "
+            f"frozen, not every field spawn_minion happened to pass; got: {stored_config_fields}"
+        )
+        assert child_info.config.get("thinking_mode") == "think", (
+            "thinking_mode diverges from the template's (class-default) value — "
+            "a genuine parent-inheritance fallback that must be frozen"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Issue #1425 — Problem A: OAuth MCP credential bypass (5 scenarios)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Resolves #1875

`_init_session_overrides()` was persisting its computed overrides via a `session_overrides=` kwarg that `SessionManager.update_session()` doesn't support (removed by #1230's migration to the unified `config` dict), so the write silently no-op'd every time. That alone matches the issue's traced root cause.

However, this fix also closes a **second, more severe bug** that the issue's own text didn't anticipate: `SessionManager.create_session()` independently writes a cruder heuristic into `session.config` — any `CONFIG_FIELDS` value that differs from `SessionConfig`'s own class default, with zero template awareness. This runs unconditionally (not dead code) and, combined with the dead write above, produces two opposite-direction bugs that were both live in production:

- **False negative** (the issue's scenario, but worse than assumed): a caller explicitly customizes a field to a value that happens to *equal* `SessionConfig`'s class default (e.g. sets `permission_mode="acceptEdits"` while the template's own value is `"plan"`). `create_session()`'s heuristic skips storing it since it matches the class default, so the customization is lost **immediately at creation**, not just after a later template edit as the issue assumed.
- **False positive** (the issue's named edge case): a field inherited from the template, whose value simply differs from the class default (e.g. template sets `docker_enabled=True`, class default is `False`), gets baked into `session.config` as if customized. A later template edit to that field then silently fails to propagate.

## Changes Made

- `_init_session_overrides()` (`backend/session_coordinator.py`) now uses `config.model_fields_set` (native to every Pydantic `SessionConfig` instance, including `SessionCreateRequest`, `MinionCreateRequest`, and `spawn_minion`'s constructed config) to detect genuine customization — present regardless of whether the value happens to equal a default — instead of `is not None`, which can't distinguish "customized to the default" from "never touched."
- Diffs against the template's value with a `DEFAULTS` fallback for fields the template doesn't itself set (mirrors the same category of fix #1660 already applied to the 3 MCP-specific fields, generalized here to all `CONFIG_FIELDS`).
- Persists via the existing `_replace_config` verb instead of the dead `session_overrides=` kwarg, and runs **unconditionally** (not gated on a non-empty override set) so it also clears out any false-positive entries `create_session()`'s heuristic wrote moments earlier — this is what makes "pure template inheritance is unaffected" actually hold.
- **Review-pass fix**: the template lookup's `if template is None: return` previously short-circuited *before* the unconditional clear-out could run, so an invalid/deleted `template_id` left `create_session()`'s false positives stuck. Reachable via `POST /api/legions/{id}/minions`, since `MinionCreateRequest` overrides `permission_mode`'s own default away from `SessionConfig`'s (`"manual"` vs `"acceptEdits"`), and no caller validates `template_id` exists beforehand. Fixed by treating an unresolved template as an empty template-values dict rather than bailing out early.
- Read side (`resolve_effective_config()`) needed no changes — it already implements the 3-tier resolution chain correctly; this was a write-side-only bug.

## Testing

- Added `TestIssue1875InitSessionOverrides` (`backend/tests/test_session_coordinator.py`) covering:
  1. False-negative customization (coincides with class default) survives both immediately and after a later template edit
  2. Pure inheritance (no `CONFIG_FIELDS` passed) is unaffected and tracks template edits
  3. False-positive value (merely matches the template) is not recorded as an override, and later template edits propagate
  4. `spawn_minion` path only freezes genuine parent-inheritance-fallback fields, not every field the call happens to pass explicitly
  5. Invalid/deleted `template_id` still clears `create_session()`'s false positives (regression test verified to fail without the fix)
- Added a router-level integration test (`backend/tests/integration/test_api_sessions_crud.py`) exercising `POST /api/sessions` → `SessionCreateRequest` → `model_copy()` → `coordinator.create_session()` → `_init_session_overrides()` end-to-end.
- `TestIssue1115SessionConfigStorage` (pre-existing regression class for the same file) confirmed still green and unmodified — none of its cases set `template_id`.
- Ran a `builder-review` pass (8 finder angles + verification); the one confirmed correctness finding (invalid-template-id gap) is fixed above with a regression test, two minor cleanup findings were applied (dead `getattr` default, a spawn_minion test assertion strengthened to check the full field set), and remaining findings (helper-extraction opportunities across 4 call sites, a deliberate unconditional-persist tradeoff already justified in-line) were dismissed as out of scope or intentional.
- Full suite: `uv run pytest backend/tests/ src/tests/ -q` → 2647 passed.
- `uv run ruff check` → zero violations on all changed files.
- No frontend changes — the bug isn't reachable through the current session-creation UI (confirmed: no UI path exposes `CONFIG_FIELDS` at creation time while a template is selected), only through direct API/MCP-tool callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)