### PR TITLE
feat: expose full schedule UUID and add name-based lookup for schedule tools

### DIFF
--- a/backend/legion/mcp/legion_mcp_tools.py
+++ b/backend/legion/mcp/legion_mcp_tools.py
@@ -335,10 +335,12 @@ class LegionMCPTools:
         @tool(
             "pause_schedule",
             "Pause one of your active schedules. The schedule will stop firing until resumed."
-            "\n\nParameters:"
-            "\n- schedule_id: The ID of the schedule to pause",
+            "\n\nParameters (provide exactly one of schedule_id/schedule_name):"
+            "\n- schedule_id: The ID of the schedule to pause"
+            "\n- schedule_name: The name of the schedule to pause (must be one of your own schedules)",
             {
                 "schedule_id": str,
+                "schedule_name": str,
             }
         )
         async def pause_schedule_tool(args: dict[str, Any]) -> dict[str, Any]:
@@ -350,10 +352,12 @@ class LegionMCPTools:
             "resume_schedule",
             "Resume one of your paused schedules. The schedule will start firing again "
             "from the next cron window."
-            "\n\nParameters:"
-            "\n- schedule_id: The ID of the schedule to resume",
+            "\n\nParameters (provide exactly one of schedule_id/schedule_name):"
+            "\n- schedule_id: The ID of the schedule to resume"
+            "\n- schedule_name: The name of the schedule to resume (must be one of your own schedules)",
             {
                 "schedule_id": str,
+                "schedule_name": str,
             }
         )
         async def resume_schedule_tool(args: dict[str, Any]) -> dict[str, Any]:
@@ -364,10 +368,12 @@ class LegionMCPTools:
         @tool(
             "delete_schedule",
             "Delete one of your schedules permanently."
-            "\n\nParameters:"
-            "\n- schedule_id: The ID of the schedule to delete",
+            "\n\nParameters (provide exactly one of schedule_id/schedule_name):"
+            "\n- schedule_id: The ID of the schedule to delete"
+            "\n- schedule_name: The name of the schedule to delete (must be one of your own schedules)",
             {
                 "schedule_id": str,
+                "schedule_name": str,
             }
         )
         async def delete_schedule_tool(args: dict[str, Any]) -> dict[str, Any]:
@@ -383,13 +389,17 @@ class LegionMCPTools:
             "it is bound to, or its session configuration via this tool. You can "
             "only update schedules that belong to you."
             "\n\nParameters:"
-            "\n- schedule_id: The ID of the schedule to update"
+            "\n- schedule_id: The ID of the schedule to update (provide exactly one of schedule_id/schedule_name)"
+            "\n- schedule_name: The name of the schedule to update, used to find it "
+            "(must be one of your own schedules). This is independent of 'name' below — "
+            "'schedule_name' looks the schedule up, 'name' renames it."
             "\n- name (optional): New display name for the schedule"
             "\n- prompt (optional): New prompt text. Only valid for prompt-type schedules. Must be non-empty"
             "\n- cron_expression (optional): New cron expression (5-field standard cron). "
             "Examples: '0 8 * * 1-5' (weekdays 8am), '*/30 * * * *' (every 30 min)",
             {
                 "schedule_id": str,
+                "schedule_name": str,
                 "name": str,
                 "prompt": str,
                 "cron_expression": str,
@@ -1993,7 +2003,7 @@ class LegionMCPTools:
                         "%Y-%m-%d %H:%M %Z"
                     )
                 lines.append(
-                    f"\n- **{s.name}** (ID: {s.schedule_id[:8]}...)\n"
+                    f"\n- **{s.name}** (ID: {s.schedule_id})\n"
                     f"  - Cron: `{s.cron_expression}`\n"
                     f"  - Status: {s.status.value}\n"
                     f"  - Next run: {next_run_str}\n"
@@ -2007,25 +2017,54 @@ class LegionMCPTools:
         except Exception as e:
             return self._err(f"Unexpected error listing schedules: {e}")
 
+    async def _resolve_schedule_for_args(
+        self, from_minion_id: str, args: dict[str, Any], action_verb: str
+    ) -> tuple[Any, dict[str, Any] | None]:
+        """Resolve a schedule from args' schedule_id/schedule_name for a mutation handler.
+
+        Returns (schedule, None) on success, or (None, error_result) on failure —
+        callers should `return` the error_result directly when it is not None.
+        """
+        from backend.legion.scheduler_service import (
+            ScheduleAmbiguousNameError,
+            ScheduleNotFoundError,
+            ScheduleOwnershipError,
+        )
+
+        schedule_id = (args.get("schedule_id") or "").strip()
+        schedule_name = (args.get("schedule_name") or "").strip()
+        if not schedule_id and not schedule_name:
+            return None, self._err("Error: Provide either schedule_id or schedule_name")
+
+        try:
+            schedule = await self.system.scheduler_service.resolve_schedule_for_minion(
+                from_minion_id,
+                schedule_id=schedule_id or None,
+                schedule_name=schedule_name or None,
+            )
+            return schedule, None
+        except ScheduleNotFoundError as e:
+            return None, self._err(f"Error: Schedule {e.identifier} not found")
+        except ScheduleAmbiguousNameError as e:
+            return None, self._err(
+                f"Error: Multiple schedules named '{e.schedule_name}' found ({e.count}). "
+                "Use schedule_id to disambiguate."
+            )
+        except ScheduleOwnershipError:
+            return None, self._err(f"Error: You can only {action_verb} your own schedules")
+
     async def _handle_pause_schedule(self, args: dict[str, Any]) -> dict[str, Any]:
         """Handle pause_schedule tool call."""
         from_minion_id = args.get("_from_minion_id")
-        schedule_id = args.get("schedule_id", "").strip()
-
         if not from_minion_id:
             return self._err("Error: Unable to determine minion ID")
-        if not schedule_id:
-            return self._err("Error: schedule_id is required")
 
-        # Validate ownership
-        schedule = await self.system.scheduler_service.get_schedule(schedule_id)
-        if not schedule:
-            return self._err(f"Error: Schedule {schedule_id} not found")
-        if schedule.minion_id != from_minion_id:
-            return self._err("Error: You can only pause your own schedules")
+        schedule, err = await self._resolve_schedule_for_args(from_minion_id, args, "pause")
+        if err:
+            return err
 
         try:
-            await self.system.scheduler_service.pause_schedule(schedule_id)
+            await self.system.scheduler_service.pause_schedule(schedule.schedule_id)
             return {
                 "content": [{"type": "text", "text": f"Schedule '{schedule.name}' paused successfully."}],
                 "is_error": False,
@@ -2038,21 +2077,15 @@ class LegionMCPTools:
     async def _handle_resume_schedule(self, args: dict[str, Any]) -> dict[str, Any]:
         """Handle resume_schedule tool call."""
         from_minion_id = args.get("_from_minion_id")
-        schedule_id = args.get("schedule_id", "").strip()
-
         if not from_minion_id:
             return self._err("Error: Unable to determine minion ID")
-        if not schedule_id:
-            return self._err("Error: schedule_id is required")
 
-        schedule = await self.system.scheduler_service.get_schedule(schedule_id)
-        if not schedule:
-            return self._err(f"Error: Schedule {schedule_id} not found")
-        if schedule.minion_id != from_minion_id:
-            return self._err("Error: You can only resume your own schedules")
+        schedule, err = await self._resolve_schedule_for_args(from_minion_id, args, "resume")
+        if err:
+            return err
 
         try:
-            updated = await self.system.scheduler_service.resume_schedule(schedule_id)
+            updated = await self.system.scheduler_service.resume_schedule(schedule.schedule_id)
 
             from datetime import datetime
             next_run_str = "N/A"
@@ -2076,21 +2109,15 @@ class LegionMCPTools:
     async def _handle_delete_schedule(self, args: dict[str, Any]) -> dict[str, Any]:
         """Handle delete_schedule tool call."""
         from_minion_id = args.get("_from_minion_id")
-        schedule_id = args.get("schedule_id", "").strip()
-
         if not from_minion_id:
             return self._err("Error: Unable to determine minion ID")
-        if not schedule_id:
-            return self._err("Error: schedule_id is required")
 
-        schedule = await self.system.scheduler_service.get_schedule(schedule_id)
-        if not schedule:
-            return self._err(f"Error: Schedule {schedule_id} not found")
-        if schedule.minion_id != from_minion_id:
-            return self._err("Error: You can only delete your own schedules")
+        schedule, err = await self._resolve_schedule_for_args(from_minion_id, args, "delete")
+        if err:
+            return err
 
         try:
-            await self.system.scheduler_service.delete_schedule(schedule_id)
+            await self.system.scheduler_service.delete_schedule(schedule.schedule_id)
             return {
                 "content": [{"type": "text", "text": f"Schedule '{schedule.name}' deleted."}],
                 "is_error": False,
@@ -2103,18 +2130,12 @@ class LegionMCPTools:
     async def _handle_update_schedule(self, args: dict[str, Any]) -> dict[str, Any]:
         """Handle update_schedule tool call."""
         from_minion_id = args.get("_from_minion_id")
-        schedule_id = args.get("schedule_id", "").strip()
-
         if not from_minion_id:
             return self._err("Error: Unable to determine minion ID")
-        if not schedule_id:
-            return self._err("Error: schedule_id is required")
 
-        schedule = await self.system.scheduler_service.get_schedule(schedule_id)
-        if not schedule:
-            return self._err(f"Error: Schedule {schedule_id} not found")
-        if schedule.minion_id != from_minion_id:
-            return self._err("Error: You can only update your own schedules")
+        schedule, err = await self._resolve_schedule_for_args(from_minion_id, args, "update")
+        if err:
+            return err
 
         name = args.get("name")
         prompt = args.get("prompt")
@@ -2146,9 +2167,9 @@ class LegionMCPTools:
         from backend.legion.scheduler_service import _ScheduleAutoDeletedError
 
         try:
-            updated = await self.system.scheduler_service.update_schedule(schedule_id, **fields)
+            updated = await self.system.scheduler_service.update_schedule(schedule.schedule_id, **fields)
         except _ScheduleAutoDeletedError:
-            return self._err(f"Schedule {schedule_id} was auto-deleted (repeat count exhausted)")
+            return self._err(f"Schedule {schedule.schedule_id} was auto-deleted (repeat count exhausted)")
         except ValueError as e:
             return self._err(f"Error: {e}")
 

--- a/backend/legion/scheduler_service.py
+++ b/backend/legion/scheduler_service.py
@@ -48,6 +48,37 @@ class _ScheduleAutoDeletedError(Exception):
         super().__init__("schedule auto-deleted")
         self.schedule = schedule
 
+
+class ScheduleLookupError(Exception):
+    """Base class for resolve_schedule_for_minion() failures."""
+
+
+class ScheduleNotFoundError(ScheduleLookupError):
+    """No schedule matched the given identifier."""
+
+    def __init__(self, identifier_type: str, identifier: str):
+        super().__init__(f"Schedule not found by {identifier_type}: {identifier}")
+        self.identifier_type = identifier_type
+        self.identifier = identifier
+
+
+class ScheduleAmbiguousNameError(ScheduleLookupError):
+    """More than one of the caller's own schedules share the given name."""
+
+    def __init__(self, schedule_name: str, count: int):
+        super().__init__(f"Ambiguous schedule name '{schedule_name}': {count} matches")
+        self.schedule_name = schedule_name
+        self.count = count
+
+
+class ScheduleOwnershipError(ScheduleLookupError):
+    """The resolved schedule is not owned by the calling minion."""
+
+    def __init__(self, schedule: "Schedule"):
+        super().__init__(f"Schedule {schedule.schedule_id} is not owned by the caller")
+        self.schedule = schedule
+
+
 TICK_INTERVAL = 30  # seconds between scheduler evaluations
 
 
@@ -221,6 +252,42 @@ class SchedulerService:
     async def get_schedule(self, schedule_id: str) -> Schedule | None:
         """Get a single schedule by ID."""
         return self._schedules.get(schedule_id)
+
+    async def resolve_schedule_for_minion(
+        self,
+        minion_id: str,
+        schedule_id: str | None = None,
+        schedule_name: str | None = None,
+    ) -> Schedule:
+        """Resolve a schedule owned by minion_id, by ID or by name.
+
+        ID lookups are global-then-ownership-checked. Name lookups are pre-scoped
+        to the calling minion's own schedules, so a name collision with another
+        minion's schedule is invisible — it surfaces as not-found, never as
+        someone else's schedule.
+
+        Raises:
+            ScheduleNotFoundError: No schedule matched the given identifier.
+            ScheduleAmbiguousNameError: More than one of the caller's schedules share the name.
+            ScheduleOwnershipError: The ID-resolved schedule belongs to a different minion.
+        """
+        if schedule_id:
+            schedule = self._schedules.get(schedule_id)
+            if not schedule:
+                raise ScheduleNotFoundError("ID", schedule_id)
+            if schedule.minion_id != minion_id:
+                raise ScheduleOwnershipError(schedule)
+            return schedule
+
+        matches = [
+            s for s in self._schedules.values()
+            if s.minion_id == minion_id and s.name == schedule_name
+        ]
+        if not matches:
+            raise ScheduleNotFoundError("name", schedule_name)
+        if len(matches) > 1:
+            raise ScheduleAmbiguousNameError(schedule_name, len(matches))
+        return matches[0]
 
     async def update_schedule(self, schedule_id: str, **fields) -> Schedule:
         """Update mutable schedule fields (name, cron_expression, prompt, max_retries, timeout_seconds).

--- a/backend/tests/test_legion_mcp_tools.py
+++ b/backend/tests/test_legion_mcp_tools.py
@@ -973,6 +973,7 @@ def _make_update_schedule_tools(
     from unittest.mock import AsyncMock, MagicMock
 
     from backend.legion.mcp.legion_mcp_tools import LegionMCPTools
+    from backend.legion.scheduler_service import ScheduleNotFoundError, ScheduleOwnershipError
     from backend.models.schedule_models import ScheduleStatus
 
     if schedule is None:
@@ -988,6 +989,15 @@ def _make_update_schedule_tools(
     mock_svc = MagicMock()
     resolved_get = schedule if get_schedule_return is _SENTINEL else get_schedule_return
     mock_svc.get_schedule = AsyncMock(return_value=resolved_get)
+
+    async def _resolve_side_effect(minion_id, schedule_id=None, schedule_name=None):
+        if not resolved_get:
+            raise ScheduleNotFoundError("ID" if schedule_id else "name", schedule_id or schedule_name)
+        if resolved_get.minion_id != minion_id:
+            raise ScheduleOwnershipError(resolved_get)
+        return resolved_get
+
+    mock_svc.resolve_schedule_for_minion = AsyncMock(side_effect=_resolve_side_effect)
 
     if update_side_effect is not None:
         mock_svc.update_schedule = AsyncMock(side_effect=update_side_effect)
@@ -1640,3 +1650,213 @@ async def test_issue_1433_list_minions_parent_unknown_fallback():
     assert result.get("is_error") is False, f"Got error: {result}"
     text = result["content"][0]["text"]
     assert "Parent: unknown" in text, f"Should show 'Parent: unknown'; got:\n{text}"
+
+
+# ── Schedule name-based lookup tests (Issue #1817) ──
+
+
+def _make_schedule_mock(schedule_id="sched-abc", minion_id="minion-123", name="My Schedule"):
+    from unittest.mock import MagicMock
+
+    from backend.models.schedule_models import ScheduleStatus
+
+    schedule = MagicMock()
+    schedule.schedule_id = schedule_id
+    schedule.minion_id = minion_id
+    schedule.schedule_type = "prompt"
+    schedule.name = name
+    schedule.cron_expression = "0 8 * * *"
+    schedule.next_run = None
+    schedule.status = ScheduleStatus.ACTIVE
+    schedule.execution_count = 0
+    schedule.failure_count = 0
+    return schedule
+
+
+def _make_mutation_tools(resolve_return=None, resolve_side_effect=None):
+    """Build LegionMCPTools with a mocked scheduler_service for mutation-handler tests."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from backend.legion.mcp.legion_mcp_tools import LegionMCPTools
+
+    mock_svc = MagicMock()
+    if resolve_side_effect is not None:
+        mock_svc.resolve_schedule_for_minion = AsyncMock(side_effect=resolve_side_effect)
+    else:
+        mock_svc.resolve_schedule_for_minion = AsyncMock(return_value=resolve_return)
+    mock_svc.pause_schedule = AsyncMock(return_value=resolve_return)
+    mock_svc.resume_schedule = AsyncMock(return_value=resolve_return)
+    mock_svc.delete_schedule = AsyncMock(return_value=True)
+    mock_svc.update_schedule = AsyncMock(return_value=resolve_return)
+
+    mock_system = MagicMock()
+    mock_system.scheduler_service = mock_svc
+    return LegionMCPTools(mock_system), mock_svc
+
+
+@pytest.mark.asyncio
+async def test_issue_1817_list_schedules_shows_full_uuid():
+    """AC1/T1: list_schedules output must contain the full untruncated schedule_id."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from backend.legion.mcp.legion_mcp_tools import LegionMCPTools
+
+    full_id = "11111111-2222-3333-4444-555555555555"
+    schedule = _make_schedule_mock(schedule_id=full_id, minion_id="minion-123")
+
+    session = MagicMock()
+    session.project_id = "legion-1"
+    session_manager = MagicMock()
+    session_manager.get_session_info = AsyncMock(return_value=session)
+    session_coordinator = MagicMock()
+    session_coordinator.session_manager = session_manager
+
+    scheduler_service = MagicMock()
+    scheduler_service.list_schedules = AsyncMock(return_value=[schedule])
+
+    mock_system = MagicMock()
+    mock_system.session_coordinator = session_coordinator
+    mock_system.scheduler_service = scheduler_service
+
+    tools = LegionMCPTools(mock_system)
+    result = await tools._handle_list_schedules({"_from_minion_id": "minion-123"})
+
+    assert result.get("is_error") is False
+    text = result["content"][0]["text"]
+    assert full_id in text
+    assert f"{full_id[:8]}..." not in text
+
+
+@pytest.mark.asyncio
+async def test_issue_1817_pause_schedule_by_name():
+    """T3: pause_schedule resolves by schedule_name and pauses the resolved ID."""
+    schedule = _make_schedule_mock(schedule_id="sched-abc", name="Daily Report")
+    tools, svc = _make_mutation_tools(resolve_return=schedule)
+
+    result = await tools._handle_pause_schedule({
+        "_from_minion_id": "minion-123",
+        "schedule_name": "Daily Report",
+    })
+
+    assert result.get("is_error") is False, f"Got error: {result}"
+    svc.resolve_schedule_for_minion.assert_awaited_once_with(
+        "minion-123", schedule_id=None, schedule_name="Daily Report"
+    )
+    svc.pause_schedule.assert_awaited_once_with("sched-abc")
+
+
+@pytest.mark.asyncio
+async def test_issue_1817_resume_schedule_by_name():
+    """T3: resume_schedule resolves by schedule_name and resumes the resolved ID."""
+    schedule = _make_schedule_mock(schedule_id="sched-abc", name="Daily Report")
+    tools, svc = _make_mutation_tools(resolve_return=schedule)
+
+    result = await tools._handle_resume_schedule({
+        "_from_minion_id": "minion-123",
+        "schedule_name": "Daily Report",
+    })
+
+    assert result.get("is_error") is False, f"Got error: {result}"
+    svc.resume_schedule.assert_awaited_once_with("sched-abc")
+
+
+@pytest.mark.asyncio
+async def test_issue_1817_delete_schedule_by_name():
+    """T4: delete_schedule resolves by schedule_name and deletes the resolved ID."""
+    schedule = _make_schedule_mock(schedule_id="sched-abc", name="Daily Report")
+    tools, svc = _make_mutation_tools(resolve_return=schedule)
+
+    result = await tools._handle_delete_schedule({
+        "_from_minion_id": "minion-123",
+        "schedule_name": "Daily Report",
+    })
+
+    assert result.get("is_error") is False, f"Got error: {result}"
+    svc.delete_schedule.assert_awaited_once_with("sched-abc")
+
+
+@pytest.mark.asyncio
+async def test_issue_1817_update_schedule_by_name_and_rename_together():
+    """AC5/T5: update_schedule accepts schedule_name (lookup) and name (rename) together,
+    passing only the rename value 'name' through to the service, not the lookup key."""
+    schedule = _make_schedule_mock(schedule_id="sched-abc", name="Old Name")
+    tools, svc = _make_mutation_tools(resolve_return=schedule)
+
+    result = await tools._handle_update_schedule({
+        "_from_minion_id": "minion-123",
+        "schedule_name": "Old Name",
+        "name": "New Name",
+    })
+
+    assert result.get("is_error") is False, f"Got error: {result}"
+    svc.resolve_schedule_for_minion.assert_awaited_once_with(
+        "minion-123", schedule_id=None, schedule_name="Old Name"
+    )
+    svc.update_schedule.assert_awaited_once_with("sched-abc", name="New Name")
+
+
+@pytest.mark.asyncio
+async def test_issue_1817_missing_both_identifiers_returns_error():
+    """Missing both schedule_id and schedule_name → is_error=True; resolver not called."""
+    tools, svc = _make_mutation_tools()
+
+    result = await tools._handle_pause_schedule({"_from_minion_id": "minion-123"})
+
+    assert result.get("is_error") is True
+    assert "schedule_id" in result["content"][0]["text"] or "schedule_name" in result["content"][0]["text"]
+    svc.resolve_schedule_for_minion.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_issue_1817_not_found_by_name_error_references_name():
+    """T6/AC7: not-found-by-name error text must reference the name, not a raw UUID."""
+    from backend.legion.scheduler_service import ScheduleNotFoundError
+
+    tools, svc = _make_mutation_tools(
+        resolve_side_effect=ScheduleNotFoundError("name", "Nonexistent Schedule")
+    )
+
+    result = await tools._handle_pause_schedule({
+        "_from_minion_id": "minion-123",
+        "schedule_name": "Nonexistent Schedule",
+    })
+
+    assert result.get("is_error") is True
+    assert "Nonexistent Schedule" in result["content"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_issue_1817_ambiguous_name_error():
+    """AC6: ambiguous schedule_name match surfaces a distinct error, not a silent pick."""
+    from backend.legion.scheduler_service import ScheduleAmbiguousNameError
+
+    tools, svc = _make_mutation_tools(
+        resolve_side_effect=ScheduleAmbiguousNameError("Daily Report", 2)
+    )
+
+    result = await tools._handle_pause_schedule({
+        "_from_minion_id": "minion-123",
+        "schedule_name": "Daily Report",
+    })
+
+    assert result.get("is_error") is True
+    assert "Daily Report" in result["content"][0]["text"]
+    svc.pause_schedule.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_issue_1817_ownership_error_keeps_action_specific_wording():
+    """T7: ownership failures keep each handler's existing action-specific wording."""
+    from backend.legion.scheduler_service import ScheduleOwnershipError
+
+    schedule = _make_schedule_mock(schedule_id="sched-abc", minion_id="minion-OTHER")
+    tools, svc = _make_mutation_tools(resolve_side_effect=ScheduleOwnershipError(schedule))
+
+    result = await tools._handle_delete_schedule({
+        "_from_minion_id": "minion-123",
+        "schedule_id": "sched-abc",
+    })
+
+    assert result.get("is_error") is True
+    assert "own schedules" in result["content"][0]["text"].lower()
+    svc.delete_schedule.assert_not_called()

--- a/backend/tests/test_schedule_status_migration.py
+++ b/backend/tests/test_schedule_status_migration.py
@@ -16,7 +16,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from backend.legion.scheduler_service import SchedulerService
+from backend.legion.scheduler_service import ScheduleOwnershipError, SchedulerService
 from backend.models.schedule_models import Schedule, ScheduleStatus
 
 
@@ -229,7 +229,7 @@ class TestDeleteScheduleMCPTool:
             schedule_id="sched-mcp-1", legion_id="leg-1", name="MySchedule",
             cron_expression="0 * * * *", prompt="p", minion_id="minion-mcp-1",
         )
-        scheduler.get_schedule = AsyncMock(return_value=schedule)
+        scheduler.resolve_schedule_for_minion = AsyncMock(return_value=schedule)
         scheduler.delete_schedule = AsyncMock(return_value=True)
         system.scheduler_service = scheduler
 
@@ -254,7 +254,7 @@ class TestDeleteScheduleMCPTool:
             schedule_id="sched-mcp-2", legion_id="leg-1", name="OtherSchedule",
             cron_expression="0 * * * *", prompt="p", minion_id="other-minion",
         )
-        scheduler.get_schedule = AsyncMock(return_value=schedule)
+        scheduler.resolve_schedule_for_minion = AsyncMock(side_effect=ScheduleOwnershipError(schedule))
         scheduler.delete_schedule = AsyncMock()
         system.scheduler_service = scheduler
 

--- a/backend/tests/test_scheduler_service.py
+++ b/backend/tests/test_scheduler_service.py
@@ -16,7 +16,13 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from backend.legion.scheduler_service import SchedulerService, _ScheduleAutoDeletedError
+from backend.legion.scheduler_service import (
+    ScheduleAmbiguousNameError,
+    ScheduleNotFoundError,
+    ScheduleOwnershipError,
+    SchedulerService,
+    _ScheduleAutoDeletedError,
+)
 from backend.models.schedule_models import Schedule, ScheduleStatus, get_next_run
 
 # ---------------------------------------------------------------------------
@@ -78,11 +84,12 @@ def _make_schedule(
     minion_id: str = "sess-1",
     repeat_count: int | None = None,
     fire_count: int = 0,
+    name: str = "Test Schedule",
 ) -> Schedule:
     return Schedule(
         schedule_id=schedule_id,
         legion_id=legion_id,
-        name="Test Schedule",
+        name=name,
         cron_expression="*/1 * * * *",
         prompt="do something",
         minion_id=minion_id,
@@ -263,3 +270,84 @@ async def test_update_schedule_set_repeat_count_to_unlimited():
 
     assert updated.repeat_count is None
     assert schedule.schedule_id in svc._schedules
+
+
+# ---------------------------------------------------------------------------
+# 7. resolve_schedule_for_minion (issue #1817)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_by_id_success():
+    svc = _make_svc()
+    schedule = _make_schedule(schedule_id="sched-1", minion_id="sess-1")
+    svc._schedules[schedule.schedule_id] = schedule
+
+    resolved = await svc.resolve_schedule_for_minion("sess-1", schedule_id="sched-1")
+
+    assert resolved is schedule
+
+
+@pytest.mark.asyncio
+async def test_resolve_by_id_not_found():
+    svc = _make_svc()
+
+    with pytest.raises(ScheduleNotFoundError):
+        await svc.resolve_schedule_for_minion("sess-1", schedule_id="does-not-exist")
+
+
+@pytest.mark.asyncio
+async def test_resolve_by_id_wrong_owner():
+    svc = _make_svc()
+    schedule = _make_schedule(schedule_id="sched-1", minion_id="sess-owner")
+    svc._schedules[schedule.schedule_id] = schedule
+
+    with pytest.raises(ScheduleOwnershipError):
+        await svc.resolve_schedule_for_minion("sess-other", schedule_id="sched-1")
+
+
+@pytest.mark.asyncio
+async def test_resolve_by_name_success():
+    svc = _make_svc()
+    schedule = _make_schedule(schedule_id="sched-1", minion_id="sess-1", name="Daily Report")
+    svc._schedules[schedule.schedule_id] = schedule
+
+    resolved = await svc.resolve_schedule_for_minion("sess-1", schedule_name="Daily Report")
+
+    assert resolved is schedule
+
+
+@pytest.mark.asyncio
+async def test_resolve_by_name_not_found():
+    svc = _make_svc()
+    schedule = _make_schedule(schedule_id="sched-1", minion_id="sess-1", name="Daily Report")
+    svc._schedules[schedule.schedule_id] = schedule
+
+    with pytest.raises(ScheduleNotFoundError):
+        await svc.resolve_schedule_for_minion("sess-1", schedule_name="Nonexistent")
+
+
+@pytest.mark.asyncio
+async def test_resolve_by_name_ambiguous():
+    svc = _make_svc()
+    s1 = _make_schedule(schedule_id="sched-1", minion_id="sess-1", name="Duplicate")
+    s2 = _make_schedule(schedule_id="sched-2", minion_id="sess-1", name="Duplicate")
+    svc._schedules[s1.schedule_id] = s1
+    svc._schedules[s2.schedule_id] = s2
+
+    with pytest.raises(ScheduleAmbiguousNameError) as exc_info:
+        await svc.resolve_schedule_for_minion("sess-1", schedule_name="Duplicate")
+
+    assert exc_info.value.count == 2
+
+
+@pytest.mark.asyncio
+async def test_resolve_by_name_scoped_away_from_other_minions_same_named_schedule():
+    """A name collision with another minion's schedule must surface as not-found,
+    never resolve to the other minion's schedule."""
+    svc = _make_svc()
+    other_schedule = _make_schedule(schedule_id="sched-other", minion_id="sess-other", name="Shared Name")
+    svc._schedules[other_schedule.schedule_id] = other_schedule
+
+    with pytest.raises(ScheduleNotFoundError):
+        await svc.resolve_schedule_for_minion("sess-1", schedule_name="Shared Name")


### PR DESCRIPTION
## Summary
Resolves #1817

Two independent improvements to the Legion scheduler MCP tools:
1. `list_schedules` now prints the full, untruncated `schedule_id` instead of an 8-character prefix, so agents don't need an extra lookup call to get a usable identifier.
2. `pause_schedule`/`resume_schedule`/`delete_schedule`/`update_schedule` now accept a `schedule_name` parameter as an alternative to `schedule_id`, so agents can reference their own schedules by name instead of tracking raw UUIDs.

## Changes Made
- `backend/legion/scheduler_service.py`: added `ScheduleNotFoundError`, `ScheduleAmbiguousNameError`, `ScheduleOwnershipError`, and `resolve_schedule_for_minion(minion_id, schedule_id=None, schedule_name=None)`. ID lookups stay global-then-ownership-checked (unchanged semantics); name lookups are pre-scoped to the calling minion's own schedules, so a name collision with another minion's schedule surfaces as not-found, never as someone else's schedule.
- `backend/legion/mcp/legion_mcp_tools.py`: fixed the `list_schedules` truncation; added `schedule_name` to the 4 mutation tool schemas/docstrings (`update_schedule`'s `schedule_name` lookup param is documented as independent from its existing `name` rename param); rewrote the four mutation handlers to share a `_resolve_schedule_for_args` helper that calls the new resolver and maps its exceptions to each handler's existing action-specific error wording.
- `backend/tests/test_scheduler_service.py`: unit tests for `resolve_schedule_for_minion` (by-ID and by-name success/not-found/ambiguous/ownership/cross-minion-scoping cases).
- `backend/tests/test_legion_mcp_tools.py` / `test_schedule_status_migration.py`: handler-level tests for name-based lookup, `schedule_name`+`name` used together on `update_schedule`, missing-both-identifiers, ambiguous-name, and ownership-error wording; updated two pre-existing `test_schedule_status_migration.py` tests that mocked the now-removed `get_schedule()` call path.

## Testing
- `uv run pytest backend/tests/` — 2578 passed
- `uv run ruff check` — clean on all touched files
- Ran the `builder-review` skill against the diff (8 finder angles + verification); applied two low-risk quality fixes it surfaced (reuse the exception's own `identifier` attribute instead of re-deriving it; deduplicated a near-identical test helper). Dismissed as out-of-scope/subjective: the JSON-schema-marks-all-tool-params-required limitation (pre-existing behavior of this file's `@tool` schema pattern, not introduced by this change) and the `schedule_id`-takes-silent-priority-over-`schedule_name`-when-both-given edge case (minor, no clear "correct" behavior specified by the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)