### PR TITLE
fix: stop mixing cursor disciplines on ui_queue

### DIFF
--- a/shared/event_queue.py
+++ b/shared/event_queue.py
@@ -17,6 +17,18 @@ class EventQueue:
         self._waiters: list[asyncio.Event] = []
 
     def append(self, event: dict, cursor: int | None = None) -> int:
+        """Append an event, either auto-incrementing the local cursor (cursor=None)
+        or adopting an externally-authoritative cursor value.
+
+        A given queue instance must pick exactly one discipline and stick to it:
+        the `cursor` param's contiguity/reset logic below assumes every write to
+        this instance comes from the same authoritative numbering scheme. Mixing
+        an auto-incrementing writer with a cursor-adopting writer on the same
+        instance breaks that assumption — an auto-increment bump can collide with
+        or desync the adopted cursor space, causing a dropped event (dedup branch)
+        or a full local-history wipe (reset branch) on the next adopted write
+        (issue #1890).
+        """
         if cursor is not None:
             if self._events and cursor == self._cursor:
                 return self._cursor  # exact redelivery of the last-known event — idempotent skip

--- a/src/poll_relay.py
+++ b/src/poll_relay.py
@@ -23,6 +23,16 @@ defeating #1598's unread-detection fix. ensure_session_relay() is called on
 every local poll request and refreshes the last-activity timestamp; the loop
 checks it and stops itself once idle, restarting lazily next time a real
 browser poll arrives.
+
+_relay_loop's append discipline differs by stream (issue #1890): session
+queues adopt Backend's own cursor numbering (required — see event_cursor
+handoff in backend/routers/sessions.py and frontend/src/stores/message.js),
+while the UI queue uses plain auto-increment, since no REST contract ever
+exposes a Backend-derived cursor for that stream to the browser. The UI
+queue also has a second local writer (src/routers/system.py's restart
+notice); mixing cursor-adoption and auto-increment on one EventQueue
+instance violates the queue's one-discipline-per-instance invariant and can
+silently drop or wipe events.
 """
 
 import asyncio
@@ -98,14 +108,28 @@ class PollRelay:
                     return
             try:
                 events, next_cursor = await self._poll_once(path, cursor)
-                # Backend's events_since() guarantees a returned batch is contiguous
-                # (either a slice of retained events or the full retained window), so
-                # this formula recovers each event's real Backend cursor exactly —
-                # adopting it keeps the local queue in Backend's own cursor space
-                # instead of generating an independent numbering (issue #1886).
-                start_cursor = next_cursor - len(events) + 1
-                for i, event in enumerate(events):
-                    queue.append(event, cursor=start_cursor + i)
+                if session_id is not None:
+                    # Session queues: local numbering must match Backend's real cursor
+                    # space — GET /api/sessions/{id}/messages hands the browser a
+                    # Backend-space event_cursor it later polls
+                    # /api/poll/session/{id}?since= against (issue #1886/#1889).
+                    # Backend's events_since() guarantees a returned batch is
+                    # contiguous, so this formula recovers each event's real Backend
+                    # cursor exactly.
+                    start_cursor = next_cursor - len(events) + 1
+                    for i, event in enumerate(events):
+                        queue.append(event, cursor=start_cursor + i)
+                else:
+                    # UI queue: no Backend-derived cursor is ever exposed to the
+                    # browser for this stream (no REST endpoint hands out a "global
+                    # event cursor"), so there is no contract requiring this queue's
+                    # numbering to match Backend's. Plain auto-increment keeps this
+                    # queue on the SAME discipline /api/system/restart's direct local
+                    # write already uses (src/routers/system.py) — mixing disciplines
+                    # on one queue caused #1890 (a local auto-increment bump colliding
+                    # with/desyncing Backend's adopted cursor space).
+                    for event in events:
+                        queue.append(event)
                 cursor = next_cursor
             except asyncio.CancelledError:
                 raise

--- a/src/routers/system.py
+++ b/src/routers/system.py
@@ -437,6 +437,11 @@ def build_router(webui) -> APIRouter:
 
         # Append restart notice to the local UI poll queue — same event shape Backend
         # already used for its own restart broadcast, so no frontend JS change is needed.
+        # This write and poll_relay.py's _ui_task both intentionally use the
+        # auto-increment discipline (no cursor= arg) for ui_queue (issue #1890) — do
+        # not reintroduce cursor adoption on one writer without also revisiting the
+        # other, since mixing disciplines on one EventQueue instance can silently
+        # drop or wipe events.
         try:
             webui.ui_queue.append({
                 "type": "server_restarting",

--- a/src/tests/test_poll_relay.py
+++ b/src/tests/test_poll_relay.py
@@ -372,3 +372,76 @@ async def test_backend_restart_regression_delivers_next_event_exactly_once():
     assert next_cursor == 1
 
     await relay.stop()
+
+
+# --- issue #1890: ui_queue local-write / relay-cursor collision ---
+
+
+@pytest.mark.asyncio
+async def test_ui_relay_uses_auto_increment_not_backend_cursor():
+    """The UI queue has no Backend-derived cursor contract — no REST endpoint
+    ever hands the browser a "global event cursor" to resolve against
+    (unlike sessions' event_cursor). The relay must number ui_queue events
+    with its own auto-increment, not adopt Backend's next_cursor verbatim."""
+    first_batch_done = asyncio.Event()
+
+    async def side_effect(*args, **kwargs):
+        if not first_batch_done.is_set():
+            first_batch_done.set()
+            return {"events": [{"type": "message", "n": 1}], "next_cursor": 500}
+        await asyncio.sleep(100)
+
+    relay, backend_client, ui_queue, _ = _make_relay(get_json_side_effect=side_effect)
+    relay.start_ui_relay()
+
+    for _ in range(300):
+        if ui_queue.current_cursor:
+            break
+        await asyncio.sleep(0.01)
+
+    assert ui_queue.current_cursor == 1  # local auto-increment, not Backend's next_cursor=500
+    events, next_cursor = ui_queue.events_since(0)
+    assert [e["n"] for e in events] == [1]
+    assert next_cursor == 1
+
+    await relay.stop()
+
+
+@pytest.mark.asyncio
+async def test_ui_queue_local_write_and_relay_write_do_not_collide():
+    """Core regression test for #1890: a direct local write (simulating
+    /api/system/restart's ui_queue.append) and a relay-delivered event on the
+    SAME EventQueue instance must not collide. Under the pre-fix
+    cursor-adoption behavior, a relay event whose computed Backend-derived
+    cursor happened to equal the queue's already-bumped local cursor would be
+    silently dropped as a duplicate (shared/event_queue.py's dedup branch)."""
+    first_batch_done = asyncio.Event()
+
+    async def side_effect(*args, **kwargs):
+        if not first_batch_done.is_set():
+            first_batch_done.set()
+            # Chosen so pre-fix cursor-adoption arithmetic (next_cursor - len + 1)
+            # would land exactly on 1 — the cursor the direct write below already
+            # bumped to, triggering the dedup-skip branch and dropping this event.
+            return {"events": [{"type": "message", "n": "relay-1"}], "next_cursor": 1}
+        await asyncio.sleep(100)
+
+    relay, backend_client, ui_queue, _ = _make_relay(get_json_side_effect=side_effect)
+
+    # Simulate /api/system/restart's direct local write happening first.
+    ui_queue.append({"type": "server_restarting", "n": "restart-notice"})
+    assert ui_queue.current_cursor == 1
+
+    relay.start_ui_relay()
+
+    for _ in range(300):
+        events, _ = ui_queue.events_since(0)
+        if len(events) >= 2:
+            break
+        await asyncio.sleep(0.01)
+
+    events, next_cursor = ui_queue.events_since(0)
+    assert [e["n"] for e in events] == ["restart-notice", "relay-1"]  # no drop, no reset
+    assert next_cursor == 2
+
+    await relay.stop()

--- a/src/tests/test_system_router.py
+++ b/src/tests/test_system_router.py
@@ -14,6 +14,7 @@ so they always described Backend's repo, never Frontend's own — in embedded mo
 this happened to look correct only because it's the same checkout.
 """
 
+import asyncio
 import logging
 import subprocess
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -23,6 +24,8 @@ import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
+from shared.event_queue import EventQueue
+from src.poll_relay import PollRelay
 from src.routers.system import _finish_restart, build_router
 
 
@@ -105,6 +108,95 @@ class TestRestartDefaultPath:
 
         assert first.status_code == 202
         assert second.status_code == 429
+
+
+class TestRestartNoticeAgainstLiveQueue:
+    """Issue #1890: every other test in this file mocks webui.ui_queue.append
+    entirely (see _make_webui), so the restart-notice write never touches real
+    EventQueue state — exactly how the original ui_queue local-write/relay-cursor
+    collision shipped untested. This exercises the real EventQueue plus a running
+    (mocked-backend) UI relay task sharing that same instance."""
+
+    @pytest.mark.asyncio
+    async def test_restart_notice_survives_concurrent_relay_delivery(self):
+        # Embedded mode: skips _restart_remote_backend's health()/ready()/
+        # request_json() awaits entirely, so restart_server's own body runs with
+        # no internal await before its ui_queue.append call — needed so the
+        # relay's release below deterministically lands AFTER the restart
+        # notice, not racing it via an unrelated await point.
+        webui = _make_webui(backend_supervisor=MagicMock(stop=AsyncMock()))
+        webui.ui_queue = EventQueue()
+
+        release_relay = asyncio.Event()
+        delivered = asyncio.Event()
+
+        async def get_json_side_effect(*args, **kwargs):
+            await release_relay.wait()
+            if not delivered.is_set():
+                delivered.set()
+                # Chosen so pre-#1890-fix cursor-adoption arithmetic would land
+                # exactly on the cursor the restart notice's auto-increment write
+                # already bumped ui_queue to (1), triggering the old dedup-skip
+                # branch instead of appending this event.
+                return {"events": [{"type": "message", "n": "relay-1"}], "next_cursor": 1}
+            await asyncio.sleep(100)
+
+        backend_client = MagicMock()
+        backend_client.get_json = AsyncMock(side_effect=get_json_side_effect)
+        relay = PollRelay(backend_client, webui.ui_queue, {})
+        relay.start_ui_relay()
+
+        def run_side_effect(cmd, **kwargs):
+            if cmd == ["git", "pull"]:
+                return _fake_completed(stdout="Already up to date.\n")
+            if cmd == ["uv", "sync"]:
+                return _fake_completed(stdout="Synced\n")
+            raise AssertionError(f"Unexpected subprocess.run call: {cmd}")
+
+        finish_restart_task = None
+        try:
+            with (
+                patch("src.routers.system.subprocess.run", side_effect=run_side_effect),
+                patch("src.routers.system.os.execv"),
+            ):
+                async with AsyncClient(transport=ASGITransport(app=webui.app), base_url="http://test") as client:
+                    resp = await client.post("/api/system/restart")
+
+                assert resp.status_code == 202
+                assert webui.ui_queue.current_cursor == 1  # restart notice landed via auto-increment
+
+                # restart_server() scheduled _finish_restart fire-and-forget — it's
+                # irrelevant to this test's ui_queue collision scenario, and letting
+                # its background 0.5s-later real-os.execv call race this test's own
+                # polling below (rather than being cancelled outright) would make
+                # safety depend on incidental timing instead of being deterministic.
+                for task in asyncio.all_tasks():
+                    if getattr(task.get_coro(), "__name__", "") == "_finish_restart":
+                        finish_restart_task = task
+                        task.cancel()
+
+                # Only now let the relay deliver its event, guaranteeing the collision
+                # ordering: local write first, adopted-cursor-shaped relay write second.
+                release_relay.set()
+
+                for _ in range(300):
+                    events, _ = webui.ui_queue.events_since(0)
+                    if len(events) >= 2:
+                        break
+                    await asyncio.sleep(0.01)
+
+            events, _ = webui.ui_queue.events_since(0)
+            markers = [(e.get("type"), e.get("n")) for e in events]
+            assert ("server_restarting", None) in markers
+            assert ("message", "relay-1") in markers
+            assert len(events) == 2  # neither writer's event was dropped or wiped
+        finally:
+            await relay.stop()
+            if finish_restart_task is not None:
+                try:
+                    await finish_restart_task
+                except asyncio.CancelledError:
+                    pass
 
 
 class TestRestartCustomTarget:


### PR DESCRIPTION
## Summary
Resolves #1890

`src/poll_relay.py`'s `_relay_loop` always adopted Backend's explicit cursor numbering for every relayed event, including the UI queue (`ui_queue`) — a side effect of #1889's fix for #1886. That discipline is required for per-session queues (their Backend-space `event_cursor` is handed to the browser via `GET /api/sessions/{id}/messages` and later polled against), but `ui_queue` has no such REST contract — no endpoint ever exposes a Backend-derived cursor for that stream to the browser.

`src/routers/system.py`'s `/api/system/restart` handler also writes directly to `ui_queue` using plain auto-increment (no `cursor=`). Mixing both disciplines on one `EventQueue` instance violates its one-discipline-per-instance invariant: a local auto-increment bump can collide with or desync the relay's adopted cursor space, silently dropping the next relayed event (dedup branch) or wiping the queue's entire local history (reset branch) — most likely to manifest right after a restart, since the restart handler's blocking `git pull`/`uv sync` calls stall the event loop (and the relay task with it) for up to several minutes.

## Changes Made
- `src/poll_relay.py`: branch `_relay_loop`'s append call on `session_id` — session queues keep cursor-adoption (required), the UI queue (`session_id is None`) reverts to plain auto-increment, matching the restart handler's existing discipline. Updated module docstring to document the split.
- `src/routers/system.py`: comment-only update noting both `ui_queue` writers now intentionally share the auto-increment discipline (no behavior change — this write already used auto-increment).
- `shared/event_queue.py`: doc-only clarification of `append()`'s one-discipline-per-instance contract.
- `src/tests/test_poll_relay.py`: two new regression tests — one pinning the UI relay's auto-increment behavior, one reproducing the exact collision (direct local write + relay-delivered event on the same queue instance) that #1890 hit.
- `src/tests/test_system_router.py`: new test exercising the restart-notice write against a *real* `EventQueue` + a running (mocked-backend) UI relay task, since every other test in that file mocks `ui_queue.append` entirely — which is how the original bug shipped untested.

## Testing
- `uv run pytest src/tests/test_poll_relay.py src/tests/test_event_queue.py src/tests/test_system_router.py -v` — 48 passed.
- `uv run pytest backend/tests/ src/tests/ -q` (full suite) — 2755 passed, 46 deselected, 0 failed.
- `uv run ruff check` on all changed files — zero violations.
- Confirmed both new/updated regression tests fail against the pre-fix `poll_relay.py` (reproducing the original collision) and pass against the fix.
- Confirmed the 3 existing session-cursor-adoption tests in `test_poll_relay.py` still pass unmodified.
- Manual verification (start Frontend+Backend, trigger `/api/system/restart` while polling `/api/poll/ui`) was not performed in this session — no UI/frontend files are touched by this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)