### PR TITLE
fix: propagate message_id for live-polled user messages to close reload dedup gap

### DIFF
--- a/backend/message_parser.py
+++ b/backend/message_parser.py
@@ -1080,6 +1080,17 @@ class UserMessageHandler(MessageHandler):
                 if key in orig_meta:
                     extracted["metadata"][key] = orig_meta[key]
 
+        # Issue #1845: capture the stable message_id assigned by
+        # data_storage.append_message() (top-level on the persisted dict, mirroring
+        # the live-broadcast dict since append_message mutates it in place before the
+        # message callback fires) so a live-polled user message carries the same id as
+        # its REST-loaded counterpart, letting frontend dedup catch redelivery races.
+        message_id = message_data.get("message_id")
+        if not message_id and isinstance(orig_meta, dict):
+            message_id = orig_meta.get("message_id")
+        if message_id:
+            extracted["metadata"]["message_id"] = message_id
+
         return extracted
 
 

--- a/backend/tests/test_message_parser.py
+++ b/backend/tests/test_message_parser.py
@@ -1002,6 +1002,68 @@ class TestIssue1486MessageIdPropagation:
         assert parsed.metadata.get("message_id") == "msg_stored456"
 
 
+class TestIssue1845UserMessageIdPropagation:
+    """Regression tests for issue #1845 reload-duplicated-user-message bug.
+
+    Root cause: UserMessageHandler never copied the stable message_id (assigned by
+    data_storage.append_message() at persistence time, before the same dict is passed
+    to the live message callback) into ParsedMessage.metadata. AssistantMessageHandler
+    already does this (issue #1486). Without it, a user message redelivered live via
+    the poll stream during the jsonl-write/queue-push race carries no id, so the
+    frontend's message_id-keyed dedup can't catch it and it renders twice.
+
+    Fix: UserMessageHandler now captures message_data["message_id"] (top-level, where
+    append_message() puts it) into metadata, with a fallback to a nested metadata
+    message_id for re-parsed stored dicts.
+    """
+
+    def test_user_message_id_captured_from_raw_dict(self):
+        """message_id set at the top level (live path, set by append_message()) is surfaced in parsed metadata."""
+        handler = UserMessageHandler()
+        message_data = {
+            "type": "user",
+            "content": "Please help me",
+            "session_id": "sess-1",
+            "timestamp": time.time(),
+            "message_id": "msg_user_abc123",
+        }
+        parsed = handler.parse(message_data)
+
+        assert parsed.metadata.get("message_id") == "msg_user_abc123", (
+            "Top-level message_id must be propagated so a live-polled user message "
+            "carries the same id as its REST-loaded counterpart"
+        )
+
+    def test_user_message_id_absent_when_none(self):
+        """metadata message_id is absent when no message_id is present anywhere."""
+        handler = UserMessageHandler()
+        message_data = {
+            "type": "user",
+            "content": "Please help me",
+            "session_id": "sess-1",
+            "timestamp": time.time(),
+        }
+        parsed = handler.parse(message_data)
+
+        assert "message_id" not in parsed.metadata or parsed.metadata["message_id"] is None
+
+    def test_user_message_id_restored_from_stored_dict(self):
+        """message_id is restored when re-parsing a stored user message that has it nested in metadata."""
+        handler = UserMessageHandler()
+        message_data = {
+            "type": "user",
+            "content": "Please help me",
+            "metadata": {
+                "message_id": "msg_user_stored456",
+            },
+            "session_id": "sess-1",
+            "timestamp": time.time(),
+        }
+        parsed = handler.parse(message_data)
+
+        assert parsed.metadata.get("message_id") == "msg_user_stored456"
+
+
 class TestIssue1840UsageExtraction:
     """Regression tests for issue #1840: subagent (Task/Agent tool) usage capture.
 

--- a/frontend/src/stores/__tests__/message.test.js
+++ b/frontend/src/stores/__tests__/message.test.js
@@ -27,6 +27,24 @@ describe('message store', () => {
     expect(store.messagesBySession.get('sess-1')[0].content).toBe('hi')
   })
 
+  it('addMessage skips a duplicate user message redelivered with the same message_id (#1845)', async () => {
+    // Regression test: backend/message_parser.py's UserMessageHandler now propagates
+    // the stable message_id assigned at persistence time, so a user message redelivered
+    // live via the poll stream (the jsonl-write/queue-push race #1845 describes) carries
+    // the same message_id as its already-loaded counterpart and this dedup catches it.
+    const { useMessageStore } = await import('@/stores/message')
+    const store = useMessageStore()
+
+    store.addMessage('sess-1', makeMessage({
+      type: 'user', content: 'Please help me', message_id: 'msg-user-dup'
+    }))
+    store.addMessage('sess-1', makeMessage({
+      type: 'user', content: 'Please help me', message_id: 'msg-user-dup'
+    }))
+
+    expect(store.messagesBySession.get('sess-1').length).toBe(1)
+  })
+
   it('loadMessages stores messages from paged API response', async () => {
     const { useMessageStore } = await import('@/stores/message')
     const store = useMessageStore()


### PR DESCRIPTION
## Summary
Resolves #1845

A user-sent chat message could render twice after a page reload. The frontend already dedups incoming messages by `message_id` (`frontend/src/stores/message.js`'s `addMessage()`), but `backend/message_parser.py`'s `UserMessageHandler` never propagated `message_id` into `ParsedMessage.metadata` the way `AssistantMessageHandler` already does (issue #1486). The REST history path worked around this with an explicit re-attachment in `session_coordinator.py`, but the live poll path only reads `message_id` from parsed metadata — which was empty for user messages. So a user message redelivered live during the jsonl-write/queue-push race carried no id, and the frontend dedup had nothing to match against, producing a visible duplicate.

## Changes Made
- `backend/message_parser.py`: `UserMessageHandler._extract_business_data()` now captures `message_id` from the top-level of the raw message dict (where `data_storage.append_message()` puts it, mutating the same dict later passed to the live message callback), with a fallback to a nested `metadata.message_id` for re-parsed stored dicts.
- `backend/tests/test_message_parser.py`: new `TestIssue1845UserMessageIdPropagation` test class covering id captured from the live-path dict, id absent when missing, and id restored on stored-dict re-parse.
- `frontend/src/stores/__tests__/message.test.js`: new test confirming `addMessage()` skips a duplicate user message when `message_id` matches an already-loaded message.

## Testing
- `uv run pytest backend/tests/ src/tests/ -v` — 2676 passed, 46 deselected
- `uv run ruff check backend/ src/` — clean
- Frontend `npx vitest run` — all passing except 2 pre-existing failures in `ProjectOverview.test.js` (issue #1733 batch-resume timing test), confirmed unrelated by reproducing them identically on the tree with this fix stashed out
- `builder-review` skill run against the diff — independently traced the full propagation chain (`data_storage.append_message()` → `claude_sdk.py` live callback → `message_parser.py` → `web_server.py`'s `_create_message_callback` → frontend `addMessage()` dedup) and found no issues; empty findings array

🤖 Generated with [Claude Code](https://claude.com/claude-code)