### PR TITLE
security: pin restrictedpython to >=8.3 via uv override

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ dev = [
     "mypy>=1.7.0",
 ]
 
+[tool.uv]
+override-dependencies = ["restrictedpython>=8.3"]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,9 @@ resolution-markers = [
     "python_full_version < '3.14'",
 ]
 
+[manifest]
+overrides = [{ name = "restrictedpython", specifier = ">=8.3" }]
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
@@ -441,7 +444,7 @@ wheels = [
 
 [[package]]
 name = "claudecode-webui"
-version = "1.5.0"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "claude-agent-sdk" },
@@ -2382,11 +2385,11 @@ wheels = [
 
 [[package]]
 name = "restrictedpython"
-version = "8.1"
+version = "8.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5f/1c/aec08bcb4ab14a1521579fbe21ceff2a634bb1f737f11cf7f9c8bb96e680/restrictedpython-8.1.tar.gz", hash = "sha256:4a69304aceacf6bee74bdf153c728221d4e3109b39acbfe00b3494927080d898", size = 838331, upload-time = "2025-10-19T14:11:32.531Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/3b/8e41f7cfabbb30b1013ebc7484303d6c87da2906ec432d69dea11d2f7d75/restrictedpython-8.5.tar.gz", hash = "sha256:4ed1269dbe3caa88db650d1af325198a952aeb1451eca05df0cfa65db4466215", size = 455879, upload-time = "2026-08-19T07:02:10.934Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/c0/3848f4006f7e164ee20833ca984067e4b3fc99fe7f1dfa88b4927e681299/restrictedpython-8.1-py3-none-any.whl", hash = "sha256:4769449c6cdb10f2071649ba386902befff0eff2a8fd6217989fa7b16aeae926", size = 27651, upload-time = "2025-10-19T14:11:30.201Z" },
+    { url = "https://files.pythonhosted.org/packages/58/57/16ce3c721f5a33317e4110575d5c9976c0c45f7fd96ca2e0adeab06e6026/restrictedpython-8.5-py3-none-any.whl", hash = "sha256:6c70e0a3af13e830d37225788cdc8ab5804a8df4b500c135086eaef34b5c01e0", size = 30962, upload-time = "2026-08-19T07:02:09.553Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Resolves #1897

Dependabot alert #46 flags `RestrictedPython` 8.1 (transitive, via `litellm[proxy]`) for
GHSA-ffg3-p8fm-mjx2 / CVE-2026-55830, patched in 8.3. This adds a `uv` dependency override to
force the transitive resolution to `>=8.3`, with zero application code changes.

## Reachability Investigation (Definition of Done requirement)

**Every RestrictedPython call site in the installed litellm package (1.98.0)** is exactly one
module: `litellm/proxy/guardrails/guardrail_hooks/custom_code/sandbox.py`
- `build_sandbox_globals()` (lines 101-116) wires the guard hooks the CVE targets:
  `_getattr_` → `safer_getattr`, `_getitem_` → `default_guarded_getitem`, `_write_` → `full_write_guard`.
- `compile_sandboxed()` (lines 119-130) calls `compile_restricted(source=source, ..., mode="exec", policy=AsyncAwareTransformer)`.

Callers:
- `litellm/proxy/guardrails/guardrail_hooks/custom_code/custom_code_guardrail.py:151-153` —
  `CustomCodeGuardrail._do_compile()` compiles and `exec()`s an admin-authored
  `apply_guardrail(inputs, request_data, input_type)` function.
- `litellm/proxy/guardrails/guardrail_endpoints.py:2080-2084` — a "test custom code guardrail"
  POST endpoint, gated by `if user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN: raise HTTPException(403, ...)`.

**This project's litellm usage** (`backend/litellm_proxy_manager.py`):
- Runs litellm's proxy embedded (`litellm.proxy.proxy_server.app`, served directly via
  `uvicorn.Server`), but **never calls litellm's own `ProxyConfig.load_config()`** with a YAML
  config — no `guardrails:` block exists anywhere in this repo
  (`grep -rniI "guardrail" backend/ src/ shared/` → 0 hits).
- `auth_callback()` returns `UserAPIKeyAuth(...)` with `user_role` unset (defaults to `None`,
  never `PROXY_ADMIN`); no master key is configured anywhere
  (`grep -rn "master_key\|MASTER_KEY\|PROXY_ADMIN"` → 0 hits in backend/src).

**Conclusion**: The vulnerable code path (`CustomCodeGuardrail`/`sandbox.py`) requires either an
explicit `guardrails:` config entry or a `PROXY_ADMIN`-role API key to reach — neither exists in
this deployment. The vulnerable path is confirmed unreachable, even from a fully compromised
claudecode_webui session/virtual key, since the feature is never wired up and the one interactive
endpoint is admin-gated.

The bump is applied anyway since it's low-risk and directly satisfies the issue's Definition of
Done: litellm 1.98.0's own dependency metadata (`Requires-Dist: restrictedpython>=8.1,<9.0 ;
extra == 'proxy'`) already permits `>=8.3`, so no litellm version bump is needed — `uv.lock` had
simply resolved to the oldest satisfying version. RestrictedPython's changelog shows no breaking
API changes between 8.1 and 8.5 affecting any symbol `sandbox.py` imports.

## Changes Made
- `pyproject.toml`: add `[tool.uv]` section with `override-dependencies = ["restrictedpython>=8.3"]`
- `uv.lock`: regenerated via `uv lock`; `restrictedpython` now resolves to `8.5`

No application code changes.

## Testing
- `grep -A2 'name = "restrictedpython"' uv.lock` confirms version `8.5` (satisfies `>=8.3`)
- `uv run python -c "import litellm.proxy.proxy_server"` — imports cleanly
- `uv run pytest backend/tests/ src/tests/ -v` — 2752 passed, 46 deselected (slow), 0 failed
- `uv run ruff check src/` — all checks passed (zero violations)
- `builder-review` correctness/quality pass — no findings (diff is a minimal 2-file
  dependency-resolution change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)