### PR TITLE
fix: mount --settings tempfile into Docker container for auto-memory/Auto Mode

### DIFF
--- a/backend/docker/claude-docker
+++ b/backend/docker/claude-docker
@@ -139,11 +139,11 @@ while IFS='=' read -r name value; do
 done < <(env)
 
 # Scan arguments for file-based flags that need host files mounted into container
-# The SDK passes --append-system-prompt-file or --system-prompt-file with a temp file path
+# The SDK passes --append-system-prompt-file, --system-prompt-file, or --settings with a temp file path
 FILE_MOUNT_FLAGS=""
 PREV_ARG=""
 for arg in "$@"; do
-    if [ "$PREV_ARG" = "--append-system-prompt-file" ] || [ "$PREV_ARG" = "--system-prompt-file" ]; then
+    if [ "$PREV_ARG" = "--append-system-prompt-file" ] || [ "$PREV_ARG" = "--system-prompt-file" ] || [ "$PREV_ARG" = "--settings" ]; then
         if [ -f "$arg" ]; then
             FILE_MOUNT_FLAGS="$FILE_MOUNT_FLAGS -v $arg:$arg:ro"
         fi

--- a/backend/tests/test_docker_utils.py
+++ b/backend/tests/test_docker_utils.py
@@ -17,6 +17,7 @@ from backend.docker_utils import (
     cleanup_session_tmp,
     detect_docker_bridge_gateway,
     get_session_tmp_dir,
+    get_wrapper_script_path,
     resolve_docker_cli_path,
     translate_docker_tmp_path,
 )
@@ -359,3 +360,19 @@ class TestClassifyDockerOutput:
 
     def test_unrelated_output_is_ambiguous(self):
         assert classify_docker_output("Traceback (most recent call last):") == "ambiguous"
+
+
+# ---------------------------------------------------------------------------
+# claude-docker wrapper script: file-mount scan (issue #1894)
+# ---------------------------------------------------------------------------
+
+
+class TestWrapperScriptFileMountFlags:
+    def test_settings_flag_is_mounted_alongside_system_prompt_flags(self):
+        script_text = get_wrapper_script_path().read_text()
+        condition_line = next(
+            (line for line in script_text.splitlines() if "--system-prompt-file" in line), None
+        )
+        assert condition_line is not None, "file-mount scan condition not found in wrapper script"
+        assert "--append-system-prompt-file" in condition_line
+        assert "--settings" in condition_line


### PR DESCRIPTION
## Summary
- `backend/docker/claude-docker`'s file-mount scan bind-mounts host tempfile paths passed via `--append-system-prompt-file`/`--system-prompt-file` into the container at the identical path. PR #1891 introduced a new `--settings <tempfile>` flag (for auto-memory/Auto Mode config) but never added it to this scan, so the settings tempfile was unreachable inside the container and Docker-mode sessions with `auto_memory_mode` or Auto Mode classifier config set failed to start with `Error: Settings file not found: <path>`.
- Extends the existing scan condition to also match `--settings`, mirroring the proven system-prompt-file mount mechanism exactly. No changes to `backend/claude_sdk.py`'s temp-file creation/merge logic — that logic is correct and already covered by existing tests.
- Adds a regression test (`backend/tests/test_docker_utils.py::TestWrapperScriptFileMountFlags`) that reads the wrapper script's source and asserts `--settings` is present in the mount-scan condition, so a future new file-based CLI flag can't silently regress the same way.

Resolves #1894

## Test plan
- [x] `uv run pytest backend/tests/test_docker_utils.py backend/tests/test_claude_sdk.py -q` — 94 passed
- [x] `uv run ruff check backend/tests/test_docker_utils.py` — no violations
- [x] `bash -n backend/docker/claude-docker` — syntax valid
- [ ] Manual live-Docker verification (session with `auto_memory_mode`/Auto Mode config starts without "Settings file not found") — **not performed**: this sandboxed environment has no `docker` binary available, so end-to-end container-start verification could not be run here. Recommend a maintainer with Docker access confirm before/after merge, per the plan's manual testing strategy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)