### PR TITLE
fix: correct MCP tool schemas to mark params required only when true

### DIFF
--- a/backend/legion/mcp/legion_mcp_tools.py
+++ b/backend/legion/mcp/legion_mcp_tools.py
@@ -16,7 +16,7 @@ Tools are exposed to minions with names like: mcp__legion__send_comm
 import asyncio
 import uuid
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NotRequired, TypedDict
 
 try:
     from claude_agent_sdk import create_sdk_mcp_server, tool
@@ -36,6 +36,83 @@ legion_logger = get_logger('legion', 'MCP_TOOLS')
 
 if TYPE_CHECKING:
     from backend.legion_system import LegionSystem
+
+
+class SendCommInput(TypedDict):
+    to_minion_name: str                    # Exact name of target minion (case-sensitive)
+    summary: NotRequired[str]              # Specific one-sentence update (actionable)
+    content: NotRequired[str]              # Details only if summary needs elaboration (supports markdown)
+    comm_type: NotRequired[str]            # One of: task, question, report, info
+    interrupt_priority: NotRequired[str]   # Optional: "none", "halt", or "pivot" (default: "none")
+    attachments: NotRequired[str]          # Optional: JSON array of absolute file paths to attach
+
+
+class SpawnMinionInput(TypedDict):
+    name: str                              # Unique name for new minion
+    role: str                              # Human-readable role description
+    system_prompt: str                     # System prompt defining expertise
+    template_name: str                     # Template to apply for permissions (required)
+    working_directory: NotRequired[str]    # Custom working directory (optional)
+    sandbox_enabled: NotRequired[bool]     # Enable OS-level sandboxing (optional, default: False)
+    parent_name: NotRequired[str]          # Name of existing descendant to be parent (optional)
+
+
+class DisposeMinionInput(TypedDict):
+    minion_name: str                # Name of child minion to dispose
+    delete: NotRequired[bool]       # If True, fully delete after archive (default: False = soft dispose)
+
+
+class UpdateExpertiseInput(TypedDict):
+    capability: str                             # Capability keyword (lowercase with underscores)
+    expertise_score: NotRequired[float | None]  # 0.0-1.0 score (default: 0.5 if None)
+
+
+class CreateScheduleInput(TypedDict):
+    name: str
+    cron_expression: str
+    prompt: NotRequired[str]
+    script: NotRequired[str]
+    script_timeout_seconds: NotRequired[int]
+    reset_session: NotRequired[bool]
+    max_retries: NotRequired[int]
+    timeout_seconds: NotRequired[int]
+
+
+class ListSchedulesInput(TypedDict):
+    status: NotRequired[str]
+
+
+class PauseScheduleInput(TypedDict):
+    schedule_id: NotRequired[str]
+    schedule_name: NotRequired[str]
+
+
+class ResumeScheduleInput(TypedDict):
+    schedule_id: NotRequired[str]
+    schedule_name: NotRequired[str]
+
+
+class DeleteScheduleInput(TypedDict):
+    schedule_id: NotRequired[str]
+    schedule_name: NotRequired[str]
+
+
+class UpdateScheduleInput(TypedDict):
+    schedule_id: NotRequired[str]
+    schedule_name: NotRequired[str]
+    name: NotRequired[str]
+    prompt: NotRequired[str]
+    cron_expression: NotRequired[str]
+
+
+class RestartSessionInput(TypedDict):
+    reason: str
+
+
+class QueueTaskInput(TypedDict):
+    session_id: str
+    content: str
+    reset_session: NotRequired[bool]
 
 
 class LegionMCPTools:
@@ -99,15 +176,9 @@ class LegionMCPTools:
             "\n\n**File Attachments (optional):**"
             "\nPass `attachments` as a list of absolute file paths to share files with the recipient. "
             "Files are copied into the recipient's session and registered for auto-approve Read. "
-            "Max 10MB per file. Supported extensions: text, code, config, image, and data files.",
-            {
-                "to_minion_name": str,       # Exact name of target minion (case-sensitive)
-                "summary": str,              # Specific one-sentence update (actionable)
-                "content": str,              # Details only if summary needs elaboration (supports markdown)
-                "comm_type": str,            # One of: task, question, report, info
-                "interrupt_priority": str,   # Optional: "none", "halt", or "pivot" (default: "none")
-                "attachments": str           # Optional: JSON array of absolute file paths to attach
-            }
+            "Max 10MB per file. Supported extensions: text, code, config, image, and data files."
+            "\n\n**Note:** At least one of `summary` or `content` must be provided.",
+            SendCommInput,
         )
         async def send_comm_tool(args: dict[str, Any]) -> dict[str, Any]:
             """Send communication to another minion."""
@@ -126,15 +197,11 @@ class LegionMCPTools:
             "\n\nWorkflow:"
             "\n1. spawn_minion(name='Helper', template_name='Code Expert', system_prompt='Review auth code')"
             "\n2. send_comm(to_minion_name='Helper', summary='Begin task', content='Task details...', comm_type='task')"
-            "\n\n**Using Templates (Recommended):**"
-            "\nUse a template to spawn with specific permissions:"
+            "\n\n**Using Templates (Required):**"
+            "\nEvery minion must be spawned from a template — there is no templateless option:"
             "\n- First, use list_templates() to see available templates"
             "\n- Then spawn: spawn_minion(name='Helper', template_name='Code Expert', system_prompt='Review auth code')"
             "\n- Template enforces permission_mode and allowed_tools (secure, user-controlled)"
-            "\n\n**Without Template:**"
-            "\nIf no template specified, child gets default restricted permissions:"
-            "\n- permission_mode='manual' (prompts for every tool use)"
-            "\n- allowed_tools=[] (no pre-authorized tools)"
             "\n\n**Working Directory (Optional):**"
             "\nSpecify a custom working directory for git worktrees or multi-repo workflows:"
             "\n- working_directory='/path/to/worktree' - Use absolute or relative path"
@@ -148,15 +215,7 @@ class LegionMCPTools:
             "\n- parent_name='TeamLead' - The new minion becomes a child of TeamLead instead of you"
             "\n- The named parent must be one of your descendants (or yourself)"
             "\n- If omitted, the new minion is your direct child (default behavior)",
-            {
-                "name": str,                           # Unique name for new minion
-                "role": str,                           # Human-readable role description
-                "system_prompt": str,                   # System prompt defining expertise
-                "template_name": str,                  # Template to apply for permissions (optional)
-                "working_directory": str,              # Custom working directory (optional)
-                "sandbox_enabled": bool,               # Enable OS-level sandboxing (optional, default: False)
-                "parent_name": str                     # Name of existing descendant to be parent (optional)
-            }
+            SpawnMinionInput,
         )
         async def spawn_minion_tool(args: dict[str, Any]) -> dict[str, Any]:
             """Spawn a new child minion."""
@@ -171,10 +230,7 @@ class LegionMCPTools:
             "Use delete=True to permanently remove the minion (their data is archived first). "
             "Use delete=False (default) for soft dispose - the minion can be restarted later "
             "by sending it a comm.",
-            {
-                "minion_name": str,  # Name of child minion to dispose
-                "delete": bool       # If True, fully delete after archive (default: False = soft dispose)
-            }
+            DisposeMinionInput,
         )
         async def dispose_minion_tool(args: dict[str, Any]) -> dict[str, Any]:
             """Dispose of a child minion."""
@@ -253,10 +309,7 @@ class LegionMCPTools:
             "\n- update_expertise('jwt_authentication', 0.7)"
             "\n- update_expertise('postgresql', 0.9)"
             "\n- update_expertise('docker')  # Uses default 0.5",
-            {
-                "capability": str,                    # Capability keyword (lowercase with underscores)
-                "expertise_score": float | None       # 0.0-1.0 score (default: 0.5 if None)
-            }
+            UpdateExpertiseInput,
         )
         async def update_expertise_tool(args: dict[str, Any]) -> dict[str, Any]:
             """Update minion's expertise for a capability."""
@@ -301,16 +354,7 @@ class LegionMCPTools:
             "\n- reset_session (optional, default false): Reset session before each execution for clean context"
             "\n- max_retries (optional, default 3): Max delivery retries on failure"
             "\n- timeout_seconds (optional, default 3600): Delivery timeout",
-            {
-                "name": str,
-                "cron_expression": str,
-                "prompt": str,
-                "script": str,
-                "script_timeout_seconds": int,
-                "reset_session": bool,
-                "max_retries": int,
-                "timeout_seconds": int,
-            }
+            CreateScheduleInput,
         )
         async def create_schedule_tool(args: dict[str, Any]) -> dict[str, Any]:
             """Create a recurring schedule for the calling minion."""
@@ -323,9 +367,7 @@ class LegionMCPTools:
             "and status. Optionally filter by status."
             "\n\nParameters:"
             "\n- status (optional): Filter by 'active', 'paused', or 'cancelled'",
-            {
-                "status": str,
-            }
+            ListSchedulesInput,
         )
         async def list_schedules_tool(args: dict[str, Any]) -> dict[str, Any]:
             """List schedules for the calling minion."""
@@ -338,10 +380,7 @@ class LegionMCPTools:
             "\n\nParameters (provide exactly one of schedule_id/schedule_name):"
             "\n- schedule_id: The ID of the schedule to pause"
             "\n- schedule_name: The name of the schedule to pause (must be one of your own schedules)",
-            {
-                "schedule_id": str,
-                "schedule_name": str,
-            }
+            PauseScheduleInput,
         )
         async def pause_schedule_tool(args: dict[str, Any]) -> dict[str, Any]:
             """Pause a schedule owned by the calling minion."""
@@ -355,10 +394,7 @@ class LegionMCPTools:
             "\n\nParameters (provide exactly one of schedule_id/schedule_name):"
             "\n- schedule_id: The ID of the schedule to resume"
             "\n- schedule_name: The name of the schedule to resume (must be one of your own schedules)",
-            {
-                "schedule_id": str,
-                "schedule_name": str,
-            }
+            ResumeScheduleInput,
         )
         async def resume_schedule_tool(args: dict[str, Any]) -> dict[str, Any]:
             """Resume a schedule owned by the calling minion."""
@@ -371,10 +407,7 @@ class LegionMCPTools:
             "\n\nParameters (provide exactly one of schedule_id/schedule_name):"
             "\n- schedule_id: The ID of the schedule to delete"
             "\n- schedule_name: The name of the schedule to delete (must be one of your own schedules)",
-            {
-                "schedule_id": str,
-                "schedule_name": str,
-            }
+            DeleteScheduleInput,
         )
         async def delete_schedule_tool(args: dict[str, Any]) -> dict[str, Any]:
             """Delete a schedule owned by the calling minion."""
@@ -397,13 +430,7 @@ class LegionMCPTools:
             "\n- prompt (optional): New prompt text. Only valid for prompt-type schedules. Must be non-empty"
             "\n- cron_expression (optional): New cron expression (5-field standard cron). "
             "Examples: '0 8 * * 1-5' (weekdays 8am), '*/30 * * * *' (every 30 min)",
-            {
-                "schedule_id": str,
-                "schedule_name": str,
-                "name": str,
-                "prompt": str,
-                "cron_expression": str,
-            }
+            UpdateScheduleInput,
         )
         async def update_schedule_tool(args: dict[str, Any]) -> dict[str, Any]:
             """Update a schedule owned by the calling minion."""
@@ -420,10 +447,9 @@ class LegionMCPTools:
             "Do not execute any more tools or produce further output. The system will "
             "restart your session and send a continuation message so you can resume."
             "\n\nParameters:"
-            "\n- reason (optional): Why you need to restart (logged for audit)",
-            {
-                "reason": str,
-            }
+            "\n- reason (required): Why you need to restart (logged for audit and included "
+            "in your post-restart continuation message)",
+            RestartSessionInput,
         )
         async def restart_session_tool(args: dict[str, Any]) -> dict[str, Any]:
             """Request a session restart."""
@@ -446,11 +472,7 @@ class LegionMCPTools:
             "Returns queue_id and position for your own bookkeeping.\n\n"
             "Note: queue_task is not hierarchy-scoped — you may queue into any session "
             "whose ID you know, not just your own children.",
-            {
-                "session_id": str,
-                "content": str,
-                "reset_session": bool,
-            }
+            QueueTaskInput,
         )
         async def queue_task_tool(args: dict[str, Any]) -> dict[str, Any]:
             """Enqueue a prompt for deferred delivery to a session."""
@@ -621,6 +643,9 @@ class LegionMCPTools:
         content = args.get("content", "")
         summary = args.get("summary", "")
 
+        if not (summary or "").strip() and not (content or "").strip():
+            return self._err("Error: provide at least one of 'summary' or 'content'.")
+
         # Fallback: If summary is empty, auto-generate from first 50 chars of content
         if not summary and content:
             summary = content[:50] + ("..." if len(content) > 50 else "")
@@ -767,7 +792,7 @@ class LegionMCPTools:
         Handle spawn_minion tool call from a minion.
 
         Security Model:
-        - Minions can ONLY use templates or default restricted permissions
+        - Minions can ONLY spawn from a template (template_name is required)
         - NO ad-hoc permission specification allowed (prevents privilege escalation)
         - Templates are user-controlled and enforce specific permission sets
 
@@ -777,7 +802,7 @@ class LegionMCPTools:
                 "name": str,
                 "role": str,
                 "system_prompt": str,
-                "template_name": str,  # Optional - if provided, enforces template permissions
+                "template_name": str,  # Required - enforces template permissions
                 "capabilities": List[str]  # Optional
             }
 
@@ -850,141 +875,119 @@ class LegionMCPTools:
         if not system_prompt:
             return self._err("Error: 'system_prompt' parameter is required and cannot be empty. Provide clear instructions for what this minion should do.")
 
-        # SECURITY: Apply template permissions or use safe defaults
-        # Minions cannot specify custom permissions directly
+        if not template_name:
+            return self._err(
+                "Error: 'template_name' parameter is required — minions can only be "
+                "spawned from a template. Use list_templates() to see available templates."
+            )
+
+        # SECURITY: Apply template permissions (no ad-hoc overrides allowed)
         permission_mode = None
         allowed_tools = None
         disallowed_tools = None
         template_applied = None
 
-        if template_name:
-            # Template specified - look up and apply (no overrides allowed)
-            try:
-                template = await self.system.template_manager.get_template_by_name(template_name)
+        # Template specified - look up and apply (no overrides allowed)
+        try:
+            template = await self.system.template_manager.get_template_by_name(template_name)
 
-                if not template:
-                    return self._err(f"❌ Error: Template '{template_name}' not found. Use list_templates() to see available templates.")
+            if not template:
+                return self._err(f"❌ Error: Template '{template_name}' not found. Use list_templates() to see available templates.")
 
-                template_applied = template
+            template_applied = template
 
-                profile_manager = getattr(self.system.session_coordinator, 'profile_manager', None)
-                resolved = await resolve_template_config(template, profile_manager)
+            profile_manager = getattr(self.system.session_coordinator, 'profile_manager', None)
+            resolved = await resolve_template_config(template, profile_manager)
 
-                # Apply resolved values (enforced, no overrides)
-                # Use resolved config with parent fallback for missing fields.
-                permission_mode = resolved.get('permission_mode') or parent_session.current_permission_mode
-                allowed_tools = resolved.get('allowed_tools')
-                disallowed_tools = resolved.get('disallowed_tools')
+            # Apply resolved values (enforced, no overrides)
+            # Use resolved config with parent fallback for missing fields.
+            permission_mode = resolved.get('permission_mode') or parent_session.current_permission_mode
+            allowed_tools = resolved.get('allowed_tools')
+            disallowed_tools = resolved.get('disallowed_tools')
 
-                # Use template's role if role not provided
-                if not role and template.role:
-                    role = template.role
+            # Use template's role if role not provided
+            if not role and template.role:
+                role = template.role
 
-                # Prepend template's system_prompt if exists
-                _tpl_sp = template.config.get("system_prompt")
-                if _tpl_sp:
-                    system_prompt = f"{_tpl_sp}\n\n{system_prompt}"
+            # Prepend template's system_prompt if exists
+            _tpl_sp = template.config.get("system_prompt")
+            if _tpl_sp:
+                system_prompt = f"{_tpl_sp}\n\n{system_prompt}"
 
-                # Apply model from resolved config if set
-                model = resolved.get('model') or None
+            # Apply model from resolved config if set
+            model = resolved.get('model') or None
 
-                # Apply capabilities from template (merge with any provided)
-                if template.capabilities:
-                    template_caps = list(template.capabilities)
-                    for cap in capabilities:
-                        if cap not in template_caps:
-                            template_caps.append(cap)
-                    capabilities = template_caps
+            # Apply capabilities from template (merge with any provided)
+            if template.capabilities:
+                template_caps = list(template.capabilities)
+                for cap in capabilities:
+                    if cap not in template_caps:
+                        template_caps.append(cap)
+                capabilities = template_caps
 
-                # Apply override_system_prompt from resolved config
-                override_system_prompt = resolved.get(
-                    'override_system_prompt', template.config.get('override_system_prompt', False)
-                )
+            # Apply override_system_prompt from resolved config
+            override_system_prompt = resolved.get(
+                'override_system_prompt', template.config.get('override_system_prompt', False)
+            )
 
-                # Apply sandbox_enabled from resolved config
-                if resolved.get('sandbox_enabled'):
-                    sandbox_enabled = True
+            # Apply sandbox_enabled from resolved config
+            if resolved.get('sandbox_enabled'):
+                sandbox_enabled = True
 
-                # Apply cli_path from resolved config (issue #489)
-                # SECURITY: cli_path flows only through user-controlled templates
-                cli_path = resolved.get('cli_path')
+            # Apply cli_path from resolved config (issue #489)
+            # SECURITY: cli_path flows only through user-controlled templates
+            cli_path = resolved.get('cli_path')
 
-                # Apply process_wrapper from resolved config (issue #1672)
-                # SECURITY: process_wrapper flows only through user-controlled templates
-                process_wrapper = resolved.get('process_wrapper')
+            # Apply process_wrapper from resolved config (issue #1672)
+            # SECURITY: process_wrapper flows only through user-controlled templates
+            process_wrapper = resolved.get('process_wrapper')
 
-                # Apply Docker isolation from resolved config (issue #496)
-                # SECURITY: Docker config flows only through user-controlled templates
-                docker_enabled = resolved.get('docker_enabled', False)
-                docker_image = resolved.get('docker_image')
-                docker_extra_mounts = resolved.get('docker_extra_mounts')
+            # Apply Docker isolation from resolved config (issue #496)
+            # SECURITY: Docker config flows only through user-controlled templates
+            docker_enabled = resolved.get('docker_enabled', False)
+            docker_image = resolved.get('docker_image')
+            docker_extra_mounts = resolved.get('docker_extra_mounts')
 
-                # Extract additional config fields, falling back to parent session
-                # (issue #762: ensure all SessionConfig fields propagate through spawn path)
-                _pc = parent_session.config
-                thinking_mode = resolved.get('thinking_mode') or _pc.get('thinking_mode')
-                thinking_budget_tokens = (
-                    resolved.get('thinking_budget_tokens') or _pc.get('thinking_budget_tokens')
-                )
-                effort = resolved.get('effort') or _pc.get('effort')
-                setting_sources = resolved.get('setting_sources') or _pc.get('setting_sources')
-                additional_directories = (
-                    resolved.get('additional_directories') or _pc.get('additional_directories')
-                )
-                sandbox_config = resolved.get('sandbox_config') or _pc.get('sandbox_config')
-                docker_home_directory = (
-                    resolved.get('docker_home_directory') or _pc.get('docker_home_directory')
-                )
-                # Booleans: fall back to SessionConfig defaults when neither resolved nor
-                # parent config has the field (post-#1230 config dicts omit default values).
-                history_distillation_enabled = resolved.get(
-                    'history_distillation_enabled',
-                    _pc.get('history_distillation_enabled', _SESSION_DEFAULTS['history_distillation_enabled']),
-                )
-                auto_memory_mode = resolved.get('auto_memory_mode') or _pc.get('auto_memory_mode') or _SESSION_DEFAULTS['auto_memory_mode']
-                skill_creating_enabled = resolved.get(
-                    'skill_creating_enabled',
-                    _pc.get('skill_creating_enabled', _SESSION_DEFAULTS['skill_creating_enabled']),
-                )
-                mcp_server_ids = resolved.get('mcp_server_ids') or _pc.get('mcp_server_ids')
-                enable_claudeai_mcp_servers = resolved.get(
-                    'enable_claudeai_mcp_servers',
-                    _pc.get('enable_claudeai_mcp_servers', _SESSION_DEFAULTS['enable_claudeai_mcp_servers']),
-                )
-                strict_mcp_config = resolved.get(
-                    'strict_mcp_config',
-                    _pc.get('strict_mcp_config', _SESSION_DEFAULTS['strict_mcp_config']),
-                )
-
-            except Exception as e:
-                legion_logger.error(f"Error applying template: {e}", exc_info=True)
-                return self._err(f"❌ Error applying template: {str(e)}")
-        else:
-            # No template - use safe default restricted permissions
-            permission_mode = "manual"  # Prompts for most actions
-            allowed_tools = []  # No pre-authorized tools (user must approve each tool use)
-            model = None
-            override_system_prompt = False
-            cli_path = None
-            process_wrapper = None
+            # Extract additional config fields, falling back to parent session
+            # (issue #762: ensure all SessionConfig fields propagate through spawn path)
             _pc = parent_session.config
-            docker_enabled = _pc.get('docker_enabled', False)
-            docker_image = _pc.get('docker_image')
-            docker_extra_mounts = _pc.get('docker_extra_mounts')
-            # Inherit operational config from parent (issue #762)
-            thinking_mode = _pc.get('thinking_mode')
-            thinking_budget_tokens = _pc.get('thinking_budget_tokens')
-            effort = _pc.get('effort')
-            setting_sources = _pc.get('setting_sources')
-            additional_directories = _pc.get('additional_directories') or []
-            sandbox_config = _pc.get('sandbox_config')
-            docker_home_directory = _pc.get('docker_home_directory')
-            history_distillation_enabled = _pc.get('history_distillation_enabled', _SESSION_DEFAULTS['history_distillation_enabled'])
-            auto_memory_mode = _pc.get('auto_memory_mode') or _SESSION_DEFAULTS['auto_memory_mode']
-            skill_creating_enabled = _pc.get('skill_creating_enabled', _SESSION_DEFAULTS['skill_creating_enabled'])
-            mcp_server_ids = _pc.get('mcp_server_ids')
-            enable_claudeai_mcp_servers = _pc.get('enable_claudeai_mcp_servers', _SESSION_DEFAULTS['enable_claudeai_mcp_servers'])
-            strict_mcp_config = _pc.get('strict_mcp_config', _SESSION_DEFAULTS['strict_mcp_config'])
+            thinking_mode = resolved.get('thinking_mode') or _pc.get('thinking_mode')
+            thinking_budget_tokens = (
+                resolved.get('thinking_budget_tokens') or _pc.get('thinking_budget_tokens')
+            )
+            effort = resolved.get('effort') or _pc.get('effort')
+            setting_sources = resolved.get('setting_sources') or _pc.get('setting_sources')
+            additional_directories = (
+                resolved.get('additional_directories') or _pc.get('additional_directories')
+            )
+            sandbox_config = resolved.get('sandbox_config') or _pc.get('sandbox_config')
+            docker_home_directory = (
+                resolved.get('docker_home_directory') or _pc.get('docker_home_directory')
+            )
+            # Booleans: fall back to SessionConfig defaults when neither resolved nor
+            # parent config has the field (post-#1230 config dicts omit default values).
+            history_distillation_enabled = resolved.get(
+                'history_distillation_enabled',
+                _pc.get('history_distillation_enabled', _SESSION_DEFAULTS['history_distillation_enabled']),
+            )
+            auto_memory_mode = resolved.get('auto_memory_mode') or _pc.get('auto_memory_mode') or _SESSION_DEFAULTS['auto_memory_mode']
+            skill_creating_enabled = resolved.get(
+                'skill_creating_enabled',
+                _pc.get('skill_creating_enabled', _SESSION_DEFAULTS['skill_creating_enabled']),
+            )
+            mcp_server_ids = resolved.get('mcp_server_ids') or _pc.get('mcp_server_ids')
+            enable_claudeai_mcp_servers = resolved.get(
+                'enable_claudeai_mcp_servers',
+                _pc.get('enable_claudeai_mcp_servers', _SESSION_DEFAULTS['enable_claudeai_mcp_servers']),
+            )
+            strict_mcp_config = resolved.get(
+                'strict_mcp_config',
+                _pc.get('strict_mcp_config', _SESSION_DEFAULTS['strict_mcp_config']),
+            )
+
+        except Exception as e:
+            legion_logger.error(f"Error applying template: {e}", exc_info=True)
+            return self._err(f"❌ Error applying template: {str(e)}")
 
         # Validate role is set (from parameter or template)
         if not role:
@@ -1034,7 +1037,7 @@ class LegionMCPTools:
                 mcp_server_ids=mcp_server_ids,
                 enable_claudeai_mcp_servers=enable_claudeai_mcp_servers,
                 strict_mcp_config=strict_mcp_config,
-                template_id=template_applied.template_id if template_applied else None,
+                template_id=template_applied.template_id,
             )
             spawn_result = await self.system.overseer_controller.spawn_minion(
                 parent_overseer_id=parent_overseer_id,
@@ -1051,21 +1054,13 @@ class LegionMCPTools:
             child_slug = child_session.slug if child_session else name
 
             # Build success message with permission info
-            perm_info = ""
-            if template_applied:
-                _tpl_tools = template_applied.config.get("allowed_tools") or []
-                tools_str = ", ".join(_tpl_tools) if _tpl_tools else "all"
-                perm_info = (
-                    f"\n**Permissions** (from template '{template_applied.name}'):\n"
-                    f"  - Permission Mode: {template_applied.config.get('permission_mode', 'manual')}\n"
-                    f"  - Allowed Tools: {tools_str}"
-                )
-            else:
-                perm_info = (
-                    "\n**Permissions** (safe defaults):\n"
-                    "  - Permission Mode: manual\n"
-                    "  - Allowed Tools: none (user must approve each tool use)"
-                )
+            _tpl_tools = template_applied.config.get("allowed_tools") or []
+            tools_str = ", ".join(_tpl_tools) if _tpl_tools else "all"
+            perm_info = (
+                f"\n**Permissions** (from template '{template_applied.name}'):\n"
+                f"  - Permission Mode: {template_applied.config.get('permission_mode', 'manual')}\n"
+                f"  - Allowed Tools: {tools_str}"
+            )
 
             # Add working directory info if specified
             wd_info = ""
@@ -2208,6 +2203,9 @@ class LegionMCPTools:
 
         if not session_id:
             return self._err("Error: Unable to determine session ID")
+
+        if not reason:
+            return self._err("Error: 'reason' parameter is required.")
 
         # Check session exists and is active
         session_info = await self.system.session_coordinator.session_manager.get_session_info(

--- a/backend/mcp/resource_mcp_tools.py
+++ b/backend/mcp/resource_mcp_tools.py
@@ -15,7 +15,7 @@ import json
 import logging
 import uuid
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NotRequired, TypedDict
 
 try:
     from claude_agent_sdk import create_sdk_mcp_server, tool
@@ -30,6 +30,21 @@ if TYPE_CHECKING:
     from backend.session_coordinator import SessionCoordinator
 
 logger = logging.getLogger(__name__)
+
+
+class RegisterResourceInput(TypedDict):
+    file_path: str                     # Absolute path to file (required)
+    title: str                         # Short caption (required)
+    description: NotRequired[str]      # Detailed description (optional)
+
+
+class ListResourcesInput(TypedDict):
+    format_filter: NotRequired[str]    # Optional filter: "image" or specific format
+
+
+class GetResourceInput(TypedDict):
+    resource_id: NotRequired[str]      # Optional: exact resource ID
+    filename: NotRequired[str]         # Optional: original filename (case-insensitive)
 
 # Constants
 MAX_RESOURCE_SIZE_BYTES = 10 * 1024 * 1024  # 10MB limit per resource
@@ -174,7 +189,7 @@ INLINE DISPLAY: For image resources, the response includes a `markdown` field wi
 ready-to-use markdown. To display the image inline in your response, paste the markdown
 from the `markdown` field directly into your message text.
 
-USAGE: Provide the absolute path to a file. The backend reads it directly.
+USAGE: Provide the absolute path to a file and a short title. The backend reads the file directly.
 
 Examples:
   register_resource(file_path="/home/user/screenshot.png", title="Login Page")
@@ -184,11 +199,7 @@ Examples:
 
 Supported types: Text, Code, Config, Images, Videos (webm, mp4), Data files
 Maximum size: 10MB per resource""",
-            {
-                "file_path": str,      # Absolute path to file (required)
-                "title": str,          # Short caption (optional, default: filename)
-                "description": str     # Detailed description (optional)
-            }
+            RegisterResourceInput,
         )
         async def register_resource_tool(args: dict[str, Any]) -> dict[str, Any]:
             """Register a resource for display in the task panel."""
@@ -202,11 +213,7 @@ Maximum size: 10MB per resource""",
 DEPRECATED: Use register_resource() instead - it supports all file types.
 
 This tool is kept for backward compatibility but simply calls register_resource.""",
-            {
-                "file_path": str,
-                "title": str,
-                "description": str
-            }
+            RegisterResourceInput,
         )
         async def register_image_tool(args: dict[str, Any]) -> dict[str, Any]:
             """Register an image (backward compatibility wrapper)."""
@@ -231,9 +238,7 @@ Each resource includes:
 
 Optional: Use format_filter to filter by format type (e.g. "image" for images only,
 or a specific extension like "png", "json").""",
-            {
-                "format_filter": str,  # Optional filter: "image" or specific format
-            }
+            ListResourcesInput,
         )
         async def list_resources_tool(args: dict[str, Any]) -> dict[str, Any]:
             """List all session resources with metadata."""
@@ -246,11 +251,8 @@ or a specific extension like "png", "json").""",
 Returns a single resource with its metadata and markdown URL for inline embedding.
 Provide either resource_id or filename (case-insensitive match on original filename).
 
-At least one of resource_id or filename must be provided.""",
-            {
-                "resource_id": str,  # Optional: exact resource ID
-                "filename": str,    # Optional: original filename (case-insensitive)
-            }
+Provide exactly one of resource_id or filename.""",
+            GetResourceInput,
         )
         async def get_resource_tool(args: dict[str, Any]) -> dict[str, Any]:
             """Get a specific resource by ID or filename."""
@@ -299,6 +301,15 @@ At least one of resource_id or filename must be provided.""",
                     "content": [{
                         "type": "text",
                         "text": "Error: 'file_path' parameter is required and cannot be empty"
+                    }],
+                    "is_error": True
+                }
+
+            if not title:
+                return {
+                    "content": [{
+                        "type": "text",
+                        "text": "Error: 'title' parameter is required and cannot be empty"
                     }],
                     "is_error": True
                 }
@@ -405,10 +416,6 @@ At least one of resource_id or filename must be provided.""",
 
             # Generate unique resource ID
             resource_id = str(uuid.uuid4())
-
-            # Use filename as default title if not provided
-            if not title:
-                title = file_path.name
 
             # Create resource metadata
             from backend.timestamp_utils import get_unix_timestamp
@@ -583,6 +590,12 @@ At least one of resource_id or filename must be provided.""",
             if not resource_id and not filename:
                 return {
                     "content": [{"type": "text", "text": "Error: Provide at least one of 'resource_id' or 'filename'"}],
+                    "is_error": True
+                }
+
+            if resource_id and filename:
+                return {
+                    "content": [{"type": "text", "text": "Error: provide only one of 'resource_id' or 'filename', not both."}],
                     "is_error": True
                 }
 

--- a/backend/session_coordinator.py
+++ b/backend/session_coordinator.py
@@ -5861,7 +5861,8 @@ class SessionCoordinator:
         Args:
             session_id: Session ID that owns the resource
             file_path: Absolute path to the uploaded file
-            title: Optional title for the resource (defaults to filename)
+            title: Title for the resource (required — the underlying MCP handler
+                rejects an empty title, issue #1912)
             description: Optional description
 
         Returns:

--- a/backend/tests/integration/test_lifecycle_tools.py
+++ b/backend/tests/integration/test_lifecycle_tools.py
@@ -20,29 +20,39 @@ pytestmark = pytest.mark.slow
 @pytest.mark.asyncio
 async def test_spawn_minion_minimal(legion_test_env):
     """
-    Test spawn_minion with minimal parameters.
+    Test spawn_minion with minimal parameters (name/role/system_prompt/template_name).
+
+    Issue #1912: template_name is now a required parameter — minions can only be
+    spawned from a template, so this test supplies one instead of exercising the
+    (now removed) templateless default-permissions path.
 
     Verifies:
     - Tool returns success with child_minion_id
     - Child session created with ACTIVE state
     - Parent marked as overseer with child in child_minion_ids
     - SPAWN comm logged to timeline
-    - Default permissions applied
     """
     env = legion_test_env
     legion_system = env["legion_system"]
     data_dir = env["data_dir"]
     legion_id = env["legion_id"]
+    template_manager = env["template_manager"]
 
     # Create parent minion (will wait for ACTIVE state)
     parent = await env["create_minion"]("parent", role="Parent")
+
+    templates = await template_manager.list_templates()
+    if not templates:
+        pytest.skip("No templates available for testing")
+    template_name = templates[0].name
 
     # Spawn child via MCP tool handler
     result = await legion_system.mcp_tools._handle_spawn_minion({
         "_parent_overseer_id": parent.session_id,
         "name": "child",
         "role": "Child Worker",
-        "system_prompt": "You are a test child minion for integration testing."
+        "system_prompt": "You are a test child minion for integration testing.",
+        "template_name": template_name,
     })
 
     # Verify success response (not an error)
@@ -116,8 +126,27 @@ async def test_spawn_minion_minimal(legion_test_env):
     assert spawn_comm["to_user"] is True  # SPAWN comms are sent to user
     assert "child" in spawn_comm["content"]
 
-    # SIDE EFFECT 5: Default permissions applied
-    assert child_info.current_permission_mode == "default"
+
+@pytest.mark.asyncio
+async def test_spawn_minion_without_template_fails(legion_test_env):
+    """
+    Issue #1912: template_name is now required — spawn_minion must reject a call
+    that omits it instead of silently applying restricted default permissions.
+    """
+    env = legion_test_env
+    legion_system = env["legion_system"]
+
+    parent = await env["create_minion"]("parent", role="Parent")
+
+    result = await legion_system.mcp_tools._handle_spawn_minion({
+        "_parent_overseer_id": parent.session_id,
+        "name": "child",
+        "role": "Child Worker",
+        "system_prompt": "You are a test child minion for integration testing.",
+    })
+
+    assert result.get("is_error") is True
+    assert "template_name" in result["content"][0]["text"]
 
 
 @pytest.mark.asyncio
@@ -276,9 +305,14 @@ async def test_spawn_minion_with_capabilities(legion_test_env):
     """
     env = legion_test_env
     legion_system = env["legion_system"]
+    template_manager = env["template_manager"]
 
     # Create parent minion
     parent = await env["create_minion"]("parent", role="Parent")
+
+    templates = await template_manager.list_templates()
+    if not templates:
+        pytest.skip("No templates available for testing")
 
     # Spawn child with capabilities
     result = await legion_system.mcp_tools._handle_spawn_minion({
@@ -286,6 +320,7 @@ async def test_spawn_minion_with_capabilities(legion_test_env):
         "name": "child",
         "role": "Data Scientist",
         "system_prompt": "Test child with capabilities.",
+        "template_name": templates[0].name,
         "capabilities": ["python", "data analysis", "machine learning"]
     })
 
@@ -345,16 +380,23 @@ async def test_spawn_minion_error_duplicate_name(legion_test_env):
     """
     env = legion_test_env
     legion_system = env["legion_system"]
+    template_manager = env["template_manager"]
 
     # Create parent minion
     parent = await env["create_minion"]("parent", role="Parent")
+
+    templates = await template_manager.list_templates()
+    if not templates:
+        pytest.skip("No templates available for testing")
+    template_name = templates[0].name
 
     # Spawn first child
     result1 = await legion_system.mcp_tools._handle_spawn_minion({
         "_parent_overseer_id": parent.session_id,
         "name": "duplicate",
         "role": "Worker",
-        "system_prompt": "First test child."
+        "system_prompt": "First test child.",
+        "template_name": template_name,
     })
     assert result1.get("is_error") is not True
 
@@ -363,7 +405,8 @@ async def test_spawn_minion_error_duplicate_name(legion_test_env):
         "_parent_overseer_id": parent.session_id,
         "name": "duplicate",
         "role": "Worker",
-        "system_prompt": "Second test child (should fail)."
+        "system_prompt": "Second test child (should fail).",
+        "template_name": template_name,
     })
 
     # Verify error response
@@ -419,15 +462,21 @@ async def test_dispose_minion_direct_child(legion_test_env):
     legion_system = env["legion_system"]
     data_dir = env["data_dir"]
     legion_id = env["legion_id"]
+    template_manager = env["template_manager"]
 
     # Create parent and child
     parent = await env["create_minion"]("parent", role="Parent")
+
+    templates = await template_manager.list_templates()
+    if not templates:
+        pytest.skip("No templates available for testing")
 
     spawn_result = await legion_system.mcp_tools._handle_spawn_minion({
         "_parent_overseer_id": parent.session_id,
         "name": "child",
         "role": "Worker",
-        "system_prompt": "Test child for disposal."
+        "system_prompt": "Test child for disposal.",
+        "template_name": templates[0].name,
     })
     assert spawn_result.get("is_error") is not True
 
@@ -508,16 +557,23 @@ async def test_dispose_minion_with_descendants(legion_test_env):
     """
     env = legion_test_env
     legion_system = env["legion_system"]
+    template_manager = env["template_manager"]
 
     # Create parent, child, and grandchild
     parent = await env["create_minion"]("parent", role="Parent")
+
+    templates = await template_manager.list_templates()
+    if not templates:
+        pytest.skip("No templates available for testing")
+    template_name = templates[0].name
 
     # Spawn child
     child_result = await legion_system.mcp_tools._handle_spawn_minion({
         "_parent_overseer_id": parent.session_id,
         "name": "child",
         "role": "Worker",
-        "system_prompt": "Test child for recursive disposal."
+        "system_prompt": "Test child for recursive disposal.",
+        "template_name": template_name,
     })
     assert child_result.get("is_error") is not True
 
@@ -551,7 +607,8 @@ async def test_dispose_minion_with_descendants(legion_test_env):
         "_parent_overseer_id": child_id,
         "name": "grandchild",
         "role": "Sub-worker",
-        "system_prompt": "Test grandchild for recursive disposal."
+        "system_prompt": "Test grandchild for recursive disposal.",
+        "template_name": template_name,
     })
     assert grandchild_result.get("is_error") is not True
 
@@ -637,15 +694,21 @@ async def test_dispose_minion_error_not_your_child(legion_test_env):
     """
     env = legion_test_env
     legion_system = env["legion_system"]
+    template_manager = env["template_manager"]
 
     # Create parent1 and child
     parent1 = await env["create_minion"]("parent1", role="Parent 1")
+
+    templates = await template_manager.list_templates()
+    if not templates:
+        pytest.skip("No templates available for testing")
 
     spawn_result = await legion_system.mcp_tools._handle_spawn_minion({
         "_parent_overseer_id": parent1.session_id,
         "name": "child",
         "role": "Worker",
-        "system_prompt": "Test child for permission test."
+        "system_prompt": "Test child for permission test.",
+        "template_name": templates[0].name,
     })
     assert spawn_result.get("is_error") is not True
 

--- a/backend/tests/test_legion_mcp_tools.py
+++ b/backend/tests/test_legion_mcp_tools.py
@@ -5,8 +5,16 @@ Tests for Legion MCP tools with SDK integration.
 from unittest.mock import Mock
 
 import pytest
+from mcp.types import ListToolsRequest
 
 from backend.legion_system import LegionSystem
+
+
+async def _get_tools_by_name(server_config):
+    """Introspect a session MCP server's registered tool schemas (issue #1912)."""
+    handler = server_config["instance"].request_handlers[ListToolsRequest]
+    result = await handler(ListToolsRequest(method="tools/list"))
+    return {t.name: t for t in result.root.tools}
 
 
 @pytest.fixture
@@ -48,6 +56,52 @@ def test_create_mcp_server_for_session(legion_system):
     # If None, SDK not available in test environment (expected)
 
 
+@pytest.mark.asyncio
+async def test_schema_required_fields_for_modified_tools(mcp_tools):
+    """Issue #1912: declared `required` sets must match actual handler behavior."""
+    server_config = mcp_tools.create_mcp_server_for_session("test-session")
+    tools_by_name = await _get_tools_by_name(server_config)
+
+    assert set(tools_by_name["pause_schedule"].inputSchema.get("required", [])) == set()
+    assert set(tools_by_name["resume_schedule"].inputSchema.get("required", [])) == set()
+    assert set(tools_by_name["delete_schedule"].inputSchema.get("required", [])) == set()
+    assert set(tools_by_name["create_schedule"].inputSchema.get("required", [])) == {
+        "name", "cron_expression"
+    }
+    assert set(tools_by_name["send_comm"].inputSchema.get("required", [])) == {"to_minion_name"}
+    assert set(tools_by_name["spawn_minion"].inputSchema.get("required", [])) == {
+        "name", "role", "system_prompt", "template_name"
+    }
+    assert set(tools_by_name["dispose_minion"].inputSchema.get("required", [])) == {"minion_name"}
+    assert set(tools_by_name["update_expertise"].inputSchema.get("required", [])) == {"capability"}
+    assert set(tools_by_name["update_schedule"].inputSchema.get("required", [])) == set()
+    assert set(tools_by_name["restart_session"].inputSchema.get("required", [])) == {"reason"}
+    assert set(tools_by_name["queue_task"].inputSchema.get("required", [])) == {
+        "session_id", "content"
+    }
+    assert set(tools_by_name["list_schedules"].inputSchema.get("required", [])) == set()
+
+
+@pytest.mark.asyncio
+async def test_schema_negative_controls_untouched_tools(mcp_tools):
+    """Issue #1912: tools not part of this fix must keep their existing schemas exactly."""
+    server_config = mcp_tools.create_mcp_server_for_session("test-session")
+    tools_by_name = await _get_tools_by_name(server_config)
+
+    assert set(tools_by_name["search_capability"].inputSchema.get("required", [])) == {
+        "capability"
+    }
+    assert list(tools_by_name["list_minions"].inputSchema.get("required", [])) == []
+    assert set(tools_by_name["get_minion_info"].inputSchema.get("required", [])) == {
+        "minion_name"
+    }
+    assert list(tools_by_name["list_templates"].inputSchema.get("required", [])) == []
+    assert list(tools_by_name["whoami"].inputSchema.get("required", [])) == []
+    assert set(tools_by_name["reparent_minion"].inputSchema.get("required", [])) == {
+        "subject_name", "new_parent_name"
+    }
+
+
 def test_tool_handler_methods_exist(mcp_tools):
     """Test that all tool handler methods are defined."""
     handler_methods = [
@@ -82,6 +136,19 @@ async def test_send_comm_handler_requires_sender_id(mcp_tools):
     # Expect error about missing sender ID
     assert "sender minion id" in result["content"][0]["text"].lower()
     assert result.get("is_error") is True
+
+
+@pytest.mark.asyncio
+async def test_send_comm_requires_summary_or_content(mcp_tools):
+    """Issue #1912: send_comm must reject calls where both summary and content are blank."""
+    result = await mcp_tools._handle_send_comm({
+        "_from_minion_id": "sender-id",
+        "to_minion_name": "user",
+        "comm_type": "info",
+    })
+
+    assert result.get("is_error") is True
+    assert "at least one" in result["content"][0]["text"].lower()
 
 
 @pytest.mark.asyncio
@@ -538,6 +605,44 @@ async def test_issue_1730_send_comm_embeds_resolved_resource_id_per_attachment(t
         {"name": "a.txt", "resource_id": "res-a", "size": 9, "mime_type": "text/plain"},
         {"name": "b.txt", "resource_id": "res-b", "size": 10, "mime_type": "text/plain"},
     ]
+
+
+@pytest.mark.asyncio
+async def test_send_comm_summary_only_succeeds(tmp_path):
+    """Issue #1912: summary alone (no content) satisfies the at-least-one requirement."""
+    from backend.legion.mcp.legion_mcp_tools import LegionMCPTools
+
+    session_id = "sender-summary-only"
+    mock_system = _make_send_comm_system_with_router(session_id, tmp_path, resource_ids=[])
+    mcp_tools = LegionMCPTools(mock_system)
+
+    result = await mcp_tools._handle_send_comm({
+        "_from_minion_id": session_id,
+        "to_minion_name": "user",
+        "summary": "Task complete",
+        "comm_type": "report",
+    })
+
+    assert result["is_error"] is False
+
+
+@pytest.mark.asyncio
+async def test_send_comm_content_only_succeeds(tmp_path):
+    """Issue #1912: content alone (no summary) satisfies the at-least-one requirement."""
+    from backend.legion.mcp.legion_mcp_tools import LegionMCPTools
+
+    session_id = "sender-content-only"
+    mock_system = _make_send_comm_system_with_router(session_id, tmp_path, resource_ids=[])
+    mcp_tools = LegionMCPTools(mock_system)
+
+    result = await mcp_tools._handle_send_comm({
+        "_from_minion_id": session_id,
+        "to_minion_name": "user",
+        "content": "Detailed report body",
+        "comm_type": "report",
+    })
+
+    assert result["is_error"] is False
 
 
 @pytest.mark.asyncio
@@ -1454,10 +1559,22 @@ async def test_issue_1581_spawn_parent_name_large_subtree():
         "slug": "newchild",
     })
 
+    # Issue #1912: template_name is now required for spawn_minion.
+    template = MagicMock()
+    template.name = "TestTemplate"
+    template.role = None
+    template.capabilities = []
+    template.profile_ids = {}
+    template.config = {"permission_mode": "default"}
+    template.template_id = "template-id"
+    template_manager = MagicMock()
+    template_manager.get_template_by_name = AsyncMock(return_value=template)
+
     mock_system = MagicMock()
     mock_system.session_coordinator = session_coordinator
     mock_system.legion_coordinator = legion_coordinator
     mock_system.overseer_controller = overseer_controller
+    mock_system.template_manager = template_manager
 
     mcp_tools = LegionMCPTools(mock_system)
 
@@ -1466,6 +1583,7 @@ async def test_issue_1581_spawn_parent_name_large_subtree():
         "name": "NewChild",
         "role": "Worker",
         "system_prompt": "Do work.",
+        "template_name": "TestTemplate",
         "parent_name": "NamedParent",
     })
 

--- a/backend/tests/test_links_mcp_tools.py
+++ b/backend/tests/test_links_mcp_tools.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from mcp.types import ListToolsRequest
 
 from backend.mcp.links_mcp_tools import (
     MAX_LABEL_LENGTH,
@@ -11,6 +12,13 @@ from backend.mcp.links_mcp_tools import (
     LinksMCPTools,
     _validate_url,
 )
+
+
+async def _get_tools_by_name(server_config):
+    """Introspect a session MCP server's registered tool schemas (issue #1912)."""
+    handler = server_config["instance"].request_handlers[ListToolsRequest]
+    result = await handler(ListToolsRequest(method="tools/list"))
+    return {t.name: t for t in result.root.tools}
 
 # ---------------------------------------------------------------------------
 # _validate_url
@@ -184,3 +192,19 @@ class TestHandleListLinks:
         tools = LinksMCPTools(session_coordinator=coordinator)
         result = await tools._handle_list_links("missing-sid", {})
         assert result["is_error"] is True
+
+
+# ---------------------------------------------------------------------------
+# Schema shape (issue #1912) — regression guard: links_mcp_tools is unchanged
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_schema_negative_control_unchanged():
+    tools = _make_tools()
+    server_config = tools.create_mcp_server_for_session("sess1")
+    tools_by_name = await _get_tools_by_name(server_config)
+
+    assert set(tools_by_name["register_link"].inputSchema.get("required", [])) == {
+        "label", "url"
+    }
+    assert list(tools_by_name["list_links"].inputSchema.get("required", [])) == []

--- a/backend/tests/test_overseer_controller.py
+++ b/backend/tests/test_overseer_controller.py
@@ -50,6 +50,22 @@ def _make_session(session_id, name, project_id="legion-1", parent_id=None, child
     return s
 
 
+def _make_template(name="TestTemplate"):
+    """Helper to create a mock Template (issue #1912: template_name is now required).
+
+    Sets an explicit permission_mode so resolve_template_config doesn't need to fall
+    back to parent_session.current_permission_mode (an unset Mock attribute in these tests).
+    """
+    t = Mock()
+    t.name = name
+    t.role = None
+    t.capabilities = []
+    t.profile_ids = {}
+    t.config = {"permission_mode": "default"}
+    t.template_id = "template-id"
+    return t
+
+
 @pytest.fixture
 def mock_system():
     """Create a mock LegionSystem with required components."""
@@ -107,13 +123,14 @@ class TestSpawnWithParentName:
             return_value={"minion_id": "child-id"}
         )
         session_map["child-id"] = child_session
-        mock_system.template_manager.get_template_by_name = AsyncMock(return_value=None)
+        mock_system.template_manager.get_template_by_name = AsyncMock(return_value=_make_template())
 
         args = {
             "_parent_overseer_id": "gp-id",
             "name": "Child",
             "role": "Worker",
             "system_prompt": "Do work",
+            "template_name": "TestTemplate",
             "parent_name": "Parent",
         }
 
@@ -177,13 +194,14 @@ class TestSpawnWithParentName:
         mock_system.overseer_controller.spawn_minion = AsyncMock(
             return_value={"minion_id": "child-id"}
         )
-        mock_system.template_manager.get_template_by_name = AsyncMock(return_value=None)
+        mock_system.template_manager.get_template_by_name = AsyncMock(return_value=_make_template())
 
         args = {
             "_parent_overseer_id": "caller-id",
             "name": "Child",
             "role": "Worker",
             "system_prompt": "Do work",
+            "template_name": "TestTemplate",
             # No parent_name
         }
 
@@ -244,13 +262,14 @@ class TestSpawnWithParentName:
         mock_system.overseer_controller.spawn_minion = AsyncMock(
             return_value={"minion_id": "child-id"}
         )
-        mock_system.template_manager.get_template_by_name = AsyncMock(return_value=None)
+        mock_system.template_manager.get_template_by_name = AsyncMock(return_value=_make_template())
 
         args = {
             "_parent_overseer_id": "caller-id",
             "name": "Child",
             "role": "Worker",
             "system_prompt": "Do work",
+            "template_name": "TestTemplate",
             "parent_name": "Caller",
         }
 

--- a/backend/tests/test_resource_mcp_tools.py
+++ b/backend/tests/test_resource_mcp_tools.py
@@ -1,8 +1,16 @@
 """Tests for video resource support in ResourceMCPTools (issue #1546)."""
 
 import pytest
+from mcp.types import ListToolsRequest
 
 from backend.mcp.resource_mcp_tools import MIME_TYPES, VIDEO_EXTENSIONS, ResourceMCPTools
+
+
+async def _get_tools_by_name(server_config):
+    """Introspect a session MCP server's registered tool schemas (issue #1912)."""
+    handler = server_config["instance"].request_handlers[ListToolsRequest]
+    result = await handler(ListToolsRequest(method="tools/list"))
+    return {t.name: t for t in result.root.tools}
 
 # Minimal WebM bytes: EBML header magic + padding
 VALID_WEBM_BYTES = b'\x1a\x45\xdf\xa3' + b'\x00' * 100
@@ -101,7 +109,7 @@ async def test_register_valid_webm(tmp_path, tools, storage):
     webm_file = tmp_path / "recording.webm"
     webm_file.write_bytes(VALID_WEBM_BYTES)
 
-    result = await tools._handle_register_resource("sess1", {"file_path": str(webm_file)})
+    result = await tools._handle_register_resource("sess1", {"file_path": str(webm_file), "title": "Recording"})
 
     assert not result["is_error"]
     assert storage.appended_resources
@@ -118,7 +126,7 @@ async def test_register_valid_mp4(tmp_path, tools, storage):
     mp4_file = tmp_path / "video.mp4"
     mp4_file.write_bytes(VALID_MP4_BYTES)
 
-    result = await tools._handle_register_resource("sess1", {"file_path": str(mp4_file)})
+    result = await tools._handle_register_resource("sess1", {"file_path": str(mp4_file), "title": "Video"})
 
     assert not result["is_error"]
     meta = storage.appended_resources[0]
@@ -132,7 +140,7 @@ async def test_register_invalid_video_bytes_rejected(tmp_path, tools):
     bad_file = tmp_path / "fake.mp4"
     bad_file.write_bytes(INVALID_VIDEO_BYTES)
 
-    result = await tools._handle_register_resource("sess1", {"file_path": str(bad_file)})
+    result = await tools._handle_register_resource("sess1", {"file_path": str(bad_file), "title": "Fake Video"})
 
     assert result["is_error"]
     assert "valid video" in result["content"][0]["text"]
@@ -144,7 +152,7 @@ async def test_register_oversized_video_rejected(tmp_path, tools):
     # 11 MB — just over the 10 MB limit
     big_file.write_bytes(b'x' * (11 * 1024 * 1024))
 
-    result = await tools._handle_register_resource("sess1", {"file_path": str(big_file)})
+    result = await tools._handle_register_resource("sess1", {"file_path": str(big_file), "title": "Big Video"})
 
     assert result["is_error"]
     assert "too large" in result["content"][0]["text"].lower()
@@ -155,7 +163,7 @@ async def test_register_mov_rejected(tmp_path, tools):
     mov_file = tmp_path / "video.mov"
     mov_file.write_bytes(VALID_MP4_BYTES)
 
-    result = await tools._handle_register_resource("sess1", {"file_path": str(mov_file)})
+    result = await tools._handle_register_resource("sess1", {"file_path": str(mov_file), "title": "Movie"})
 
     assert result["is_error"]
     assert "Unsupported file extension" in result["content"][0]["text"]
@@ -240,3 +248,51 @@ def test_register_resource_description_mentions_versioning():
     description = captured["register_resource"]
     assert "version" in description.lower()
     assert "_v2" in description or "_final" in description
+
+
+# ---- Schema shape (issue #1912) ----
+
+@pytest.mark.asyncio
+async def test_schema_required_fields():
+    """Issue #1912: declared `required` sets must match actual handler behavior."""
+    coordinator = FakeSessionCoordinator(FakeStorageManager())
+    t = ResourceMCPTools(coordinator)
+    server_config = t.create_mcp_server_for_session("sess1")
+    tools_by_name = await _get_tools_by_name(server_config)
+
+    assert set(tools_by_name["register_resource"].inputSchema.get("required", [])) == {
+        "file_path", "title"
+    }
+    assert set(tools_by_name["register_image"].inputSchema.get("required", [])) == {
+        "file_path", "title"
+    }
+    assert list(tools_by_name["list_resources"].inputSchema.get("required", [])) == []
+    # get_resource's "exactly one of" constraint is handler-only, not schema-expressible.
+    assert list(tools_by_name["get_resource"].inputSchema.get("required", [])) == []
+
+
+# ---- register_resource/register_image title required (issue #1912) ----
+
+@pytest.mark.asyncio
+async def test_register_resource_without_title_fails(tmp_path, tools):
+    file_path = tmp_path / "screenshot.png"
+    file_path.write_bytes(b'\x89PNG\r\n\x1a\n' + b'\x00' * 100)
+
+    result = await tools._handle_register_resource("sess1", {"file_path": str(file_path)})
+
+    assert result["is_error"] is True
+    assert "title" in result["content"][0]["text"].lower()
+
+
+# ---- get_resource exactly-one-of (issue #1912) ----
+
+@pytest.mark.asyncio
+async def test_get_resource_both_ids_provided_fails():
+    t = _tools_with_fixed_resources([
+        {"resource_id": "r1", "original_name": "report.md", "timestamp": 100},
+    ])
+
+    result = await t._handle_get_resource("sess1", {"resource_id": "r1", "filename": "report.md"})
+
+    assert result["is_error"] is True
+    assert "only one" in result["content"][0]["text"].lower()

--- a/backend/tests/test_restart_session.py
+++ b/backend/tests/test_restart_session.py
@@ -69,6 +69,15 @@ async def test_issue_680_restart_missing_session_id(mcp_tools):
 
 
 @pytest.mark.asyncio
+async def test_issue_1912_restart_requires_reason(mcp_tools):
+    """Issue #1912: reason is now required — restart_session must reject an empty reason."""
+    result = await mcp_tools._handle_restart_session({"_from_minion_id": "session-1"})
+
+    assert result["is_error"] is True
+    assert "reason" in result["content"][0]["text"].lower()
+
+
+@pytest.mark.asyncio
 async def test_issue_680_restart_session_not_found(mcp_tools):
     """Tool returns error when session doesn't exist."""
     mcp_tools.system.session_coordinator.session_manager.get_session_info = AsyncMock(
@@ -77,7 +86,7 @@ async def test_issue_680_restart_session_not_found(mcp_tools):
 
     result = await mcp_tools._handle_restart_session({
         "_from_minion_id": "nonexistent",
-        "reason": "",
+        "reason": "testing",
     })
 
     assert result["is_error"] is True
@@ -94,7 +103,7 @@ async def test_issue_680_restart_session_not_active(mcp_tools):
 
     result = await mcp_tools._handle_restart_session({
         "_from_minion_id": "session-1",
-        "reason": "",
+        "reason": "testing",
     })
 
     assert result["is_error"] is True


### PR DESCRIPTION
## Summary
Resolves #1912

MCP tools use claude-agent-sdk's `@tool()` decorator with a plain-dict input schema, which the SDK marks every key as required with no opt-out. Several Legion and resource MCP tools' handlers already treat many of those params as optional (defaults, `args.get(..., default)`), so the declared schema lied to agents about what was actually required. This PR replaces every affected plain-dict schema with a module-level `TypedDict` + `typing.NotRequired[...]` (the SDK's supported opt-out mechanism, confirmed against the installed SDK source), across all 16 affected tools in `backend/legion/mcp/legion_mcp_tools.py` and `backend/mcp/resource_mcp_tools.py`.

### Scope expansion (explicitly requested/approved during planning — see plan section 7)

Five tools also gained **new handler-level validation** that changes actual runtime behavior, not just the advertised schema:
- `spawn_minion`: `template_name` is now required — minions can only be spawned from a user-controlled template. The templateless "safe default restricted permissions" branch is deleted as unreachable, along with the dead success-message branch and stale docstrings/tool descriptions that referenced it.
- `restart_session`: `reason` is now required (it's interpolated directly into the post-restart continuation message, so it was never really optional).
- `send_comm`: rejects a call where both `summary` and `content` are blank (schema stays optional for both since JSON Schema can't express "at least one of").
- `register_resource` / `register_image`: `title` is now required, removing the filename-fallback.
- `get_resource`: now rejects supplying both `resource_id` and `filename` together (tightened from "at least one" to "exactly one").

This is a deliberate, auditable boundary-crossing beyond the original issue's "schema-only" framing — flagged explicitly here per the approved plan.

## Changes Made
- 16 new `TypedDict` schema classes replacing inline dict literals (12 in `legion_mcp_tools.py`, 4 in `resource_mcp_tools.py`); 8 already-accurate tools left untouched.
- 5 new handler-level validation checks per above.
- Deleted the now-dead "no template" branch in `_handle_spawn_minion`, its now-unreachable success-message `else` branch, and updated stale docstrings/descriptions that referenced the removed templateless path.
- Fixed a stale docstring on `session_coordinator.register_uploaded_resource` that promised a filename-default title (that fallback no longer exists in the handler it calls; all 4 real call sites already pass an explicit title, so this was latent, not a live break).
- Builder-review (8 finder angles + verify pass) surfaced 6 additional pre-existing integration tests in `test_lifecycle_tools.py` that called `_handle_spawn_minion` without `template_name` — these were beyond what the original plan's blast-radius analysis caught, and are fixed here too.

## Testing
- `uv run ruff check` — zero violations on all 9 touched files.
- Full non-slow backend suite: **2588 passed**, 0 failed (`uv run pytest backend/tests/`).
- 12 new tests added: schema-shape assertions for all modified tools + negative controls for untouched tools (`search_capability`, `list_minions`, `get_minion_info`, `list_templates`, `whoami`, `reparent_minion`, `register_link`, `list_links`), plus handler-validation-failure tests for all 5 new checks and their positive controls.
- 13 pre-existing tests updated for the new required-ness: `test_spawn_minion_minimal` rewritten to supply a template; 6 more `test_lifecycle_tools.py` tests + 3 `test_overseer_controller.py` tests updated to pass `template_name`; 2 `test_restart_session.py` tests updated to supply `reason`; ~5 `test_resource_mcp_tools.py` tests updated to pass `title`.
- Note: 2 pre-existing `@pytest.mark.slow` integration tests that spawn a templated minion and wait for it to reach `ACTIVE` (`test_spawn_minion_minimal`, `test_spawn_minion_with_template`) cannot be verified end-to-end in this sandbox — no `docker` binary is available here, and Claude WebUI's session-startup path invokes a Docker wrapper. Confirmed via `git stash` that this same failure occurs on `main` before this change too (pre-existing environment gap, not a regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)