### PR TITLE
fix: make Frontend's local poll queue adopt Backend's real event cursor

### DIFF
--- a/shared/event_queue.py
+++ b/shared/event_queue.py
@@ -16,8 +16,29 @@ class EventQueue:
         self._oldest_cursor: int = 1
         self._waiters: list[asyncio.Event] = []
 
-    def append(self, event: dict) -> int:
-        self._cursor += 1
+    def append(self, event: dict, cursor: int | None = None) -> int:
+        if cursor is not None:
+            if self._events and cursor == self._cursor:
+                return self._cursor  # exact redelivery of the last-known event — idempotent skip
+            if not self._events or cursor != self._cursor + 1:
+                # Source's numbering doesn't extend contiguously from what we have
+                # (source was reset — e.g. Backend process restart, which can
+                # produce a *lower* cursor than what we last saw — or evicted past
+                # our last known position, a forward gap — or this is the very
+                # first event this queue has ever seen). Trust the new value and
+                # drop now-orphaned local history rather than mis-slicing against a
+                # broken oldest_cursor invariant; any `since` that lands in the
+                # dropped range legitimately falls into the existing "too old,
+                # here's everything we have" branch of events_since() below.
+                # Checking contiguity here (not just `cursor <= self._cursor`)
+                # matters: a restart's lower cursor must still hit this reset
+                # branch instead of being mistaken for an already-seen duplicate
+                # and silently dropped.
+                self._events = []
+                self._oldest_cursor = cursor
+            self._cursor = cursor
+        else:
+            self._cursor += 1
         self._events.append(event)
         if len(self._events) > self.MAX_SIZE:
             self._events.pop(0)

--- a/src/poll_relay.py
+++ b/src/poll_relay.py
@@ -87,7 +87,7 @@ class PollRelay:
         )
 
     async def _relay_loop(self, path: str, queue: EventQueue, session_id: str | None = None) -> None:
-        cursor = 0
+        cursor = queue.current_cursor
         while not self._stopped:
             if session_id is not None:
                 last_activity = self._session_last_activity.get(session_id, 0.0)
@@ -98,8 +98,14 @@ class PollRelay:
                     return
             try:
                 events, next_cursor = await self._poll_once(path, cursor)
-                for event in events:
-                    queue.append(event)
+                # Backend's events_since() guarantees a returned batch is contiguous
+                # (either a slice of retained events or the full retained window), so
+                # this formula recovers each event's real Backend cursor exactly —
+                # adopting it keeps the local queue in Backend's own cursor space
+                # instead of generating an independent numbering (issue #1886).
+                start_cursor = next_cursor - len(events) + 1
+                for i, event in enumerate(events):
+                    queue.append(event, cursor=start_cursor + i)
                 cursor = next_cursor
             except asyncio.CancelledError:
                 raise

--- a/src/tests/test_event_queue.py
+++ b/src/tests/test_event_queue.py
@@ -1,0 +1,134 @@
+"""Tests for shared/event_queue.py's explicit-cursor append() support (issue #1886).
+
+Frontend's local poll_relay-fed EventQueue must adopt Backend's real per-event
+cursor numbering instead of generating its own independent one, so a
+Backend-space `event_cursor` (as returned by GET /api/sessions/{id}/messages)
+resolves correctly against the local queue's events_since(). See plan-1886.md
+for the full root-cause writeup.
+"""
+
+from shared.event_queue import EventQueue
+
+
+def test_explicit_cursor_contiguous_append_behaves_like_auto_increment():
+    queue = EventQueue()
+    assert queue.append({"n": 1}, cursor=1) == 1
+    assert queue.append({"n": 2}, cursor=2) == 2
+    assert queue.append({"n": 3}, cursor=3) == 3
+
+    events, next_cursor = queue.events_since(0)
+    assert [e["n"] for e in events] == [1, 2, 3]
+    assert next_cursor == 3
+
+
+def test_explicit_cursor_exact_redelivery_is_a_noop():
+    queue = EventQueue()
+    queue.append({"n": 1}, cursor=1)
+    queue.append({"n": 2}, cursor=2)
+
+    result = queue.append({"n": "duplicate-of-2"}, cursor=2)
+
+    assert result == 2
+    events, next_cursor = queue.events_since(0)
+    assert [e["n"] for e in events] == [1, 2]  # not duplicated, not replaced
+    assert next_cursor == 2
+
+
+def test_explicit_cursor_forward_gap_drops_stale_history_and_anchors_fresh():
+    """Simulates Backend evicting events past the relay's last known position:
+    the next batch arrives with a cursor that skips ahead of self._cursor + 1."""
+    queue = EventQueue()
+    queue.append({"n": 1}, cursor=1)
+    queue.append({"n": 2}, cursor=2)
+
+    result = queue.append({"n": "gap"}, cursor=50)
+
+    assert result == 50
+    events, next_cursor = queue.events_since(0)
+    assert [e["n"] for e in events] == ["gap"]
+    assert next_cursor == 50
+
+    # An old `since` value now legitimately falls into the "too old, here's
+    # everything we currently have" fallback rather than mis-slicing.
+    events, next_cursor = queue.events_since(1)
+    assert [e["n"] for e in events] == ["gap"]
+    assert next_cursor == 50
+
+
+def test_explicit_cursor_backward_jump_is_treated_as_reset_not_silent_drop():
+    """Simulates a Backend process restart: backend/web_server.py recreates a
+    fresh EventQueue() (cursor 0) for every session on startup, so post-restart
+    events arrive at the relay carrying LOWER cursor numbers than the local
+    queue's already-consumed range. The new event must not be silently dropped
+    as a false-duplicate."""
+    queue = EventQueue()
+    queue.append({"n": "pre-restart-a"}, cursor=98)
+    queue.append({"n": "pre-restart-b"}, cursor=99)
+    queue.append({"n": "pre-restart-c"}, cursor=100)
+
+    result = queue.append({"n": "post-restart-1"}, cursor=1)
+
+    assert result == 1
+    events, next_cursor = queue.events_since(0)
+    assert [e["n"] for e in events] == ["post-restart-1"]
+    assert next_cursor == 1
+
+    # The next post-restart event continues to append contiguously as normal.
+    queue.append({"n": "post-restart-2"}, cursor=2)
+    events, next_cursor = queue.events_since(0)
+    assert [e["n"] for e in events] == ["post-restart-1", "post-restart-2"]
+    assert next_cursor == 2
+
+
+def test_explicit_cursor_backward_jump_self_heals_for_a_stale_high_since():
+    """The specific production trigger for the backward-jump/reset branch: a
+    browser tab (or an in-flight long-poll waiter) is holding the OLD,
+    pre-restart high `since` value at the moment of reset. events_since() must
+    not error or mis-slice — it reports "nothing yet" at the new, lower
+    current_cursor, which is exactly the signal src/routers/poll.py's callers
+    (frontend/src/stores/polling.js unconditionally adopts next_cursor) rely on
+    to self-correct onto the new cursor space rather than polling with the
+    stale value forever."""
+    queue = EventQueue()
+    for n in range(98, 101):
+        queue.append({"n": n}, cursor=n)
+    assert queue.current_cursor == 100
+
+    queue.append({"n": "post-restart-1"}, cursor=1)
+
+    events, next_cursor = queue.events_since(100)
+    assert events == []
+    assert next_cursor == 1  # lower than the stale `since` passed in — the self-heal signal
+
+    # Once the caller adopts that lower cursor, subsequent events resolve normally.
+    queue.append({"n": "post-restart-2"}, cursor=2)
+    events, next_cursor = queue.events_since(1)
+    assert [e["n"] for e in events] == ["post-restart-2"]
+    assert next_cursor == 2
+
+
+def test_explicit_cursor_first_ever_append_anchors_oldest_cursor():
+    """A relay-fed queue's very first append may start at any Backend cursor
+    value (e.g. a session whose relay starts well after session creation) —
+    oldest_cursor must anchor there, not stay at the class default of 1."""
+    queue = EventQueue()
+
+    queue.append({"n": "first"}, cursor=42)
+
+    events, next_cursor = queue.events_since(41)
+    assert [e["n"] for e in events] == ["first"]
+    assert next_cursor == 42
+
+    # since < oldest_cursor - 1 falls into the "too old" fallback correctly.
+    events, next_cursor = queue.events_since(0)
+    assert [e["n"] for e in events] == ["first"]
+    assert next_cursor == 42
+
+
+def test_default_no_cursor_append_path_is_unchanged():
+    queue = EventQueue()
+    assert queue.append({"n": 1}) == 1
+    assert queue.append({"n": 2}) == 2
+    events, next_cursor = queue.events_since(0)
+    assert [e["n"] for e in events] == [1, 2]
+    assert next_cursor == 2

--- a/src/tests/test_poll_relay.py
+++ b/src/tests/test_poll_relay.py
@@ -232,3 +232,143 @@ async def test_issue_1844_http_status_error_logs_full_traceback_and_retries(capl
 
     assert call_count >= 2  # retried past the failure
     assert "Backend returned an error response" in caplog.text
+
+
+# --- issue #1886: Backend-cursor passthrough (local queue adopts Backend's numbering) ---
+
+
+@pytest.mark.asyncio
+async def test_relay_restart_seeds_from_local_queue_cursor_not_zero():
+    """A relay task restarting after an idle-stop must resume from the local
+    queue's own cursor (now Backend's real numbering) instead of re-fetching
+    Backend's entire backlog from since=0 and re-numbering it independently."""
+    first_batch_done = asyncio.Event()
+
+    async def first_side_effect(*args, **kwargs):
+        if not first_batch_done.is_set():
+            first_batch_done.set()
+            return {"events": [{"n": 1}, {"n": 2}], "next_cursor": 2}
+        await asyncio.sleep(0.005)  # yield control — avoid starving the event loop
+        return {"events": [], "next_cursor": 2}
+
+    relay, backend_client, _, session_queues = _make_relay(get_json_side_effect=first_side_effect)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("src.poll_relay._SESSION_IDLE_TIMEOUT_SECONDS", 0.05)
+        relay.ensure_session_relay("sess-restart")
+        task = relay._session_tasks["sess-restart"]
+
+        for _ in range(300):
+            if task.done():
+                break
+            await asyncio.sleep(0.01)
+
+        queue = session_queues["sess-restart"]
+        assert task.done()
+        assert queue.current_cursor == 2  # matches Backend's next_cursor exactly
+
+        seen_since_values = []
+        reconnect_done = asyncio.Event()
+
+        async def second_side_effect(*args, **kwargs):
+            seen_since_values.append(kwargs["params"]["since"])
+            if not reconnect_done.is_set():
+                reconnect_done.set()
+                return {"events": [{"n": 3}], "next_cursor": 3}
+            await asyncio.sleep(0.005)  # yield control — avoid starving the event loop
+            return {"events": [], "next_cursor": 3}
+
+        backend_client.get_json.side_effect = second_side_effect
+
+        # Simulate a browser tab reconnecting after the idle-stop.
+        relay.ensure_session_relay("sess-restart")
+
+        for _ in range(300):
+            if queue.current_cursor == 3:
+                break
+            await asyncio.sleep(0.01)
+
+        assert queue.current_cursor == 3
+        events, next_cursor = queue.events_since(0)
+        assert [e["n"] for e in events] == [1, 2, 3]  # no gap, no redelivery
+        assert next_cursor == 3
+        assert seen_since_values[0] == 2  # seeded from the local queue, not 0
+
+        await relay.stop()
+
+
+@pytest.mark.asyncio
+async def test_end_to_end_backend_cursor_resolves_correctly_against_local_queue():
+    """A Backend-space event_cursor value (as GET /api/sessions/{id}/messages
+    would return) must resolve correctly against the local relay-fed queue via
+    events_since() — the whole point of adopting Backend's real numbering."""
+    first_batch_done = asyncio.Event()
+
+    async def side_effect(*args, **kwargs):
+        if not first_batch_done.is_set():
+            first_batch_done.set()
+            return {"events": [{"n": 1}, {"n": 2}, {"n": 3}], "next_cursor": 3}
+        await asyncio.sleep(100)
+
+    relay, backend_client, _, session_queues = _make_relay(get_json_side_effect=side_effect)
+    relay.ensure_session_relay("sess-e2e")
+
+    for _ in range(300):
+        if session_queues["sess-e2e"].current_cursor == 3:
+            break
+        await asyncio.sleep(0.01)
+
+    queue = session_queues["sess-e2e"]
+    assert queue.current_cursor == 3  # what GET /messages' event_cursor would report
+
+    # A browser that just bootstrapped via GET /messages resumes from that
+    # exact Backend-space cursor — no gap, no redelivery.
+    events, next_cursor = queue.events_since(3)
+    assert events == []
+    assert next_cursor == 3
+
+    events, next_cursor = queue.events_since(1)
+    assert [e["n"] for e in events] == [2, 3]
+    assert next_cursor == 3
+
+    await relay.stop()
+
+
+@pytest.mark.asyncio
+async def test_backend_restart_regression_delivers_next_event_exactly_once():
+    """Simulates a Backend process restart mid-poll: backend/web_server.py
+    recreates a fresh EventQueue() (cursor 0) for the session, so the relay
+    starts seeing low Backend cursor numbers again while the local queue still
+    holds the old, higher range. Must not raise, and the first genuinely new
+    event past the restart must be delivered exactly once — not dropped as a
+    false-duplicate, not delivered twice."""
+    call_count = 0
+
+    async def side_effect(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return {"events": [{"n": "pre-1"}, {"n": "pre-2"}], "next_cursor": 100}
+        if call_count == 2:
+            # Backend restarted: fresh queue, no events yet, low current cursor.
+            return {"events": [], "next_cursor": 0}
+        if call_count == 3:
+            # First genuinely new event generated after the restart.
+            return {"events": [{"n": "post-1"}], "next_cursor": 1}
+        await asyncio.sleep(0.005)  # yield control — avoid starving the event loop
+        return {"events": [], "next_cursor": 1}
+
+    relay, backend_client, _, session_queues = _make_relay(get_json_side_effect=side_effect)
+    relay.ensure_session_relay("sess-regress")
+
+    for _ in range(300):
+        if session_queues["sess-regress"].current_cursor == 1:
+            break
+        await asyncio.sleep(0.01)
+
+    queue = session_queues["sess-regress"]
+    events, next_cursor = queue.events_since(0)
+    assert [e["n"] for e in events] == ["post-1"]  # stale pre-restart history dropped
+    assert next_cursor == 1
+
+    await relay.stop()


### PR DESCRIPTION
## Summary
Resolves #1886

Frontend's relay-fed `EventQueue` (`src/poll_relay.py`) generated its own independent, auto-incrementing cursor numbering instead of matching Backend's real per-event cursor space. `GET /api/sessions/{id}/messages` returns a Backend-space `event_cursor`, but the browser's subsequent `/api/poll/session/{id}?since=<that number>` request was evaluated against the local queue's unrelated numbering — skipping events or resuming at the wrong point depending on how the two counters had drifted.

## Changes Made
- `shared/event_queue.py`: `EventQueue.append()` gains an optional `cursor` argument. When passed, the queue adopts that value directly instead of self-incrementing, with dedup (exact redelivery) and discontinuity-reset (forward eviction gap, or backward jump on a Backend process restart) handling. The no-argument path used by all Backend direct-write call sites is unchanged.
- `src/poll_relay.py`: `_relay_loop` seeds its polling cursor from `queue.current_cursor` instead of a hardcoded `0` (so a relay task restarting after an idle timeout resumes where it left off instead of re-fetching and re-numbering Backend's whole backlog), and threads each event's real Backend cursor through to `queue.append()` using the batch's `next_cursor` and length.
- Adds `src/tests/test_event_queue.py` and extends `src/tests/test_poll_relay.py`, covering: contiguous append, exact-duplicate dedup, forward-gap and backward-jump (Backend restart) resets, a stale-high-`since` self-heal case, relay-restart cursor seeding, end-to-end cursor equivalence, and the Backend-restart-regression interaction.

## Testing
- `uv run pytest backend/tests/ src/tests/` — 2686 passed, no regressions.
- Manual verification against live Frontend+Backend: created a session, confirmed `GET /api/sessions/{id}/messages`'s `event_cursor` and the subsequent long-poll's `next_cursor` line up exactly (both `7`), with `data/logs/polling.log` confirming zero gap and zero redelivery across a real message send/receive cycle.

## Note for reviewer
`builder-review` surfaced one real, out-of-plan-scope architectural gap I did not fix myself: `src/routers/system.py`'s `/api/system/restart` handler calls `webui.ui_queue.append({...})` directly with no cursor, on the same `ui_queue` object `poll_relay.py`'s relay now populates with Backend-space cursors. This is the one Frontend-side direct-write call site into a relay-fed queue — the plan only audited Backend's ~15 direct-write sites. In the narrow window between that append and the full process re-exec it triggers, a genuine Backend UI event whose real cursor happens to collide could be silently dropped (dedup false-positive), or local history (including the restart notice itself) could be wiped by the reset branch. Blast radius is bounded by the imminent full process restart, but the right fix (skip the shared cursor space for locally-originated events entirely? reserved sentinel? separate side-channel?) is a design call beyond this issue's scope, so I'm flagging it rather than guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)